### PR TITLE
fix: data types for src on btc - chaos in conversions FIX LATER

### DIFF
--- a/indexer/src20.py
+++ b/indexer/src20.py
@@ -61,6 +61,8 @@ def sort_keys(key):
 
 def check_format(input_string):
     try:
+        if isinstance(input_string, dict):
+            input_string = json.dumps(input_string) # FIXME: chaos with all the data types, need to normalize higher up
         if isinstance(input_string, bytes):
             input_string = input_string.decode('utf-8')
         start_index = input_string.find('{')


### PR DESCRIPTION
the src-20 tokens from btc are coming in with a dict so this needed to be handled properly in all the functinos that are expecting a string from the CP tokens. This is super messy and will need some further cleanup to normalize the data regardless of source.  Further complicated with having bytestrings and other data coming from CP into the same functions. 