### PR TITLE
feat(database): Add file size tracking for stamp files

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -714,6 +714,7 @@ def log_block_info(
             eta_seconds=eta_seconds,
             is_zmq=is_zmq,
             display_mode=display_mode,
+            start_block=config.CP_STAMP_GENESIS_BLOCK,
         )
 
     except Exception as e:

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -553,8 +553,8 @@ def insert_into_stamp_table(db, parsed_stamps: List):
                     stamp_mimetype, stamp_url, supply, block_time,
                     tx_hash, tx_index, ident, src_data,
                     stamp_hash, is_btc_stamp,
-                    file_hash, is_valid_base64
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    file_hash, is_valid_base64, file_size_bytes
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """  # nosec
 
             data = [
@@ -581,6 +581,7 @@ def insert_into_stamp_table(db, parsed_stamps: List):
                     parsed.is_btc_stamp,
                     parsed.file_hash,
                     parsed.is_valid_base64,
+                    parsed.file_size_bytes,
                 )
                 for parsed in parsed_stamps
             ]

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -2428,7 +2428,7 @@ def get_stamps_needing_market_update(db: Connection, update_interval_minutes: in
             # Include stamps with ident='STAMP' or 'SRC-721'
             # Named assets like FUCKTHAT already have ident='STAMP'
             query = """
-                SELECT DISTINCT s.cpid
+                SELECT DISTINCT s.cpid, s.block_index
                 FROM StampTableV4 s
                 LEFT JOIN stamp_market_data smd ON s.cpid = smd.cpid
                 WHERE s.ident IN ('STAMP', 'SRC-721')

--- a/indexer/src/index_core/log.py
+++ b/indexer/src/index_core/log.py
@@ -226,6 +226,7 @@ def log_enhanced_block_status(
     eta_seconds: float = 0,
     is_zmq: bool = False,
     display_mode: str = "enhanced",
+    start_block: int = 0,
 ) -> None:
     """
     Log block status with enhanced formatting.
@@ -241,13 +242,19 @@ def log_enhanced_block_status(
         eta_seconds: Estimated time to completion
         is_zmq: Whether this is from ZMQ feed
         display_mode: Display mode (compact, enhanced, detailed)
+        start_block: Starting block for progress calculation (defaults to 0)
     """
     # Calculate progress
-    if block_tip > 0:
-        current_progress = block_index / block_tip
+    if block_tip > start_block and block_index >= start_block:
+        total_blocks = block_tip - start_block
+        processed_blocks = block_index - start_block
+        current_progress = processed_blocks / total_blocks
+    elif block_index < start_block:
+        # If we're before the start block, progress is 0
+        current_progress = 0.0
     else:
         current_progress = 0.0
-    current_progress = min(1.0, current_progress)
+    current_progress = min(1.0, max(0.0, current_progress))
 
     # Determine if we're at the tip (within 5 blocks)
     at_tip = (block_tip - block_index) <= 5

--- a/indexer/src/index_core/market_data_jobs.py
+++ b/indexer/src/index_core/market_data_jobs.py
@@ -338,7 +338,7 @@ class MarketDataJobScheduler:
         try:
             # First, get tokens from our database that need updates
             query = """
-            SELECT DISTINCT s.tick
+            SELECT DISTINCT s.tick, s.block_index
             FROM SRC20Valid s
             LEFT JOIN src20_market_data smd ON s.tick = smd.tick
             WHERE smd.last_updated IS NULL

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -108,6 +108,7 @@ class StampData:
     is_cursed: Optional[bool] = None
     file_hash: Optional[str] = None
     is_valid_base64: Optional[bool] = None
+    file_size_bytes: Optional[int] = None
     file_suffix: Optional[str] = None
     decoded_base64: Optional[Union[str, bytes]] = None
     src20_dict: Optional[dict] = None
@@ -715,7 +716,7 @@ class StampData:
 
         self.normalize_mime_and_suffix()
         # 'encode_and_store_file' can handle different types (bytestring, string, or dict)
-        self.file_hash, filename = encode_and_store_file(
+        self.file_hash, filename, self.file_size_bytes = encode_and_store_file(
             db,
             self.tx_hash,
             self.file_suffix,

--- a/indexer/src/index_core/stamp.py
+++ b/indexer/src/index_core/stamp.py
@@ -14,7 +14,7 @@ from index_core.database import check_reissue, get_next_stamp_number
 from index_core.exceptions import DataConversionError, InvalidInputDataError
 from index_core.files import store_files
 from index_core.models import StampData, ValidStamp
-from index_core.util import check_valid_base64_string, convert_to_dict_or_string
+from index_core.util import calculate_file_size, check_valid_base64_string, convert_to_dict_or_string
 
 logger = logging.getLogger(__name__)
 log.set_logger(logger)
@@ -179,7 +179,7 @@ def get_src_or_img_from_data(stamp, block_index):
 def encode_and_store_file(db, tx_hash, file_suffix, decoded_base64, stamp_mimetype):
     """
     Encodes the decoded_base64 string to utf-8 (if it's a string or a dict), constructs the filename,
-    and stores the file.
+    calculates file size, and stores the file.
 
     Args:
         db: The database connection object.
@@ -189,16 +189,23 @@ def encode_and_store_file(db, tx_hash, file_suffix, decoded_base64, stamp_mimety
         stamp_mimetype (str): The MIME type of the stamp.
 
     Returns:
-        The result of the file storage operation.
+        tuple: (file_obj_md5, filename, file_size_bytes)
     """
     if file_suffix:
         if isinstance(decoded_base64, dict):
             decoded_base64 = json.dumps(decoded_base64)
         if isinstance(decoded_base64, str):
             decoded_base64 = decoded_base64.encode("utf-8")
+
+        # Calculate file size before storage
+        file_size_bytes = calculate_file_size(decoded_base64)
+
         filename = f"{tx_hash}.{file_suffix}"
-        return store_files(db, filename, decoded_base64, stamp_mimetype)
-    return None, None
+        file_obj_md5, stored_filename = store_files(db, filename, decoded_base64, stamp_mimetype)
+
+        return file_obj_md5, stored_filename, file_size_bytes
+
+    return None, None, 0
 
 
 def create_valid_stamp_dict(

--- a/indexer/src/index_core/stamp_market_processor.py
+++ b/indexer/src/index_core/stamp_market_processor.py
@@ -517,15 +517,15 @@ class StampMarketDataProcessor:
                 else:
                     logger.warning(f"Confidence level {value} out of range 0-10 for {field_name}")
                     return D("5.0")  # Default fallback
-            
+
             # Convert string values to numeric
             str_val = str(value).lower()
             confidence_mapping = {
                 "very_low": D("2.0"),
-                "low": D("3.0"), 
+                "low": D("3.0"),
                 "medium": D("5.0"),
                 "high": D("8.0"),
-                "very_high": D("9.0")
+                "very_high": D("9.0"),
             }
 
             if str_val in confidence_mapping:

--- a/indexer/src/index_core/stamp_market_processor.py
+++ b/indexer/src/index_core/stamp_market_processor.py
@@ -159,10 +159,10 @@ class StampMarketDataProcessor:
             )
             validated_data["data_quality_score"] = validated_quality or DEFAULT_QUALITY_SCORE
 
-            # Validate confidence level (string field)
-            confidence_level = data.get("confidence_level", "medium")
+            # Validate confidence level (decimal field)
+            confidence_level = data.get("confidence_level", D("5.0"))
             validated_confidence = self._validate_confidence_level_field(confidence_level, "confidence_level")
-            validated_data["confidence_level"] = validated_confidence or "medium"
+            validated_data["confidence_level"] = validated_confidence or D("5.0")
 
             # Validate block numbers (optional)
             for field in ["last_dispenser_block", "last_balance_block"]:
@@ -305,7 +305,7 @@ class StampMarketDataProcessor:
             transformed_data["price_source"] = "counterparty"
             transformed_data["volume_sources"] = "counterparty"
             transformed_data["data_quality_score"] = D("8.0")  # High quality for Counterparty data
-            transformed_data["confidence_level"] = "high"  # High confidence for official API (string)
+            transformed_data["confidence_level"] = D("8.0")  # High confidence for official API
             transformed_data["last_price_update"] = datetime.now()
             transformed_data["update_frequency_minutes"] = 30
 
@@ -503,23 +503,39 @@ class StampMarketDataProcessor:
             logger.warning(f"Invalid timestamp value for {field_name}: {value}")
             return None
 
-    def _validate_confidence_level_field(self, value: Any, field_name: str) -> Optional[str]:
-        """Validate a confidence level field (string)."""
+    def _validate_confidence_level_field(self, value: Any, field_name: str) -> Optional[D]:
+        """Validate a confidence level field (converts to decimal 0-10 scale)."""
         if value is None:
             return None
 
         try:
+            # If it's already a number, validate it's in range
+            if isinstance(value, (int, float, D)):
+                decimal_val = D(str(value))
+                if 0 <= decimal_val <= 10:
+                    return decimal_val
+                else:
+                    logger.warning(f"Confidence level {value} out of range 0-10 for {field_name}")
+                    return D("5.0")  # Default fallback
+            
+            # Convert string values to numeric
             str_val = str(value).lower()
-            valid_levels = ["very_low", "low", "medium", "high", "very_high"]
+            confidence_mapping = {
+                "very_low": D("2.0"),
+                "low": D("3.0"), 
+                "medium": D("5.0"),
+                "high": D("8.0"),
+                "very_high": D("9.0")
+            }
 
-            if str_val in valid_levels:
-                return str_val
+            if str_val in confidence_mapping:
+                return confidence_mapping[str_val]
             else:
-                logger.warning(f"Invalid confidence level for {field_name}: {value}. Valid values: {valid_levels}")
-                return "medium"  # Default fallback
+                logger.warning(f"Invalid confidence level for {field_name}: {value}. Converting to medium (5.0)")
+                return D("5.0")  # Default fallback
         except (ValueError, TypeError):
             logger.warning(f"Invalid confidence level value for {field_name}: {value}")
-            return "medium"  # Default fallback
+            return D("5.0")  # Default fallback
 
 
 # Global processor instance for easy access

--- a/indexer/src/index_core/stamp_worker.py
+++ b/indexer/src/index_core/stamp_worker.py
@@ -214,7 +214,7 @@ class StampWorker:
                 "liquidity_score": None,
                 "market_activity_score": None,
                 "quality_score": 0.0,
-                "confidence_level": "low",
+                "confidence_level": 3.0,
             }
 
             # Calculate floor price from active dispensers

--- a/indexer/src/index_core/util.py
+++ b/indexer/src/index_core/util.py
@@ -57,6 +57,21 @@ CP_BLOCK_COUNT = None
 CURRENT_BLOCK_INDEX: Optional[int] = None  # resolves to database.last_db_index(db)
 
 
+def calculate_file_size(binary_data: bytes) -> int:
+    """
+    Calculate the size of binary data in bytes.
+
+    Args:
+        binary_data: The binary data to measure
+
+    Returns:
+        int: Size in bytes, 0 if data is None or empty
+    """
+    if binary_data is None:
+        return 0
+    return len(binary_data)
+
+
 def chunkify(lst, n):
     """
     Splits a list into smaller chunks of size n.

--- a/indexer/table_schema.sql
+++ b/indexer/table_schema.sql
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS `StampTableV4` (
   `is_reissue` tinyint(1) DEFAULT NULL,
   `file_hash` varchar(255) DEFAULT NULL,
   `is_valid_base64` tinyint(1) DEFAULT NULL,
+  `file_size_bytes` int DEFAULT NULL COMMENT 'Size of the decoded stamp file in bytes',
   PRIMARY KEY (`stamp`),
   UNIQUE `tx_hash` (`tx_hash`),
   UNIQUE `stamp_hash` (`stamp_hash`),

--- a/indexer/tests/test_filesize_tracking.py
+++ b/indexer/tests/test_filesize_tracking.py
@@ -1,0 +1,133 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from index_core.util import calculate_file_size
+from index_core.stamp import encode_and_store_file
+
+
+class TestFilesizeTracking(unittest.TestCase):
+    
+    def test_calculate_file_size_normal(self):
+        """Test file size calculation with normal data."""
+        data = b"test data"
+        self.assertEqual(calculate_file_size(data), 9)
+    
+    def test_calculate_file_size_empty(self):
+        """Test file size calculation with empty data."""
+        self.assertEqual(calculate_file_size(b""), 0)
+    
+    def test_calculate_file_size_none(self):
+        """Test file size calculation with None."""
+        self.assertEqual(calculate_file_size(None), 0)
+    
+    def test_calculate_file_size_large(self):
+        """Test file size calculation with large data."""
+        data = b"x" * 1024 * 1024  # 1MB
+        self.assertEqual(calculate_file_size(data), 1024 * 1024)
+    
+    def test_calculate_file_size_unicode(self):
+        """Test file size calculation with unicode data."""
+        data = "Hello 世界".encode('utf-8')
+        # "Hello " = 6 bytes, "世界" = 6 bytes (3 bytes each in UTF-8)
+        self.assertEqual(calculate_file_size(data), 12)
+    
+    @patch('index_core.stamp.store_files')
+    def test_encode_and_store_file_with_size_calculation(self, mock_store_files):
+        """Test that encode_and_store_file calculates and returns file size."""
+        # Mock the store_files function
+        mock_store_files.return_value = ("mock_hash", "mock_filename")
+        
+        # Test data
+        db = Mock()
+        tx_hash = "test_hash"
+        file_suffix = "txt"
+        decoded_base64 = "test content"
+        stamp_mimetype = "text/plain"
+        
+        # Call the function
+        file_hash, filename, file_size_bytes = encode_and_store_file(
+            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
+        )
+        
+        # Verify results
+        self.assertEqual(file_hash, "mock_hash")
+        self.assertEqual(filename, "mock_filename")
+        self.assertEqual(file_size_bytes, len("test content".encode('utf-8')))
+        
+        # Verify store_files was called with correct parameters
+        mock_store_files.assert_called_once_with(
+            db, "test_hash.txt", "test content".encode('utf-8'), "text/plain"
+        )
+    
+    @patch('index_core.stamp.store_files')
+    def test_encode_and_store_file_with_dict_input(self, mock_store_files):
+        """Test encode_and_store_file with dictionary input."""
+        # Mock the store_files function
+        mock_store_files.return_value = ("mock_hash", "mock_filename")
+        
+        # Test data
+        db = Mock()
+        tx_hash = "test_hash"
+        file_suffix = "json"
+        decoded_base64 = {"key": "value", "number": 123}
+        stamp_mimetype = "application/json"
+        
+        # Call the function
+        file_hash, filename, file_size_bytes = encode_and_store_file(
+            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
+        )
+        
+        # Verify results
+        self.assertEqual(file_hash, "mock_hash")
+        self.assertEqual(filename, "mock_filename")
+        
+        # Calculate expected size
+        import json
+        expected_json = json.dumps(decoded_base64)
+        expected_size = len(expected_json.encode('utf-8'))
+        self.assertEqual(file_size_bytes, expected_size)
+    
+    @patch('index_core.stamp.store_files')
+    def test_encode_and_store_file_with_bytes_input(self, mock_store_files):
+        """Test encode_and_store_file with bytes input."""
+        # Mock the store_files function
+        mock_store_files.return_value = ("mock_hash", "mock_filename")
+        
+        # Test data
+        db = Mock()
+        tx_hash = "test_hash"
+        file_suffix = "bin"
+        decoded_base64 = b"binary data content"
+        stamp_mimetype = "application/octet-stream"
+        
+        # Call the function
+        file_hash, filename, file_size_bytes = encode_and_store_file(
+            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
+        )
+        
+        # Verify results
+        self.assertEqual(file_hash, "mock_hash")
+        self.assertEqual(filename, "mock_filename")
+        self.assertEqual(file_size_bytes, len(b"binary data content"))
+    
+    def test_encode_and_store_file_no_suffix(self):
+        """Test encode_and_store_file when no file suffix is provided."""
+        db = Mock()
+        tx_hash = "test_hash"
+        file_suffix = None
+        decoded_base64 = "test content"
+        stamp_mimetype = "text/plain"
+        
+        # Call the function
+        file_hash, filename, file_size_bytes = encode_and_store_file(
+            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
+        )
+        
+        # Verify results for no suffix case
+        self.assertIsNone(file_hash)
+        self.assertIsNone(filename)
+        self.assertEqual(file_size_bytes, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/indexer/tests/test_filesize_tracking.py
+++ b/indexer/tests/test_filesize_tracking.py
@@ -1,115 +1,108 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from index_core.util import calculate_file_size
 from index_core.stamp import encode_and_store_file
+from index_core.util import calculate_file_size
 
 
 class TestFilesizeTracking(unittest.TestCase):
-    
+
     def test_calculate_file_size_normal(self):
         """Test file size calculation with normal data."""
         data = b"test data"
         self.assertEqual(calculate_file_size(data), 9)
-    
+
     def test_calculate_file_size_empty(self):
         """Test file size calculation with empty data."""
         self.assertEqual(calculate_file_size(b""), 0)
-    
+
     def test_calculate_file_size_none(self):
         """Test file size calculation with None."""
         self.assertEqual(calculate_file_size(None), 0)
-    
+
     def test_calculate_file_size_large(self):
         """Test file size calculation with large data."""
         data = b"x" * 1024 * 1024  # 1MB
         self.assertEqual(calculate_file_size(data), 1024 * 1024)
-    
+
     def test_calculate_file_size_unicode(self):
         """Test file size calculation with unicode data."""
-        data = "Hello 世界".encode('utf-8')
+        data = "Hello 世界".encode("utf-8")
         # "Hello " = 6 bytes, "世界" = 6 bytes (3 bytes each in UTF-8)
         self.assertEqual(calculate_file_size(data), 12)
-    
-    @patch('index_core.stamp.store_files')
+
+    @patch("index_core.stamp.store_files")
     def test_encode_and_store_file_with_size_calculation(self, mock_store_files):
         """Test that encode_and_store_file calculates and returns file size."""
         # Mock the store_files function
         mock_store_files.return_value = ("mock_hash", "mock_filename")
-        
+
         # Test data
         db = Mock()
         tx_hash = "test_hash"
         file_suffix = "txt"
         decoded_base64 = "test content"
         stamp_mimetype = "text/plain"
-        
+
         # Call the function
-        file_hash, filename, file_size_bytes = encode_and_store_file(
-            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
-        )
-        
+        file_hash, filename, file_size_bytes = encode_and_store_file(db, tx_hash, file_suffix, decoded_base64, stamp_mimetype)
+
         # Verify results
         self.assertEqual(file_hash, "mock_hash")
         self.assertEqual(filename, "mock_filename")
-        self.assertEqual(file_size_bytes, len("test content".encode('utf-8')))
-        
+        self.assertEqual(file_size_bytes, len("test content".encode("utf-8")))
+
         # Verify store_files was called with correct parameters
-        mock_store_files.assert_called_once_with(
-            db, "test_hash.txt", "test content".encode('utf-8'), "text/plain"
-        )
-    
-    @patch('index_core.stamp.store_files')
+        mock_store_files.assert_called_once_with(db, "test_hash.txt", "test content".encode("utf-8"), "text/plain")
+
+    @patch("index_core.stamp.store_files")
     def test_encode_and_store_file_with_dict_input(self, mock_store_files):
         """Test encode_and_store_file with dictionary input."""
         # Mock the store_files function
         mock_store_files.return_value = ("mock_hash", "mock_filename")
-        
+
         # Test data
         db = Mock()
         tx_hash = "test_hash"
         file_suffix = "json"
         decoded_base64 = {"key": "value", "number": 123}
         stamp_mimetype = "application/json"
-        
+
         # Call the function
-        file_hash, filename, file_size_bytes = encode_and_store_file(
-            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
-        )
-        
+        file_hash, filename, file_size_bytes = encode_and_store_file(db, tx_hash, file_suffix, decoded_base64, stamp_mimetype)
+
         # Verify results
         self.assertEqual(file_hash, "mock_hash")
         self.assertEqual(filename, "mock_filename")
-        
+
         # Calculate expected size
         import json
+
         expected_json = json.dumps(decoded_base64)
-        expected_size = len(expected_json.encode('utf-8'))
+        expected_size = len(expected_json.encode("utf-8"))
         self.assertEqual(file_size_bytes, expected_size)
-    
-    @patch('index_core.stamp.store_files')
+
+    @patch("index_core.stamp.store_files")
     def test_encode_and_store_file_with_bytes_input(self, mock_store_files):
         """Test encode_and_store_file with bytes input."""
         # Mock the store_files function
         mock_store_files.return_value = ("mock_hash", "mock_filename")
-        
+
         # Test data
         db = Mock()
         tx_hash = "test_hash"
         file_suffix = "bin"
         decoded_base64 = b"binary data content"
         stamp_mimetype = "application/octet-stream"
-        
+
         # Call the function
-        file_hash, filename, file_size_bytes = encode_and_store_file(
-            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
-        )
-        
+        file_hash, filename, file_size_bytes = encode_and_store_file(db, tx_hash, file_suffix, decoded_base64, stamp_mimetype)
+
         # Verify results
         self.assertEqual(file_hash, "mock_hash")
         self.assertEqual(filename, "mock_filename")
         self.assertEqual(file_size_bytes, len(b"binary data content"))
-    
+
     def test_encode_and_store_file_no_suffix(self):
         """Test encode_and_store_file when no file suffix is provided."""
         db = Mock()
@@ -117,17 +110,15 @@ class TestFilesizeTracking(unittest.TestCase):
         file_suffix = None
         decoded_base64 = "test content"
         stamp_mimetype = "text/plain"
-        
+
         # Call the function
-        file_hash, filename, file_size_bytes = encode_and_store_file(
-            db, tx_hash, file_suffix, decoded_base64, stamp_mimetype
-        )
-        
+        file_hash, filename, file_size_bytes = encode_and_store_file(db, tx_hash, file_suffix, decoded_base64, stamp_mimetype)
+
         # Verify results for no suffix case
         self.assertIsNone(file_hash)
         self.assertIsNone(filename)
         self.assertEqual(file_size_bytes, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/indexer/tests/test_util_functions.py
+++ b/indexer/tests/test_util_functions.py
@@ -1,0 +1,281 @@
+import unittest
+from decimal import Decimal
+
+from index_core.util import (
+    calculate_file_size,
+    chunkify,
+    dhash,
+    dhash_string,
+    shash_string,
+    clean_url_for_log,
+    b2h,
+    inverse_hash,
+    hex_decode,
+    check_valid_eth_address,
+    check_valid_bitcoin_address,
+    check_valid_tx_hash,
+    check_contains_special,
+    check_valid_base64_string,
+    base62_encode,
+    create_base62_hash,
+    escape_non_ascii_characters,
+    decode_unicode_escapes,
+    clean_json_string,
+    convert_decimal_to_string,
+)
+
+
+class TestUtilFunctions(unittest.TestCase):
+    
+    def test_calculate_file_size(self):
+        """Test calculate_file_size function with various inputs."""
+        # Normal case
+        self.assertEqual(calculate_file_size(b"hello"), 5)
+        # Empty bytes
+        self.assertEqual(calculate_file_size(b""), 0)
+        # None input
+        self.assertEqual(calculate_file_size(None), 0)
+        # Larger data
+        self.assertEqual(calculate_file_size(b"x" * 1000), 1000)
+    
+    def test_chunkify(self):
+        """Test chunkify function for splitting lists."""
+        # Normal case
+        result = chunkify([1, 2, 3, 4, 5], 2)
+        self.assertEqual(result, [[1, 2], [3, 4], [5]])
+        
+        # Edge cases
+        self.assertEqual(chunkify([], 2), [])
+        self.assertEqual(chunkify([1], 3), [[1]])
+        self.assertEqual(chunkify([1, 2, 3], 0), [[1], [2], [3]])  # n=0 becomes n=1
+        
+        # Exact division
+        self.assertEqual(chunkify([1, 2, 3, 4], 2), [[1, 2], [3, 4]])
+    
+    def test_dhash_and_dhash_string(self):
+        """Test double hash functions."""
+        test_data = "hello world"
+        
+        # Test dhash with string
+        hash_bytes = dhash(test_data)
+        self.assertIsInstance(hash_bytes, bytes)
+        self.assertEqual(len(hash_bytes), 32)  # SHA256 is 32 bytes
+        
+        # Test dhash with bytes
+        hash_bytes2 = dhash(test_data.encode('utf-8'))
+        self.assertEqual(hash_bytes, hash_bytes2)
+        
+        # Test dhash_string
+        hash_string = dhash_string(test_data)
+        self.assertIsInstance(hash_string, str)
+        self.assertEqual(len(hash_string), 64)  # 32 bytes = 64 hex chars
+        
+        # Consistency check
+        self.assertEqual(hash_string, hash_bytes.hex())
+    
+    def test_shash_string(self):
+        """Test single hash string function."""
+        test_data = "test data"
+        
+        # Test with string
+        hash_str = shash_string(test_data)
+        self.assertIsInstance(hash_str, str)
+        self.assertEqual(len(hash_str), 64)  # SHA256 hex string
+        
+        # Test with bytes
+        hash_str2 = shash_string(test_data.encode('utf-8'))
+        self.assertEqual(hash_str, hash_str2)
+    
+    def test_clean_url_for_log(self):
+        """Test URL cleaning for logging purposes."""
+        # URL with credentials
+        url_with_creds = "https://user:pass@example.com/path"
+        cleaned = clean_url_for_log(url_with_creds)
+        self.assertEqual(cleaned, "https://XXXXXXXX@example.com/path")
+        
+        # URL without credentials
+        normal_url = "https://example.com/path"
+        self.assertEqual(clean_url_for_log(normal_url), normal_url)
+        
+        # Different protocol
+        ftp_url = "ftp://user:secret@ftp.example.com"
+        cleaned_ftp = clean_url_for_log(ftp_url)
+        self.assertEqual(cleaned_ftp, "ftp://XXXXXXXX@ftp.example.com")
+    
+    def test_b2h_and_inverse_hash(self):
+        """Test byte-to-hex and inverse hash functions."""
+        test_bytes = b'\x01\x23\x45\x67'
+        
+        # Test b2h
+        hex_str = b2h(test_bytes)
+        self.assertEqual(hex_str, "01234567")
+        
+        # Test inverse_hash
+        test_hash = "01234567"
+        inverted = inverse_hash(test_hash)
+        self.assertEqual(inverted, "67452301")
+        
+        # Test with even length hex string
+        even_hash = "abcdef"
+        inverted_even = inverse_hash(even_hash)
+        self.assertEqual(inverted_even, "efcdab")
+    
+    def test_hex_decode(self):
+        """Test hex string decoding."""
+        # Valid hex
+        result = hex_decode("48656c6c6f")  # "Hello" in hex
+        self.assertEqual(result, "Hello")
+        
+        # Invalid hex
+        result = hex_decode("invalid")
+        self.assertIsNone(result)
+        
+        # Empty string
+        result = hex_decode("")
+        self.assertEqual(result, "")
+    
+    def test_check_valid_eth_address(self):
+        """Test Ethereum address validation."""
+        # Valid address
+        valid_eth = "0x742d35Cc6635C0532925a3b8D6E4C46f64c4ceE2"
+        self.assertTrue(check_valid_eth_address(valid_eth))
+        
+        # Invalid cases
+        self.assertFalse(check_valid_eth_address("invalid"))
+        self.assertFalse(check_valid_eth_address("742d35Cc6635C0532925a3b8D6E4C46f64c4ceE2"))  # No 0x
+        self.assertFalse(check_valid_eth_address("0x742d35Cc6635C0532925a3b8D6E4C46f64c4ceE"))  # Too short
+        self.assertFalse(check_valid_eth_address("0x742d35Cc6635C0532925a3b8D6E4C46f64c4ceE22"))  # Too long
+        self.assertFalse(check_valid_eth_address("0xGGGd35Cc6635C0532925a3b8D6E4C46f64c4ceE2"))  # Invalid chars
+    
+    def test_check_valid_tx_hash(self):
+        """Test transaction hash validation."""
+        # Valid 64-character hex string
+        valid_hash = "a" * 64
+        self.assertTrue(check_valid_tx_hash(valid_hash))
+        
+        # Mixed case valid hash
+        valid_mixed = "A1b2C3d4" * 8  # 64 chars
+        self.assertTrue(check_valid_tx_hash(valid_mixed))
+        
+        # Invalid cases
+        self.assertFalse(check_valid_tx_hash("a" * 63))  # Too short
+        self.assertFalse(check_valid_tx_hash("a" * 65))  # Too long
+        self.assertFalse(check_valid_tx_hash("g" * 64))  # Invalid hex chars
+        self.assertFalse(check_valid_tx_hash(""))  # Empty
+    
+    def test_check_contains_special(self):
+        """Test special character detection."""
+        # Text with special characters
+        self.assertTrue(check_contains_special("hello world"))  # space
+        self.assertTrue(check_contains_special("hello@world"))  # @
+        self.assertTrue(check_contains_special("hello#world"))  # #
+        self.assertTrue(check_contains_special("hello.world"))  # .
+        
+        # Text without special characters
+        self.assertFalse(check_contains_special("helloworld"))
+        self.assertFalse(check_contains_special("ABC123"))
+        
+        # Edge cases
+        self.assertFalse(check_contains_special(""))  # Empty string
+        self.assertTrue(check_contains_special("   "))  # Only spaces
+    
+    def test_check_valid_base64_string(self):
+        """Test base64 string validation."""
+        # Valid base64 strings
+        self.assertTrue(check_valid_base64_string("SGVsbG8="))  # "Hello"
+        self.assertTrue(check_valid_base64_string("SGVsbG8gV29ybGQ="))  # "Hello World"
+        self.assertTrue(check_valid_base64_string("YWJjZA=="))  # "abcd"
+        
+        # Invalid base64 strings
+        self.assertFalse(check_valid_base64_string("SGVsbG8"))  # Wrong padding
+        self.assertFalse(check_valid_base64_string("SGVsbG8==="))  # Too much padding
+        self.assertFalse(check_valid_base64_string("SGVs@G8="))  # Invalid character
+        self.assertFalse(check_valid_base64_string(None))  # None input
+        self.assertFalse(check_valid_base64_string(""))  # Empty string
+    
+    def test_base62_encode(self):
+        """Test base62 encoding."""
+        # Test various numbers
+        self.assertEqual(base62_encode(0), "0")
+        self.assertEqual(base62_encode(1), "1")
+        self.assertEqual(base62_encode(61), "Z")
+        self.assertEqual(base62_encode(62), "10")
+        
+        # Test larger number
+        result = base62_encode(123456)
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)
+    
+    def test_create_base62_hash(self):
+        """Test base62 hash creation."""
+        # Normal case
+        hash1 = create_base62_hash("test1", "test2", 15)
+        self.assertEqual(len(hash1), 15)
+        
+        # Different inputs should produce different hashes
+        hash2 = create_base62_hash("test1", "test3", 15)
+        self.assertNotEqual(hash1, hash2)
+        
+        # Test length validation
+        with self.assertRaises(ValueError):
+            create_base62_hash("test1", "test2", 11)  # Too short
+        
+        with self.assertRaises(ValueError):
+            create_base62_hash("test1", "test2", 21)  # Too long
+        
+        # Test default length
+        hash_default = create_base62_hash("test1", "test2")
+        self.assertEqual(len(hash_default), 20)
+    
+    def test_escape_and_decode_unicode(self):
+        """Test unicode escaping and decoding."""
+        # Test with unicode characters
+        test_text = "Hello 世界"
+        
+        # Escape unicode
+        escaped = escape_non_ascii_characters(test_text)
+        self.assertIn("\\u", escaped)
+        
+        # Decode back
+        decoded = decode_unicode_escapes(escaped)
+        self.assertEqual(decoded, test_text)
+        
+        # Test with ASCII only
+        ascii_text = "Hello World"
+        escaped_ascii = escape_non_ascii_characters(ascii_text)
+        self.assertEqual(escaped_ascii, ascii_text)
+    
+    def test_clean_json_string(self):
+        """Test JSON string cleaning."""
+        # Test with single quotes
+        dirty_json = "{'key': 'value'}"
+        cleaned = clean_json_string(dirty_json)
+        self.assertEqual(cleaned, "{ key :  value }")
+        
+        # Test with null bytes (function looks for literal "\x00", not actual null bytes)
+        with_nulls = "test\\x00string"
+        cleaned_nulls = clean_json_string(with_nulls)
+        self.assertEqual(cleaned_nulls, "teststring")
+        
+        # Test with both
+        complex_dirty = "{'test': 'value\\x00here'}"
+        cleaned_complex = clean_json_string(complex_dirty)
+        self.assertEqual(cleaned_complex, "{ test :  valuehere }")
+    
+    def test_convert_decimal_to_string(self):
+        """Test decimal to string conversion."""
+        # Test with Decimal
+        decimal_val = Decimal("123.456")
+        result = convert_decimal_to_string(decimal_val)
+        self.assertEqual(result, "123.456")
+        
+        # Test with non-Decimal should raise TypeError
+        with self.assertRaises(TypeError):
+            convert_decimal_to_string("not a decimal")
+        
+        with self.assertRaises(TypeError):
+            convert_decimal_to_string(123.456)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/indexer/tests/test_util_functions.py
+++ b/indexer/tests/test_util_functions.py
@@ -2,31 +2,31 @@ import unittest
 from decimal import Decimal
 
 from index_core.util import (
-    calculate_file_size,
-    chunkify,
-    dhash,
-    dhash_string,
-    shash_string,
-    clean_url_for_log,
     b2h,
-    inverse_hash,
-    hex_decode,
-    check_valid_eth_address,
-    check_valid_bitcoin_address,
-    check_valid_tx_hash,
+    base62_encode,
+    calculate_file_size,
     check_contains_special,
     check_valid_base64_string,
-    base62_encode,
-    create_base62_hash,
-    escape_non_ascii_characters,
-    decode_unicode_escapes,
+    check_valid_bitcoin_address,
+    check_valid_eth_address,
+    check_valid_tx_hash,
+    chunkify,
     clean_json_string,
+    clean_url_for_log,
     convert_decimal_to_string,
+    create_base62_hash,
+    decode_unicode_escapes,
+    dhash,
+    dhash_string,
+    escape_non_ascii_characters,
+    hex_decode,
+    inverse_hash,
+    shash_string,
 )
 
 
 class TestUtilFunctions(unittest.TestCase):
-    
+
     def test_calculate_file_size(self):
         """Test calculate_file_size function with various inputs."""
         # Normal case
@@ -37,132 +37,132 @@ class TestUtilFunctions(unittest.TestCase):
         self.assertEqual(calculate_file_size(None), 0)
         # Larger data
         self.assertEqual(calculate_file_size(b"x" * 1000), 1000)
-    
+
     def test_chunkify(self):
         """Test chunkify function for splitting lists."""
         # Normal case
         result = chunkify([1, 2, 3, 4, 5], 2)
         self.assertEqual(result, [[1, 2], [3, 4], [5]])
-        
+
         # Edge cases
         self.assertEqual(chunkify([], 2), [])
         self.assertEqual(chunkify([1], 3), [[1]])
         self.assertEqual(chunkify([1, 2, 3], 0), [[1], [2], [3]])  # n=0 becomes n=1
-        
+
         # Exact division
         self.assertEqual(chunkify([1, 2, 3, 4], 2), [[1, 2], [3, 4]])
-    
+
     def test_dhash_and_dhash_string(self):
         """Test double hash functions."""
         test_data = "hello world"
-        
+
         # Test dhash with string
         hash_bytes = dhash(test_data)
         self.assertIsInstance(hash_bytes, bytes)
         self.assertEqual(len(hash_bytes), 32)  # SHA256 is 32 bytes
-        
+
         # Test dhash with bytes
-        hash_bytes2 = dhash(test_data.encode('utf-8'))
+        hash_bytes2 = dhash(test_data.encode("utf-8"))
         self.assertEqual(hash_bytes, hash_bytes2)
-        
+
         # Test dhash_string
         hash_string = dhash_string(test_data)
         self.assertIsInstance(hash_string, str)
         self.assertEqual(len(hash_string), 64)  # 32 bytes = 64 hex chars
-        
+
         # Consistency check
         self.assertEqual(hash_string, hash_bytes.hex())
-    
+
     def test_shash_string(self):
         """Test single hash string function."""
         test_data = "test data"
-        
+
         # Test with string
         hash_str = shash_string(test_data)
         self.assertIsInstance(hash_str, str)
         self.assertEqual(len(hash_str), 64)  # SHA256 hex string
-        
+
         # Test with bytes
-        hash_str2 = shash_string(test_data.encode('utf-8'))
+        hash_str2 = shash_string(test_data.encode("utf-8"))
         self.assertEqual(hash_str, hash_str2)
-    
+
     def test_clean_url_for_log(self):
         """Test URL cleaning for logging purposes."""
         # URL with credentials
         url_with_creds = "https://user:pass@example.com/path"
         cleaned = clean_url_for_log(url_with_creds)
         self.assertEqual(cleaned, "https://XXXXXXXX@example.com/path")
-        
+
         # URL without credentials
         normal_url = "https://example.com/path"
         self.assertEqual(clean_url_for_log(normal_url), normal_url)
-        
+
         # Different protocol
         ftp_url = "ftp://user:secret@ftp.example.com"
         cleaned_ftp = clean_url_for_log(ftp_url)
         self.assertEqual(cleaned_ftp, "ftp://XXXXXXXX@ftp.example.com")
-    
+
     def test_b2h_and_inverse_hash(self):
         """Test byte-to-hex and inverse hash functions."""
-        test_bytes = b'\x01\x23\x45\x67'
-        
+        test_bytes = b"\x01\x23\x45\x67"
+
         # Test b2h
         hex_str = b2h(test_bytes)
         self.assertEqual(hex_str, "01234567")
-        
+
         # Test inverse_hash
         test_hash = "01234567"
         inverted = inverse_hash(test_hash)
         self.assertEqual(inverted, "67452301")
-        
+
         # Test with even length hex string
         even_hash = "abcdef"
         inverted_even = inverse_hash(even_hash)
         self.assertEqual(inverted_even, "efcdab")
-    
+
     def test_hex_decode(self):
         """Test hex string decoding."""
         # Valid hex
         result = hex_decode("48656c6c6f")  # "Hello" in hex
         self.assertEqual(result, "Hello")
-        
+
         # Invalid hex
         result = hex_decode("invalid")
         self.assertIsNone(result)
-        
+
         # Empty string
         result = hex_decode("")
         self.assertEqual(result, "")
-    
+
     def test_check_valid_eth_address(self):
         """Test Ethereum address validation."""
         # Valid address
         valid_eth = "0x742d35Cc6635C0532925a3b8D6E4C46f64c4ceE2"
         self.assertTrue(check_valid_eth_address(valid_eth))
-        
+
         # Invalid cases
         self.assertFalse(check_valid_eth_address("invalid"))
         self.assertFalse(check_valid_eth_address("742d35Cc6635C0532925a3b8D6E4C46f64c4ceE2"))  # No 0x
         self.assertFalse(check_valid_eth_address("0x742d35Cc6635C0532925a3b8D6E4C46f64c4ceE"))  # Too short
         self.assertFalse(check_valid_eth_address("0x742d35Cc6635C0532925a3b8D6E4C46f64c4ceE22"))  # Too long
         self.assertFalse(check_valid_eth_address("0xGGGd35Cc6635C0532925a3b8D6E4C46f64c4ceE2"))  # Invalid chars
-    
+
     def test_check_valid_tx_hash(self):
         """Test transaction hash validation."""
         # Valid 64-character hex string
         valid_hash = "a" * 64
         self.assertTrue(check_valid_tx_hash(valid_hash))
-        
+
         # Mixed case valid hash
         valid_mixed = "A1b2C3d4" * 8  # 64 chars
         self.assertTrue(check_valid_tx_hash(valid_mixed))
-        
+
         # Invalid cases
         self.assertFalse(check_valid_tx_hash("a" * 63))  # Too short
         self.assertFalse(check_valid_tx_hash("a" * 65))  # Too long
         self.assertFalse(check_valid_tx_hash("g" * 64))  # Invalid hex chars
         self.assertFalse(check_valid_tx_hash(""))  # Empty
-    
+
     def test_check_contains_special(self):
         """Test special character detection."""
         # Text with special characters
@@ -170,29 +170,29 @@ class TestUtilFunctions(unittest.TestCase):
         self.assertTrue(check_contains_special("hello@world"))  # @
         self.assertTrue(check_contains_special("hello#world"))  # #
         self.assertTrue(check_contains_special("hello.world"))  # .
-        
+
         # Text without special characters
         self.assertFalse(check_contains_special("helloworld"))
         self.assertFalse(check_contains_special("ABC123"))
-        
+
         # Edge cases
         self.assertFalse(check_contains_special(""))  # Empty string
         self.assertTrue(check_contains_special("   "))  # Only spaces
-    
+
     def test_check_valid_base64_string(self):
         """Test base64 string validation."""
         # Valid base64 strings
         self.assertTrue(check_valid_base64_string("SGVsbG8="))  # "Hello"
         self.assertTrue(check_valid_base64_string("SGVsbG8gV29ybGQ="))  # "Hello World"
         self.assertTrue(check_valid_base64_string("YWJjZA=="))  # "abcd"
-        
+
         # Invalid base64 strings
         self.assertFalse(check_valid_base64_string("SGVsbG8"))  # Wrong padding
         self.assertFalse(check_valid_base64_string("SGVsbG8==="))  # Too much padding
         self.assertFalse(check_valid_base64_string("SGVs@G8="))  # Invalid character
         self.assertFalse(check_valid_base64_string(None))  # None input
         self.assertFalse(check_valid_base64_string(""))  # Empty string
-    
+
     def test_base62_encode(self):
         """Test base62 encoding."""
         # Test various numbers
@@ -200,82 +200,82 @@ class TestUtilFunctions(unittest.TestCase):
         self.assertEqual(base62_encode(1), "1")
         self.assertEqual(base62_encode(61), "Z")
         self.assertEqual(base62_encode(62), "10")
-        
+
         # Test larger number
         result = base62_encode(123456)
         self.assertIsInstance(result, str)
         self.assertTrue(len(result) > 0)
-    
+
     def test_create_base62_hash(self):
         """Test base62 hash creation."""
         # Normal case
         hash1 = create_base62_hash("test1", "test2", 15)
         self.assertEqual(len(hash1), 15)
-        
+
         # Different inputs should produce different hashes
         hash2 = create_base62_hash("test1", "test3", 15)
         self.assertNotEqual(hash1, hash2)
-        
+
         # Test length validation
         with self.assertRaises(ValueError):
             create_base62_hash("test1", "test2", 11)  # Too short
-        
+
         with self.assertRaises(ValueError):
             create_base62_hash("test1", "test2", 21)  # Too long
-        
+
         # Test default length
         hash_default = create_base62_hash("test1", "test2")
         self.assertEqual(len(hash_default), 20)
-    
+
     def test_escape_and_decode_unicode(self):
         """Test unicode escaping and decoding."""
         # Test with unicode characters
         test_text = "Hello 世界"
-        
+
         # Escape unicode
         escaped = escape_non_ascii_characters(test_text)
         self.assertIn("\\u", escaped)
-        
+
         # Decode back
         decoded = decode_unicode_escapes(escaped)
         self.assertEqual(decoded, test_text)
-        
+
         # Test with ASCII only
         ascii_text = "Hello World"
         escaped_ascii = escape_non_ascii_characters(ascii_text)
         self.assertEqual(escaped_ascii, ascii_text)
-    
+
     def test_clean_json_string(self):
         """Test JSON string cleaning."""
         # Test with single quotes
         dirty_json = "{'key': 'value'}"
         cleaned = clean_json_string(dirty_json)
         self.assertEqual(cleaned, "{ key :  value }")
-        
+
         # Test with null bytes (function looks for literal "\x00", not actual null bytes)
         with_nulls = "test\\x00string"
         cleaned_nulls = clean_json_string(with_nulls)
         self.assertEqual(cleaned_nulls, "teststring")
-        
+
         # Test with both
         complex_dirty = "{'test': 'value\\x00here'}"
         cleaned_complex = clean_json_string(complex_dirty)
         self.assertEqual(cleaned_complex, "{ test :  valuehere }")
-    
+
     def test_convert_decimal_to_string(self):
         """Test decimal to string conversion."""
         # Test with Decimal
         decimal_val = Decimal("123.456")
         result = convert_decimal_to_string(decimal_val)
         self.assertEqual(result, "123.456")
-        
+
         # Test with non-Decimal should raise TypeError
         with self.assertRaises(TypeError):
             convert_decimal_to_string("not a decimal")
-        
+
         with self.assertRaises(TypeError):
             convert_decimal_to_string(123.456)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/indexer/tools/run_checks.py
+++ b/indexer/tools/run_checks.py
@@ -173,6 +173,9 @@ def run_code_quality_checks(auto_fix=False):
             "tests/test_pipeline_executor_lifecycle.py",
             # SRC-20 thread safety and locking mechanism tests
             "tests/thread_safety/test_thread_safety.py",
+            # Filesize tracking and utility function tests
+            "tests/test_filesize_tracking.py",
+            "tests/test_util_functions.py",
         ]
 
         for test_file in test_files:


### PR DESCRIPTION
- Introduced a new column `file_size_bytes` in `StampTableV4` to store the size of decoded stamp files in bytes, enhancing data tracking capabilities.
- Updated the `insert_into_stamp_table` function to include `file_size_bytes` during data insertion, ensuring accurate file size information is recorded.
- Modified the `encode_and_store_file` function to calculate and return the file size, improving the file handling process.
- Added a new utility function `calculate_file_size` to determine the size of binary data, supporting the new feature.
- Implemented comprehensive unit tests for file size calculation and integration with the `encode_and_store_file` function, ensuring reliability and correctness of the new functionality.