### PR TITLE
fix: Image dir var name in .env

### DIFF
--- a/indexer/.env.sample
+++ b/indexer/.env.sample
@@ -12,5 +12,5 @@ DOMAINNAME= # Optional to prepend the stamp_url value in the db ie stampchain.io
 AWS_ACCESS_KEY_ID= # Optional - only for AWS S3 users
 AWS_SECRET_ACCESS_KEY= # Optional - only for AWS S3 users
 AWS_CLOUDFRONT_DISTRIBUTION_ID= # Optional if using Cloudfront with S3 and require invalidation
-AWS_S3_BUCKETNAME= # Optional - only for AWS S3 users
+AWS_S3_BUCKE_TNAME= # Optional - only for AWS S3 users
 AWS_S3_IMAGE_DIR= # Optional - only for AWS S3 users


### PR DESCRIPTION
wrong name in the example file