### PR TITLE
fix: precision loss

### DIFF
--- a/indexer/src/stamp.py
+++ b/indexer/src/stamp.py
@@ -304,7 +304,7 @@ def convert_to_dict_or_string(input_data, output_format='dict'):
     try:
         if isinstance(input_data, bytes):
             try:
-                input_data = json.loads(input_data)
+                input_data = json.loads(input_data, parse_float=Decimal)
             except json.JSONDecodeError:
                 # get a string representation of the bytes object
                 input_data = repr(input_data)[2:-1]


### PR DESCRIPTION
In Python, floating-point numbers are represented using the double precision format defined by the IEEE 754 standard, which provides approximately 15.9 decimal digits of precision.

Here is example:
b'{"p":"src-20","op":"transfer","tick":"roro","amt":10000000000000000.1}'
->
{'amt': 1e+16, 'op': 'transfer', 'p': 'src-20', 'tick': 'roro'}