### PR TITLE
 Block 866000 Subassets No Longer Require XCP

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -80,6 +80,7 @@ CP_SRC721_GENESIS_BLOCK: int = 792370  # block height of first SRC-721
 CP_SRC20_END_BLOCK: int = 796000  # The last SRC-20 on CP  - IGNORE ALL SRC-20 on CP AFTER THIS BLOCK
 CP_BMN_FEAT_BLOCK_START: int = 815130  # BMN audio file support
 CP_P2WSH_FEAT_BLOCK_START: int = 833000  # OLGA / P2WSH transactions
+CP_SUBASSET_FEAT_BLOCK_START: int = 866000  # Subasset no longer require XCP fees
 
 # Consensus changes
 STRIP_WHITESPACE: int = 797200


### PR DESCRIPTION
Subassets after block 866000 should become valid stamps with a + number now that they do not require XCP fees per protocol design.  

TODO: Add logic for assigning the subassets to the parent stamp name collection. Perhaps we design logic where a collection description, website, tg, etc can be embedded in the parent stamp for full onchain collection details. 