### PR TITLE
fix: clear mimetype if > the db column length

### DIFF
--- a/stamp.py
+++ b/stamp.py
@@ -207,7 +207,7 @@ def get_src_or_img_data(stamp, block_index):
     else:
         stamp_description = stamp.get('description')
         #FIXME: stamp_mimetype may also be pulled in from the data json string as the stamp_mimetype key.
-        # below will over-write that user-input value
+        # below will over-write that user-input value assuming the base64 decodes properly
         # we also may have text or random garbage in the description field to look out for
         base64_string, stamp_mimetype = parse_base64_from_description(
             stamp_description

--- a/xcprequest.py
+++ b/xcprequest.py
@@ -99,6 +99,7 @@ def parse_base64_from_description(description):
         stamp_search = stamp_search.strip()
         if ";" in stamp_search:
             stamp_mimetype, stamp_base64 = stamp_search.split(";", 1)
+            stamp_mimetype = stamp_mimetype.strip() if len(stamp_mimetype) <= 255 else "" # db limit
             stamp_base64 = stamp_base64.strip() if len(stamp_base64) > 1 else None
         else:
             stamp_mimetype = ""


### PR DESCRIPTION
    Adjusting for incorrect user input on the mime_type field. this one was created with a , instead of a ;
    
    # 'A6974263043721917000' is invalid, however the base64 string is parsed as the mimetype
    # the stamp_base64 = 'base64,iVBORw....=='

we may want to handle differently for cursed stamps.  ie an additional re-formatting of the string after we detect is_btc_stamp false. 

