### PR TITLE
fix(src20): remove dest address from image string,

### DIFF
--- a/indexer/src20.py
+++ b/indexer/src20.py
@@ -82,7 +82,6 @@ def generate_srcbackground_svg(input_dict, base64, font_size, text_color):
             "op": input_dict.get("op", None),
             "tick": input_dict.get("tick", None),
             "amt": input_dict.get("amt", None),
-            "dest": format_address(input_dict.get("destination", None)),
         }
 
     sorted_keys = sorted(dict_to_use.keys(), key=sort_keys)


### PR DESCRIPTION

to re-add this feature we  will need to change the logic in stamp.py so the destination address will be present when building the image string. 

This was changed in the prior PR because we needed to check first for is_reissue on the cpid for an src-20 token before we pushed them into the src20/src20valid tables, but yet leave them in the StampTable to not impact numbering. 

Since numbering is impacted in the pending release anyway it may be prudent to remove these entirely to avoid confusion, however they are at some relatively low block heights. 