### PR TITLE
fix: txlist_hash mismatches

### DIFF
--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -314,7 +314,7 @@ class StampData:
         self.file_suffix = mime_type.split("/")[-1]
         self.stamp_mimetype = mime_type
 
-        if (mime_type == "text/plain" or mime_type == 'application/javascript') and self.is_javascript(bytestring_data):
+        if (mime_type == "text/plain" or mime_type == "application/javascript") and self.is_javascript(bytestring_data):
             self.file_suffix = "js"
             self.stamp_mimetype = "application/javascript"
 

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -314,7 +314,7 @@ class StampData:
         self.file_suffix = mime_type.split("/")[-1]
         self.stamp_mimetype = mime_type
 
-        if mime_type == "text/plain" and self.is_javascript(bytestring_data):
+        if (mime_type == "text/plain" or mime_type == 'application/javascript') and self.is_javascript(bytestring_data):
             self.file_suffix = "js"
             self.stamp_mimetype = "application/javascript"
 


### PR DESCRIPTION
I run `1.8.5+canary.12` and still got the same error #329.

After debugging, I found that the mime_type of transaction `69762c76d3c7d79ca9d7c08fd80e15f679b477b27843eea9f5e919e052a2b0ca` is `application/javascript`.
 https://github.com/stampchain-io/btc_stamps/blob/ff64a45364eff951787e2f7c37959002db01adfa/indexer/src/index_core/models.py#L310-L313

Now we need to modify the conditions:
https://github.com/stampchain-io/btc_stamps/blob/02cac4f4bffda72d93200e269a526083560a3f51/indexer/src/index_core/models.py#L317
