### PR TITLE
Build deno - on pull req

### DIFF
--- a/.github/workflows/build-deno.yml
+++ b/.github/workflows/build-deno.yml
@@ -1,0 +1,24 @@
+name: Build Deno on Pull Request
+
+on:
+  pull_request:
+    branches: [ dev, main ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1.1.3
+        with:
+          deno-version: 1.x
+
+      - name: Build Deno App
+        run: |
+          cd app
+          deno run -A dev.ts build


### PR DESCRIPTION
Whenever a pull req is created on dev or main - some tests or checks should run in a github workflow. Initially the only test could be - building the Deno app
- [added build deno workflow on pull req](https://github.com/stampchain-io/btc_stamps/commit/bb17fb5df4c2a220ec82a3f3e093d0347ed193e3)


This workflow can also be triggered manually.

### Resolves #123 