### PR TITLE
fix: src20 setting to is_btc_stamp = 0

### DIFF
--- a/stamp.py
+++ b/stamp.py
@@ -358,6 +358,8 @@ def parse_stamps_to_stamp_table(db, stamps):
                 src_data = decoded_base64
                 is_btc_stamp = 1
                 #TODO: call query_tokens_custom, build the svg image, and update file_suffix to svg
+                # hardcode for now to ensure is_btc_stamp below
+                file_suffix = 'svg'
             elif valid_src20 and not check_format(decoded_base64):
                 continue
 


### PR DESCRIPTION
this will need to be updated when we are building the svg string for src-20. hacking in for now so we can do some more db validation from the current production. 