### PR TITLE
fix(indexer): fix table structure support uint64_max(1844674407370955…

### DIFF
--- a/indexer/table_schema.sql
+++ b/indexer/table_schema.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS `StampTableV4` (
   `stamp_base64` mediumtext,
   `stamp_mimetype` varchar(255) DEFAULT NULL,
   `stamp_url` varchar(255) DEFAULT NULL,
-  `supply` bigint DEFAULT NULL,
+  `supply` bigint unsigned DEFAULT NULL,
   `block_time` datetime NULL DEFAULT NULL,
   `tx_hash` varchar(64) NOT NULL,
   `tx_index` int NOT NULL,


### PR DESCRIPTION
Error log:
```
Initializing database...
initializing tables...
Connecting to CP Node: http://172.31.15.67:4000/api/rest/
Validating Balances Table..
No changes in balances. Skipping deletion and insertion.
data_dir: /root/.local/share/btc_stamps_20240228
log_file: log.file
Fetching CP Trx [789004..790004]: 1001it [00:06, 157.21it/s]
Unhandled Exception
Traceback (most recent call last):
  File "/usr/src/app/start.py", line 15, in <module>
    server.start_all(db)
  File "/usr/src/app/src/server.py", line 375, in start_all
    blocks.follow(db)
  File "/usr/src/app/src/blocks.py", line 902, in follow
    parse_tx_to_stamp_table(
  File "/usr/src/app/src/stamp.py", line 870, in parse_tx_to_stamp_table
    insert_into_stamp_table(stamp_cursor, parsed)
  File "/usr/src/app/src/stamp.py", line 874, in insert_into_stamp_table
    stamp_cursor.execute(f'''
  File "/usr/local/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
  File "/usr/local/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 558, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 822, in _read_query_result
    result.read()
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 1200, in read
    first_packet = self.connection._read_packet()
  File "/usr/local/lib/python3.10/site-packages/pymysql/connections.py", line 772, in _read_packet
    packet.raise_for_error()
  File "/usr/local/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/usr/local/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.DataError: (1264, "Out of range value for column 'supply' at row 1")
```

Block height: `789004`
The data associated with the transaction: 
```{"p": "src-20", "op": "mint", "tick": "\\ud83d\\ude42", "amt": "18446744073709551615"}```
insert_into_stamp_table: 
```{'stamp': 18745, 'block_index': 789004, 'cpid': 'A16340520019530349268', 'asset_longname': None, 'creator': 'bc1qv3z5edu6yf09853kcrjxthxx5zg8v4g8zmv5lt', 'divisible': False, 'ident': 'SRC-20', 'keyburn': 1, 'locked': True, 'message_index': 9441920, 'stamp_base64': 'eJxrWViwrLgoWdfIYFF+wZLczLySJSWZydlLPsyf2bQ4Mbdki6GFiYmZuYmJgbmxuYGlqamhmaEpAHOTFD0=', 'stamp_mimetype': 'image/svg+xml', 'stamp_url': 'https://# Optional to prepend the stamp_url value in the db ie stampchain.io/stamps/8e4686df05b840bd12cd427d2d3036aedb20dc3a0d75c61c1ef5ce7c27f52ee5.svg', 'supply': 18446744073709551615, 'block_time': '2023-05-10 01:17:41', 'tx_hash': '8e4686df05b840bd12cd427d2d3036aedb20dc3a0d75c61c1ef5ce7c27f52ee5', 'tx_index': 33016, 'src_data': None, 'stamp_hash': 'NTMK6ot8Wn7p7XjeqGTP', 'is_btc_stamp': 1, 'is_reissue': None, 'file_hash': '915ad4ee7e329f477b2bc58577e2be60', 'is_valid_base64': True}```

**Repair steps**: execute sql: 
```ALTER TABLE `btc_stamps`.`StampTableV4` CHANGE `supply` `supply` bigint unsigned NULL;```
