### PR TITLE
fix: fix the precision issue

### DIFF
--- a/indexer/src/index_core/src20.py
+++ b/indexer/src/index_core/src20.py
@@ -1159,7 +1159,7 @@ def validate_src20_ledger_hash(block_index, ledger_hash, valid_src20_str):
 
 def normalize_entry(entry):
     token, address, amount = entry.split(",")
-    normalized_amount = format(D(amount), ".8f")  # Adjust decimal places as needed
+    normalized_amount = format(D(amount), ".18f")  # Adjust decimal places as needed
     return f"{token},{address},{normalized_amount}"
 
 


### PR DESCRIPTION
fix #365 

> @reinamora137 After reviewing the latest dev code, I found that the current approach formats the balance value to 8 decimal places. This could cause other issues because tick supports up to 18 decimal places. If a discrepancy occurs beyond the 8 decimal places, the program will still consider them to be consistent.
> 
> https://github.com/stampchain-io/btc_stamps/blob/9d4dfae0e2928e32e481d071102257423bf4f4f8/indexer/src/index_core/src20.py#L1164

Change the formatting precision from 8 decimal places to 18 decimal places.



