### PR TITLE
fix(indexer): TypeError: 'NoneType' object is not subscriptable

### DIFF
--- a/indexer/src721.py
+++ b/indexer/src721.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def validate_src721_and_process(src721_data, db):
     src721_data = convert_to_dict(src721_data)
-    op_val = src721_data.get("op", None).upper()
+    op_val = src721_data.get("op", "").upper()
     file_suffix = None
     if 'symbol' in src721_data:
         src721_data['tick'] = src721_data.pop('symbol')
@@ -185,7 +185,7 @@ def create_src721_mint_svg(src_data, db):
                     cursor.execute(f"SELECT src_data FROM {config.STAMP_TABLE} WHERE cpid = %s", (collection_asset,))
                     result = cursor.fetchone() # pull the deploy details this one has no src_data when it should A12314949010946956252
                     logger.info(f"asset:{collection_asset}\nresult: {result}")
-                    if result[0]:
+                    if result is not None and result[0]:
                         collection_asset_item = result[0] # Return the first column of the result
                         logger.debug("got collection asset item from db", collection_asset_item)
                     else: 


### PR DESCRIPTION
fix: TypeError: 'NoneType' object is not subscriptable
```python
asset:A996047733731500
result: None
data_dir: /root/.local/share/btc_stamps
log_file: log.file
Unhandled Exception
Traceback (most recent call last):
  File "/usr/src/app/start.py", line 15, in <module>
    server.start_all(db)
  File "/usr/src/app/server.py", line 376, in start_all
    blocks.follow(db)
  File "/usr/src/app/blocks.py", line 828, in follow
    parse_tx_to_stamp_table(
  File "/usr/src/app/stamp.py", line 680, in parse_tx_to_stamp_table
    (svg_output, file_suffix) = validate_src721_and_process(src_data, stamp_cursor)
  File "/usr/src/app/src721.py", line 18, in validate_src721_and_process
    svg_output = create_src721_mint_svg(src721_data, block_cursor)
  File "/usr/src/app/src721.py", line 165, in create_src721_mint_svg
    raise e
  File "/usr/src/app/src721.py", line 157, in create_src721_mint_svg
    if result[0]:
TypeError: 'NoneType' object is not subscriptable
2024/02/04 08:27:34 Command exited with error: exit status 1
```