### PR TITLE
fix: fix the issue of data deletion failure caused by foreign keys

### DIFF
--- a/indexer/stamp.py
+++ b/indexer/stamp.py
@@ -47,11 +47,11 @@ def purge_block_db(db, block_index):
     cursor = db.cursor()
     
     tables = [
-        'transactions',
-        'blocks',
-        config.STAMP_TABLE,
+        'SRC20Valid',
         'SRC20',
-        'SRC20Valid'
+        config.STAMP_TABLE,
+        'transactions',
+        'blocks'
     ]
 
     for table in tables:
@@ -84,7 +84,7 @@ def is_prev_block_parsed(db, block_index):
                    ''', (block_index - 1,))
     block = cursor.fetchone()
     cursor.close()
-    if block[block_fields['indexed']] == 1:
+    if block is not None and block[block_fields['indexed']] == 1:
         return True
     else:
         purge_block_db(db, block_index - 1)


### PR DESCRIPTION
Fix the issue of data deletion failure caused by foreign keys; add NoneType check. Blockchain reorganization at block 827853.

```
Blockchain reorganization at block 827853.
Rolling back to block 827852 to avoid problems.
Purging transactions from database after block: 827852
data_dir: /root/.local/share/btc_stamps
log_file: log.file
Unhandled Exception
Traceback (most recent call last):
  File "/usr/src/app/start.py", line 15, in <module>
    server.start_all(db)
  File "/usr/src/app/server.py", line 376, in start_all
    blocks.follow(db)
  File "/usr/src/app/blocks.py", line 782, in follow
    purge_block_db(db, current_index)
  File "/usr/src/app/stamp.py", line 61, in purge_block_db
    cursor.execute('''
  File "/usr/local/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
  File "/usr/local/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 558, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 822, in _read_query_result
    result.read()
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 1200, in read
    first_packet = self.connection._read_packet()
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 772, in _read_packet
    packet.raise_for_error()
  File "/usr/local/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/usr/local/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1451, 'Cannot delete or update a parent row: a foreign key constraint fails (`btc_stamps`.`StampTableV4`, CONSTRAINT `StampTableV4_ibfk_1` FOREIGN KEY (`tx_hash`) REFERENCES `transactions` (`tx_hash`))')
2024/01/29 05:15:38 Command exited with error: exit status 1
```