### PR TITLE
fix: whitelist op_return 3521

### DIFF
--- a/indexer/whitelist.json
+++ b/indexer/whitelist.json
@@ -1,5 +1,6 @@
 {
     "op_return": [
-        "5e4cb38079891282fee9c035634c5cebbc9a6d30a01c710adf3f61e24d913fd3"
+        "5e4cb38079891282fee9c035634c5cebbc9a6d30a01c710adf3f61e24d913fd3",
+        "b7f303f8a385af146f7d18a6be2370de2fb0f8ae739498fd2cd146658b848009"
     ]
 }


### PR DESCRIPTION
this was another op_return stamp that was not caught in prior indexers before we had the op_return check. This is grandfathered in as to not impact numbering. 