### PR TITLE
Add enhanced SVG and gzipped SVG detection support

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -365,6 +365,8 @@ CP_SUBASSET_FEAT_BLOCK_START: int = 866000  # Subasset no longer require XCP fee
 # Consensus changes
 STRIP_WHITESPACE: int = 797200
 STOP_BASE64_REPAIR: int = 784550
+SVG_GZIP_DETECTION_V2: int = 906000  # Block height where new SVG gzip detection method activates
+ENHANCED_MIME_DETECTION: int = 906000  # Block height where enhanced MIME detection for SVG activates
 
 
 VERSION_MAJOR: Optional[int]

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -57,10 +57,10 @@ def is_legitimate_html(content_bytes):
 def is_svg_content(content_bytes):
     """
     Check if content is SVG by looking for SVG markers.
-    
+
     Args:
         content_bytes (bytes): The content to analyze
-        
+
     Returns:
         bool: True if content appears to be SVG
     """
@@ -74,10 +74,10 @@ def is_svg_content(content_bytes):
 def detect_and_decompress_svg(content_bytes):
     """
     Detect and decompress gzipped SVG files (svgz) or gzipped binary files containing SVG.
-    
+
     Args:
         content_bytes (bytes): The content to analyze and potentially decompress
-        
+
     Returns:
         tuple: (decompressed_content_bytes, is_svg, mime_type)
                - decompressed_content_bytes: Original or decompressed content
@@ -87,36 +87,36 @@ def detect_and_decompress_svg(content_bytes):
     # Check if content is already SVG
     if is_svg_content(content_bytes):
         return content_bytes, True, "image/svg+xml"
-    
+
     # Try to detect gzipped content by magic number and MIME type
     try:
         magic_mime = magic.from_buffer(content_bytes, mime=True)
     except Exception:
         magic_mime = "application/octet-stream"
-    
+
     # Check for gzip magic number (1f 8b) or gzip MIME types
     is_gzip_file = (
-        content_bytes.startswith(b"\x1f\x8b") or 
-        magic_mime in ("application/gzip", "application/x-gzip") or
-        magic_mime == "application/octet-stream"  # gzop files might be detected as octet-stream
+        content_bytes.startswith(b"\x1f\x8b")
+        or magic_mime in ("application/gzip", "application/x-gzip")
+        or magic_mime == "application/octet-stream"  # gzop files might be detected as octet-stream
     )
-    
+
     if is_gzip_file:
         try:
             # Attempt to decompress
             decompressed = gzip.decompress(content_bytes)
-            
+
             # Check if decompressed content is SVG
             if is_svg_content(decompressed):
                 return decompressed, True, "image/svg+xml"
             else:
                 # Return original content if decompressed content is not SVG
                 return content_bytes, False, magic_mime
-                
+
         except (gzip.BadGzipFile, OSError, EOFError, Exception):
             # Not actually gzipped or corrupted, return original
             return content_bytes, False, magic_mime
-    
+
     # Not gzipped or not SVG after decompression
     return content_bytes, False, magic_mime
 
@@ -124,23 +124,23 @@ def detect_and_decompress_svg(content_bytes):
 def get_processed_content_and_mime(content_bytes):
     """
     Get both processed content and MIME type for content that may need decompression.
-    
+
     Args:
         content_bytes (bytes): The content to analyze
-        
+
     Returns:
         tuple: (processed_content_bytes, mime_type)
-               - processed_content_bytes: Original or decompressed content  
+               - processed_content_bytes: Original or decompressed content
                - mime_type: The detected MIME type
     """
     # Check for gzipped SVG files first
     processed_content, is_svg, svg_mime = detect_and_decompress_svg(content_bytes)
     if is_svg:
         return processed_content, svg_mime
-    
+
     # Use processed content for further detection
     content_to_analyze = processed_content
-    
+
     # Try standard magic detection
     try:
         magic_mime = magic.from_buffer(content_to_analyze, mime=True)

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -3,6 +3,7 @@ Enhanced MIME type detection for Bitcoin Stamps
 Provides improved detection for HTML, JavaScript, CSS and other content types
 """
 
+import gzip
 import magic
 
 
@@ -53,13 +54,114 @@ def is_legitimate_html(content_bytes):
         return False
 
 
+def is_svg_content(content_bytes):
+    """
+    Check if content is SVG by looking for SVG markers.
+    
+    Args:
+        content_bytes (bytes): The content to analyze
+        
+    Returns:
+        bool: True if content appears to be SVG
+    """
+    try:
+        content_str = content_bytes.decode("utf-8", errors="ignore").lower()
+        return "<svg" in content_str and ("xmlns" in content_str or "viewbox" in content_str)
+    except Exception:
+        return False
+
+
+def detect_and_decompress_svg(content_bytes):
+    """
+    Detect and decompress gzipped SVG files (svgz) or gzipped binary files containing SVG.
+    
+    Args:
+        content_bytes (bytes): The content to analyze and potentially decompress
+        
+    Returns:
+        tuple: (decompressed_content_bytes, is_svg, mime_type)
+               - decompressed_content_bytes: Original or decompressed content
+               - is_svg: True if content is SVG after decompression
+               - mime_type: Detected MIME type ("image/svg+xml" for SVG)
+    """
+    # Check if content is already SVG
+    if is_svg_content(content_bytes):
+        return content_bytes, True, "image/svg+xml"
+    
+    # Try to detect gzipped content by magic number and MIME type
+    try:
+        magic_mime = magic.from_buffer(content_bytes, mime=True)
+    except Exception:
+        magic_mime = "application/octet-stream"
+    
+    # Check for gzip magic number (1f 8b) or gzip MIME types
+    is_gzip_file = (
+        content_bytes.startswith(b"\x1f\x8b") or 
+        magic_mime in ("application/gzip", "application/x-gzip") or
+        magic_mime == "application/octet-stream"  # gzop files might be detected as octet-stream
+    )
+    
+    if is_gzip_file:
+        try:
+            # Attempt to decompress
+            decompressed = gzip.decompress(content_bytes)
+            
+            # Check if decompressed content is SVG
+            if is_svg_content(decompressed):
+                return decompressed, True, "image/svg+xml"
+            else:
+                # Return original content if decompressed content is not SVG
+                return content_bytes, False, magic_mime
+                
+        except (gzip.BadGzipFile, OSError, EOFError, Exception):
+            # Not actually gzipped or corrupted, return original
+            return content_bytes, False, magic_mime
+    
+    # Not gzipped or not SVG after decompression
+    return content_bytes, False, magic_mime
+
+
+def get_processed_content_and_mime(content_bytes):
+    """
+    Get both processed content and MIME type for content that may need decompression.
+    
+    Args:
+        content_bytes (bytes): The content to analyze
+        
+    Returns:
+        tuple: (processed_content_bytes, mime_type)
+               - processed_content_bytes: Original or decompressed content  
+               - mime_type: The detected MIME type
+    """
+    # Check for gzipped SVG files first
+    processed_content, is_svg, svg_mime = detect_and_decompress_svg(content_bytes)
+    if is_svg:
+        return processed_content, svg_mime
+    
+    # Use processed content for further detection
+    content_to_analyze = processed_content
+    
+    # Try standard magic detection
+    try:
+        magic_mime = magic.from_buffer(content_to_analyze, mime=True)
+    except Exception:
+        magic_mime = "application/octet-stream"
+
+    # Enhanced detection for specific types
+    if is_legitimate_html(content_to_analyze):
+        return content_to_analyze, "text/html"
+
+    # For other types, fall back to magic detection
+    return content_to_analyze, magic_mime
+
+
 def enhanced_mime_detection(content_bytes):
     """
     Enhanced MIME type detection with custom logic for better accuracy.
 
     This function provides improved MIME detection that can identify content
     types that python-magic might miss or misclassify, particularly for
-    HTML, JavaScript, and CSS content.
+    HTML, JavaScript, CSS content, and gzipped SVG files.
 
     Args:
         content_bytes (bytes): The content to analyze
@@ -67,17 +169,5 @@ def enhanced_mime_detection(content_bytes):
     Returns:
         str: The detected MIME type
     """
-    # Try standard magic detection first
-    try:
-        magic_mime = magic.from_buffer(content_bytes, mime=True)
-    except Exception:
-        magic_mime = "application/octet-stream"
-
-    # Enhanced detection for specific types
-    if is_legitimate_html(content_bytes):
-        return "text/html"
-
-    # For other types, fall back to magic detection
-    # Future enhancements can add JavaScript, CSS, etc. detection here
-
-    return magic_mime
+    _, mime_type = get_processed_content_and_mime(content_bytes)
+    return mime_type

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -100,7 +100,6 @@ def detect_and_decompress_svg(content_bytes):
         or magic_mime in ("application/gzip", "application/x-gzip")
         or magic_mime == "application/octet-stream"  # gzop files might be detected as octet-stream
     )
-
     if is_gzip_file:
         try:
             # Attempt to decompress

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -4,6 +4,7 @@ Provides improved detection for HTML, JavaScript, CSS and other content types
 """
 
 import gzip
+
 import magic
 
 

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -128,6 +128,9 @@ def detect_and_decompress_svg(content_bytes, block_index=None):
     if is_svg_content(content_bytes):
         return content_bytes, True, "image/svg+xml"
 
+    # Cache for magic MIME type to avoid duplicate calls
+    magic_mime = None
+
     # Use old behavior for blocks before SVG_GZIP_DETECTION_V2
     if block_index is None or block_index < SVG_GZIP_DETECTION_V2:
         # Old behavior: attempt decompression for any gzip-like content
@@ -150,10 +153,12 @@ def detect_and_decompress_svg(content_bytes, block_index=None):
                 return decompressed, True, "image/svg+xml"
 
     # Return original for all other cases (preserves consensus)
-    try:
-        magic_mime = magic.from_buffer(content_bytes, mime=True)
-    except Exception:
-        magic_mime = "application/octet-stream"
+    # Use cached magic_mime if available, otherwise detect it
+    if magic_mime is None:
+        try:
+            magic_mime = magic.from_buffer(content_bytes, mime=True)
+        except Exception:
+            magic_mime = "application/octet-stream"
     return content_bytes, False, magic_mime
 
 

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -4,6 +4,7 @@ Provides improved detection for HTML, JavaScript, CSS and other content types
 """
 
 import gzip
+import zlib
 
 import magic
 
@@ -114,7 +115,7 @@ def detect_and_decompress_svg(content_bytes):
                 # Return original content if decompressed content is not SVG
                 return content_bytes, False, magic_mime
 
-        except (gzip.BadGzipFile, OSError, EOFError):
+        except (gzip.BadGzipFile, OSError, EOFError, zlib.error):
             # Not actually gzipped or corrupted, return original
             return content_bytes, False, magic_mime
 

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -107,12 +107,13 @@ def try_decompress(content_bytes):
         return None
 
 
-def detect_and_decompress_svg(content_bytes):
+def detect_and_decompress_svg(content_bytes, block_index=None):
     """
     Detect and decompress gzipped SVG files (svgz) or gzipped binary files containing SVG.
 
     Args:
         content_bytes (bytes): The content to analyze and potentially decompress
+        block_index (int): The block index for consensus rules (optional)
 
     Returns:
         tuple: (decompressed_content_bytes, is_svg, mime_type)
@@ -120,40 +121,70 @@ def detect_and_decompress_svg(content_bytes):
                - is_svg: True if content is SVG after decompression
                - mime_type: Detected MIME type ("image/svg+xml" for SVG)
     """
+    # Import config to check consensus block height
+    from config import SVG_GZIP_DETECTION_V2
+
     # Only decompress if it's likely to be SVG
     if is_svg_content(content_bytes):
         return content_bytes, True, "image/svg+xml"
 
-    # Get magic MIME type first (preserves old behavior)
+    # Use old behavior for blocks before SVG_GZIP_DETECTION_V2
+    if block_index is None or block_index < SVG_GZIP_DETECTION_V2:
+        # Old behavior: attempt decompression for any gzip-like content
+        if is_gzip(content_bytes):
+            decompressed = try_decompress(content_bytes)
+            if decompressed and is_svg_content(decompressed):
+                return decompressed, True, "image/svg+xml"
+    else:
+        # New behavior: only decompress for explicit gzip MIME types
+        # Get magic MIME type first (preserves old behavior)
+        try:
+            magic_mime = magic.from_buffer(content_bytes, mime=True)
+        except Exception:
+            magic_mime = "application/octet-stream"
+
+        # Only try decompression for explicit gzip MIME types
+        if magic_mime in ("application/gzip", "application/x-gzip"):
+            decompressed = try_decompress(content_bytes)
+            if decompressed and is_svg_content(decompressed):
+                return decompressed, True, "image/svg+xml"
+
+    # Return original for all other cases (preserves consensus)
     try:
         magic_mime = magic.from_buffer(content_bytes, mime=True)
     except Exception:
         magic_mime = "application/octet-stream"
-
-    # Only try decompression for explicit gzip MIME types
-    if magic_mime in ("application/gzip", "application/x-gzip"):
-        decompressed = try_decompress(content_bytes)
-        if decompressed and is_svg_content(decompressed):
-            return decompressed, True, "image/svg+xml"
-
-    # Return original for all other cases (preserves consensus)
     return content_bytes, False, magic_mime
 
 
-def get_processed_content_and_mime(content_bytes):
+def get_processed_content_and_mime(content_bytes, block_index=None):
     """
     Get both processed content and MIME type for content that may need decompression.
 
     Args:
         content_bytes (bytes): The content to analyze
+        block_index (int): The block index for consensus rules (optional)
 
     Returns:
         tuple: (processed_content_bytes, mime_type)
                - processed_content_bytes: Original or decompressed content
                - mime_type: The detected MIME type
     """
+    # Import config to check consensus block height
+    from config import ENHANCED_MIME_DETECTION
+
+    # For blocks before ENHANCED_MIME_DETECTION, use only magic detection
+    # This preserves consensus for historical blocks where SVGs with comments
+    # were misdetected as text/plain
+    if block_index is not None and block_index < ENHANCED_MIME_DETECTION:
+        try:
+            magic_mime = magic.from_buffer(content_bytes, mime=True)
+        except Exception:
+            magic_mime = "application/octet-stream"
+        return content_bytes, magic_mime
+
     # Check for gzipped SVG files first
-    processed_content, is_svg, svg_mime = detect_and_decompress_svg(content_bytes)
+    processed_content, is_svg, svg_mime = detect_and_decompress_svg(content_bytes, block_index)
     if is_svg:
         return processed_content, svg_mime
 
@@ -174,7 +205,7 @@ def get_processed_content_and_mime(content_bytes):
     return content_to_analyze, magic_mime
 
 
-def enhanced_mime_detection(content_bytes):
+def enhanced_mime_detection(content_bytes, block_index=None):
     """
     Enhanced MIME type detection with custom logic for better accuracy.
 
@@ -184,9 +215,10 @@ def enhanced_mime_detection(content_bytes):
 
     Args:
         content_bytes (bytes): The content to analyze
+        block_index (int): The block index for consensus rules (optional)
 
     Returns:
         str: The detected MIME type
     """
-    _, mime_type = get_processed_content_and_mime(content_bytes)
+    _, mime_type = get_processed_content_and_mime(content_bytes, block_index)
     return mime_type

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -88,7 +88,7 @@ def is_gzip(content_bytes):
     Returns:
         bool: True if content appears to be gzipped
     """
-    return len(content_bytes) >= 2 and content_bytes.startswith(b"\x1f\x8b")
+    return len(content_bytes) >= 3 and content_bytes[:2] == b"\x1f\x8b" and content_bytes[2] == 0x08
 
 
 def try_decompress(content_bytes):

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -100,6 +100,7 @@ def detect_and_decompress_svg(content_bytes):
         or magic_mime in ("application/gzip", "application/x-gzip")
         or magic_mime == "application/octet-stream"  # gzop files might be detected as octet-stream
     )
+
     if is_gzip_file:
         try:
             # Attempt to decompress
@@ -114,10 +115,6 @@ def detect_and_decompress_svg(content_bytes):
 
         except (gzip.BadGzipFile, OSError, EOFError):
             # Not actually gzipped or corrupted, return original
-            return content_bytes, False, magic_mime
-        except Exception as e:
-            # Log unexpected exceptions for debugging purposes
-            print(f"Unexpected error during gzip decompression: {e}")
             return content_bytes, False, magic_mime
 
     # Not gzipped or not SVG after decompression

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -56,21 +56,55 @@ def is_legitimate_html(content_bytes):
         return False
 
 
-def is_svg_content(content_bytes):
+def is_svg_content(content_bytes, max_check_size=512):
     """
     Check if content is SVG by looking for SVG markers.
 
+    Performance optimization: Only decode first 512 bytes to check for SVG markers.
+
     Args:
         content_bytes (bytes): The content to analyze
+        max_check_size (int): Maximum bytes to decode for SVG detection
 
     Returns:
         bool: True if content appears to be SVG
     """
     try:
-        content_str = content_bytes.decode("utf-8", errors="ignore").lower()
+        # Only decode a prefix for performance
+        check_bytes = content_bytes[:max_check_size]
+        content_str = check_bytes.decode("utf-8", errors="ignore").lower()
         return "<svg" in content_str and ("xmlns" in content_str or "viewbox" in content_str)
     except Exception:
         return False
+
+
+def is_gzip(content_bytes):
+    """
+    Check if content appears to be gzipped.
+
+    Args:
+        content_bytes (bytes): The content to check
+
+    Returns:
+        bool: True if content appears to be gzipped
+    """
+    return len(content_bytes) >= 2 and content_bytes.startswith(b"\x1f\x8b")
+
+
+def try_decompress(content_bytes):
+    """
+    Attempt to decompress gzipped content.
+
+    Args:
+        content_bytes (bytes): The gzipped content
+
+    Returns:
+        bytes or None: Decompressed content if successful, None otherwise
+    """
+    try:
+        return gzip.decompress(content_bytes)
+    except (gzip.BadGzipFile, OSError, EOFError, zlib.error):
+        return None
 
 
 def detect_and_decompress_svg(content_bytes):
@@ -90,34 +124,23 @@ def detect_and_decompress_svg(content_bytes):
     if is_svg_content(content_bytes):
         return content_bytes, True, "image/svg+xml"
 
-    # Try to detect gzipped content by magic number and MIME type
+    # Performance optimization: Check gzip header first before calling magic
+    if is_gzip(content_bytes):
+        decompressed = try_decompress(content_bytes)
+        if decompressed and is_svg_content(decompressed):
+            return decompressed, True, "image/svg+xml"
+
+    # If not obviously gzipped, check with magic for edge cases
     try:
         magic_mime = magic.from_buffer(content_bytes, mime=True)
     except Exception:
         magic_mime = "application/octet-stream"
 
-    # Check for gzip magic number (1f 8b) or gzip MIME types
-    is_gzip_file = (
-        content_bytes.startswith(b"\x1f\x8b")
-        or magic_mime in ("application/gzip", "application/x-gzip")
-        or magic_mime == "application/octet-stream"  # gzop files might be detected as octet-stream
-    )
-
-    if is_gzip_file:
-        try:
-            # Attempt to decompress
-            decompressed = gzip.decompress(content_bytes)
-
-            # Check if decompressed content is SVG
-            if is_svg_content(decompressed):
-                return decompressed, True, "image/svg+xml"
-            else:
-                # Return original content if decompressed content is not SVG
-                return content_bytes, False, magic_mime
-
-        except (gzip.BadGzipFile, OSError, EOFError, zlib.error):
-            # Not actually gzipped or corrupted, return original
-            return content_bytes, False, magic_mime
+    # Check for gzip MIME types that weren't caught by header check
+    if magic_mime in ("application/gzip", "application/x-gzip"):
+        decompressed = try_decompress(content_bytes)
+        if decompressed and is_svg_content(decompressed):
+            return decompressed, True, "image/svg+xml"
 
     # Not gzipped or not SVG after decompression
     return content_bytes, False, magic_mime

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -120,29 +120,23 @@ def detect_and_decompress_svg(content_bytes):
                - is_svg: True if content is SVG after decompression
                - mime_type: Detected MIME type ("image/svg+xml" for SVG)
     """
-    # Check if content is already SVG
+    # Only decompress if it's likely to be SVG
     if is_svg_content(content_bytes):
         return content_bytes, True, "image/svg+xml"
 
-    # Performance optimization: Check gzip header first before calling magic
-    if is_gzip(content_bytes):
-        decompressed = try_decompress(content_bytes)
-        if decompressed and is_svg_content(decompressed):
-            return decompressed, True, "image/svg+xml"
-
-    # If not obviously gzipped, check with magic for edge cases
+    # Get magic MIME type first (preserves old behavior)
     try:
         magic_mime = magic.from_buffer(content_bytes, mime=True)
     except Exception:
         magic_mime = "application/octet-stream"
 
-    # Check for gzip MIME types that weren't caught by header check
+    # Only try decompression for explicit gzip MIME types
     if magic_mime in ("application/gzip", "application/x-gzip"):
         decompressed = try_decompress(content_bytes)
         if decompressed and is_svg_content(decompressed):
             return decompressed, True, "image/svg+xml"
 
-    # Not gzipped or not SVG after decompression
+    # Return original for all other cases (preserves consensus)
     return content_bytes, False, magic_mime
 
 

--- a/indexer/src/index_core/enhanced_mime_detection.py
+++ b/indexer/src/index_core/enhanced_mime_detection.py
@@ -112,8 +112,12 @@ def detect_and_decompress_svg(content_bytes):
                 # Return original content if decompressed content is not SVG
                 return content_bytes, False, magic_mime
 
-        except (gzip.BadGzipFile, OSError, EOFError, Exception):
+        except (gzip.BadGzipFile, OSError, EOFError):
             # Not actually gzipped or corrupted, return original
+            return content_bytes, False, magic_mime
+        except Exception as e:
+            # Log unexpected exceptions for debugging purposes
+            print(f"Unexpected error during gzip decompression: {e}")
             return content_bytes, False, magic_mime
 
     # Not gzipped or not SVG after decompression

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -407,13 +407,21 @@ class StampData:
             pass
 
         # Use enhanced MIME detection for better accuracy
-        from .enhanced_mime_detection import enhanced_mime_detection
+        from .enhanced_mime_detection import get_processed_content_and_mime
 
         processed_data = bytestring_data.lstrip() if self.block_index > STRIP_WHITESPACE else bytestring_data
-        mime_type = enhanced_mime_detection(processed_data)
+        processed_content, mime_type = get_processed_content_and_mime(processed_data)
+
+        # Update the decoded data if it was decompressed (e.g., svgz to svg)
+        if processed_content != processed_data:
+            self.decoded_base64 = processed_content
 
         self.file_suffix = mime_type.split("/")[-1]
         self.stamp_mimetype = mime_type
+
+        # Special handling for SVG files - use 'svg' suffix instead of 'svg+xml'
+        if mime_type == "image/svg+xml":
+            self.file_suffix = "svg"
 
         if (mime_type == "text/plain" or mime_type == "application/javascript") and self.is_javascript(bytestring_data):
             self.file_suffix = "js"

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -112,6 +112,7 @@ class StampData:
     file_suffix: Optional[str] = None
     decoded_base64: Optional[Union[str, bytes]] = None
     src20_dict: Optional[dict] = None
+    actual_mimetype: Optional[str] = None  # For display when different from consensus mimetype
     src101_dict: Optional[dict] = None
     pval_src20: Optional[bool] = None
     pval_src101: Optional[bool] = None
@@ -407,10 +408,12 @@ class StampData:
             pass
 
         # Use enhanced MIME detection for better accuracy
+        from config import ENHANCED_MIME_DETECTION
+
         from .enhanced_mime_detection import get_processed_content_and_mime
 
         processed_data = bytestring_data.lstrip() if self.block_index > STRIP_WHITESPACE else bytestring_data
-        processed_content, mime_type = get_processed_content_and_mime(processed_data)
+        processed_content, mime_type = get_processed_content_and_mime(processed_data, self.block_index)
 
         # Update the decoded data if it was decompressed (e.g., svgz to svg)
         if processed_content != processed_data:
@@ -422,6 +425,20 @@ class StampData:
         # Special handling for SVG files - use 'svg' suffix instead of 'svg+xml'
         if mime_type == "image/svg+xml":
             self.file_suffix = "svg"
+
+        # Dual processing for pre-ENHANCED_MIME_DETECTION blocks:
+        # If we're before the enhanced detection block and got text/plain,
+        # try enhanced detection again just for the content (not for consensus)
+        if self.block_index is not None and self.block_index < ENHANCED_MIME_DETECTION and mime_type == "text/plain":
+            # Try enhanced detection to see if we can get better content
+            enhanced_content, enhanced_mime = get_processed_content_and_mime(processed_data, ENHANCED_MIME_DETECTION)
+            if enhanced_mime == "image/svg+xml" and enhanced_content != processed_data:
+                # Update the decoded content for proper display, but keep the consensus suffix
+                self.decoded_base64 = enhanced_content
+                # Store the actual mime type for display purposes
+                self.actual_mimetype = enhanced_mime
+                # Note: self.file_suffix remains "plain" for consensus
+                # Note: self.stamp_mimetype remains "text/plain" for consensus
 
         if (mime_type == "text/plain" or mime_type == "application/javascript") and self.is_javascript(bytestring_data):
             self.file_suffix = "js"
@@ -747,12 +764,15 @@ class StampData:
 
         self.normalize_mime_and_suffix()
         # 'encode_and_store_file' can handle different types (bytestring, string, or dict)
+        # Use actual_mimetype for file storage if available (for proper display of cursed stamps)
+        storage_mimetype = self.actual_mimetype if self.actual_mimetype else self.stamp_mimetype
+        storage_suffix = "svg" if self.actual_mimetype == "image/svg+xml" else self.file_suffix
         self.file_hash, filename, self.file_size_bytes = encode_and_store_file(
             db,
             self.tx_hash,
-            self.file_suffix,
+            storage_suffix,
             self.decoded_base64,
-            self.stamp_mimetype,
+            storage_mimetype,
         )
 
         self.update_cpid_and_stamp_url(filename)

--- a/indexer/tests/test_enhanced_mime_detection.py
+++ b/indexer/tests/test_enhanced_mime_detection.py
@@ -113,7 +113,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         """Test gzipped SVG content detection and decompression."""
         svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
         gzipped_svg = gzip.compress(svg_content)
-        
+
         content, is_svg, mime_type = detect_and_decompress_svg(gzipped_svg)
         self.assertEqual(content, svg_content)
         self.assertTrue(is_svg)
@@ -123,7 +123,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         """Test gzipped non-SVG content."""
         text_content = b"This is just plain text, not SVG"
         gzipped_text = gzip.compress(text_content)
-        
+
         content, is_svg, mime_type = detect_and_decompress_svg(gzipped_text)
         self.assertEqual(content, gzipped_text)  # Returns original gzipped content
         self.assertFalse(is_svg)
@@ -132,7 +132,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
     def test_detect_and_decompress_svg_non_gzipped_non_svg(self):
         """Test non-gzipped, non-SVG content."""
         text_content = b"This is just plain text"
-        
+
         content, is_svg, mime_type = detect_and_decompress_svg(text_content)
         self.assertEqual(content, text_content)
         self.assertFalse(is_svg)
@@ -141,7 +141,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
     def test_detect_and_decompress_svg_corrupted_gzip(self):
         """Test corrupted gzip data handling."""
         corrupted_gzip = b"\x1f\x8b\x08\x00corrupted_data"
-        
+
         content, is_svg, mime_type = detect_and_decompress_svg(corrupted_gzip)
         self.assertEqual(content, corrupted_gzip)
         self.assertFalse(is_svg)
@@ -151,7 +151,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         """Test get_processed_content_and_mime with SVG content."""
         svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
         gzipped_svg = gzip.compress(svg_content)
-        
+
         processed_content, mime_type = get_processed_content_and_mime(gzipped_svg)
         self.assertEqual(processed_content, svg_content)
         self.assertEqual(mime_type, "image/svg+xml")
@@ -159,7 +159,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
     def test_get_processed_content_and_mime_html(self):
         """Test get_processed_content_and_mime with HTML content."""
         html_content = b"<html><body><h1>Test Page</h1></body></html>"
-        
+
         processed_content, mime_type = get_processed_content_and_mime(html_content)
         self.assertEqual(processed_content, html_content)
         self.assertEqual(mime_type, "text/html")

--- a/indexer/tests/test_enhanced_mime_detection.py
+++ b/indexer/tests/test_enhanced_mime_detection.py
@@ -93,7 +93,7 @@ class TestEnhancedMimeDetection(unittest.TestCase):
 
     def test_is_svg_content_not_svg(self):
         """Test non-SVG content is not detected as SVG."""
-        html_content = b'<html><body><div>Not SVG</div></body></html>'
+        html_content = b"<html><body><div>Not SVG</div></body></html>"
         self.assertFalse(is_svg_content(html_content))
 
     def test_is_svg_content_svg_tag_without_attributes(self):

--- a/indexer/tests/test_enhanced_mime_detection.py
+++ b/indexer/tests/test_enhanced_mime_detection.py
@@ -1,6 +1,13 @@
+import gzip
 import unittest
 
-from index_core.enhanced_mime_detection import enhanced_mime_detection, is_legitimate_html
+from index_core.enhanced_mime_detection import (
+    detect_and_decompress_svg,
+    enhanced_mime_detection,
+    get_processed_content_and_mime,
+    is_legitimate_html,
+    is_svg_content,
+)
 
 
 class TestEnhancedMimeDetection(unittest.TestCase):
@@ -69,11 +76,112 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         uppercase_html = b"<HTML><BODY>content</BODY></HTML>"
         self.assertTrue(is_legitimate_html(uppercase_html))
 
+    def test_is_svg_content_valid_svg(self):
+        """Test SVG content detection with valid SVG."""
+        svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
+        self.assertTrue(is_svg_content(svg_content))
+
+    def test_is_svg_content_minimal_svg(self):
+        """Test SVG content detection with minimal SVG."""
+        minimal_svg = b'<svg viewBox="0 0 10 10"></svg>'
+        self.assertTrue(is_svg_content(minimal_svg))
+
+    def test_is_svg_content_svg_with_xmlns(self):
+        """Test SVG content detection with xmlns only."""
+        svg_xmlns = b'<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
+        self.assertTrue(is_svg_content(svg_xmlns))
+
+    def test_is_svg_content_not_svg(self):
+        """Test non-SVG content is not detected as SVG."""
+        html_content = b'<html><body><div>Not SVG</div></body></html>'
+        self.assertFalse(is_svg_content(html_content))
+
+    def test_is_svg_content_svg_tag_without_attributes(self):
+        """Test SVG tag without xmlns or viewBox is not detected as SVG."""
+        invalid_svg = b'<svg><circle cx="50" cy="50" r="40"/></svg>'
+        self.assertFalse(is_svg_content(invalid_svg))
+
+    def test_detect_and_decompress_svg_plain_svg(self):
+        """Test plain SVG content detection."""
+        svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
+        content, is_svg, mime_type = detect_and_decompress_svg(svg_content)
+        self.assertEqual(content, svg_content)
+        self.assertTrue(is_svg)
+        self.assertEqual(mime_type, "image/svg+xml")
+
+    def test_detect_and_decompress_svg_gzipped_svg(self):
+        """Test gzipped SVG content detection and decompression."""
+        svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
+        gzipped_svg = gzip.compress(svg_content)
+        
+        content, is_svg, mime_type = detect_and_decompress_svg(gzipped_svg)
+        self.assertEqual(content, svg_content)
+        self.assertTrue(is_svg)
+        self.assertEqual(mime_type, "image/svg+xml")
+
+    def test_detect_and_decompress_svg_gzipped_non_svg(self):
+        """Test gzipped non-SVG content."""
+        text_content = b"This is just plain text, not SVG"
+        gzipped_text = gzip.compress(text_content)
+        
+        content, is_svg, mime_type = detect_and_decompress_svg(gzipped_text)
+        self.assertEqual(content, gzipped_text)  # Returns original gzipped content
+        self.assertFalse(is_svg)
+        self.assertNotEqual(mime_type, "image/svg+xml")
+
+    def test_detect_and_decompress_svg_non_gzipped_non_svg(self):
+        """Test non-gzipped, non-SVG content."""
+        text_content = b"This is just plain text"
+        
+        content, is_svg, mime_type = detect_and_decompress_svg(text_content)
+        self.assertEqual(content, text_content)
+        self.assertFalse(is_svg)
+        self.assertNotEqual(mime_type, "image/svg+xml")
+
+    def test_detect_and_decompress_svg_corrupted_gzip(self):
+        """Test corrupted gzip data handling."""
+        corrupted_gzip = b"\x1f\x8b\x08\x00corrupted_data"
+        
+        content, is_svg, mime_type = detect_and_decompress_svg(corrupted_gzip)
+        self.assertEqual(content, corrupted_gzip)
+        self.assertFalse(is_svg)
+        self.assertNotEqual(mime_type, "image/svg+xml")
+
+    def test_get_processed_content_and_mime_svg(self):
+        """Test get_processed_content_and_mime with SVG content."""
+        svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
+        gzipped_svg = gzip.compress(svg_content)
+        
+        processed_content, mime_type = get_processed_content_and_mime(gzipped_svg)
+        self.assertEqual(processed_content, svg_content)
+        self.assertEqual(mime_type, "image/svg+xml")
+
+    def test_get_processed_content_and_mime_html(self):
+        """Test get_processed_content_and_mime with HTML content."""
+        html_content = b"<html><body><h1>Test Page</h1></body></html>"
+        
+        processed_content, mime_type = get_processed_content_and_mime(html_content)
+        self.assertEqual(processed_content, html_content)
+        self.assertEqual(mime_type, "text/html")
+
     def test_enhanced_mime_detection_html(self):
         """Test enhanced detection returns text/html for legitimate HTML."""
         valid_html = b"<html><body><h1>Test Page</h1></body></html>"
         result = enhanced_mime_detection(valid_html)
         self.assertEqual(result, "text/html")
+
+    def test_enhanced_mime_detection_svg(self):
+        """Test enhanced detection returns image/svg+xml for SVG content."""
+        svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
+        result = enhanced_mime_detection(svg_content)
+        self.assertEqual(result, "image/svg+xml")
+
+    def test_enhanced_mime_detection_gzipped_svg(self):
+        """Test enhanced detection returns image/svg+xml for gzipped SVG."""
+        svg_content = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
+        gzipped_svg = gzip.compress(svg_content)
+        result = enhanced_mime_detection(gzipped_svg)
+        self.assertEqual(result, "image/svg+xml")
 
     def test_enhanced_mime_detection_fallback_to_magic(self):
         """Test fallback to magic detection for non-HTML content."""

--- a/indexer/tests/test_enhanced_mime_detection.py
+++ b/indexer/tests/test_enhanced_mime_detection.py
@@ -5,8 +5,10 @@ from index_core.enhanced_mime_detection import (
     detect_and_decompress_svg,
     enhanced_mime_detection,
     get_processed_content_and_mime,
+    is_gzip,
     is_legitimate_html,
     is_svg_content,
+    try_decompress,
 )
 
 
@@ -212,6 +214,39 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         # The exact behavior depends on the magic library implementation
         result = enhanced_mime_detection(b"test content")
         self.assertIsInstance(result, str)
+
+    def test_is_gzip_valid_gzip_header(self):
+        """Test is_gzip detects valid gzip header."""
+        self.assertTrue(is_gzip(b"\x1f\x8b\x08\x00\x00\x00\x00\x00"))
+
+    def test_is_gzip_invalid_gzip_header(self):
+        """Test is_gzip rejects invalid headers."""
+        self.assertFalse(is_gzip(b"not gzipped"))
+        self.assertFalse(is_gzip(b"\x1f\x8c"))  # Wrong second byte
+        self.assertFalse(is_gzip(b""))  # Empty
+        self.assertFalse(is_gzip(b"\x1f"))  # Too short
+
+    def test_try_decompress_valid_gzip(self):
+        """Test try_decompress with valid gzip data."""
+        original = b"Hello, World!"
+        compressed = gzip.compress(original)
+        result = try_decompress(compressed)
+        self.assertEqual(result, original)
+
+    def test_try_decompress_invalid_gzip(self):
+        """Test try_decompress with invalid gzip data."""
+        self.assertIsNone(try_decompress(b"not gzipped"))
+        self.assertIsNone(try_decompress(b"\x1f\x8b\x08\x00corrupted"))
+
+    def test_is_svg_content_with_large_content(self):
+        """Test is_svg_content only checks prefix for performance."""
+        # Create large SVG content
+        large_svg = b'<svg xmlns="http://www.w3.org/2000/svg">' + b"x" * 10000 + b"</svg>"
+        self.assertTrue(is_svg_content(large_svg))
+
+        # SVG markers after 512 bytes should not be detected
+        late_svg = b"x" * 600 + b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+        self.assertFalse(is_svg_content(late_svg))
 
 
 if __name__ == "__main__":

--- a/indexer/tests/test_enhanced_mime_detection.py
+++ b/indexer/tests/test_enhanced_mime_detection.py
@@ -216,8 +216,10 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         self.assertIsInstance(result, str)
 
     def test_is_gzip_valid_gzip_header(self):
-        """Test is_gzip detects valid gzip header."""
+        """Test is_gzip detects valid gzip header with DEFLATE compression method."""
         self.assertTrue(is_gzip(b"\x1f\x8b\x08\x00\x00\x00\x00\x00"))
+        # Also test with just minimum required bytes
+        self.assertTrue(is_gzip(b"\x1f\x8b\x08"))
 
     def test_is_gzip_invalid_gzip_header(self):
         """Test is_gzip rejects invalid headers."""
@@ -225,6 +227,8 @@ class TestEnhancedMimeDetection(unittest.TestCase):
         self.assertFalse(is_gzip(b"\x1f\x8c"))  # Wrong second byte
         self.assertFalse(is_gzip(b""))  # Empty
         self.assertFalse(is_gzip(b"\x1f"))  # Too short
+        self.assertFalse(is_gzip(b"\x1f\x8b"))  # Too short (missing compression method)
+        self.assertFalse(is_gzip(b"\x1f\x8b\x00"))  # Wrong compression method (not DEFLATE)
 
     def test_try_decompress_valid_gzip(self):
         """Test try_decompress with valid gzip data."""


### PR DESCRIPTION
- Add automatic detection and decompression of gzipped SVG files (svgz format)
- Implement robust SVG content detection with xmlns/viewBox validation
- Update StampData to store decompressed content for gzipped files
- Add comprehensive test coverage for SVG and gzip handling
- Handle corrupted gzip files gracefully with fallback to original content
- Set proper file suffix 'svg' for SVG content instead of 'svg+xml'

# PR #609 Update: Consensus-Preserving SVG Detection

## Summary of Changes

This update addresses the consensus concerns raised in the PR review by modifying the `detect_and_decompress_svg` function to preserve historical behavior while still improving SVG/SVGZ detection.

## Key Changes

1. **Preserved Historic Behavior**: The function now uses `magic.from_buffer()` FIRST to determine MIME type, maintaining the exact same detection logic as before for non-SVG gzipped content.

2. **Selective Decompression**: Only attempts decompression when magic explicitly identifies the content as gzip MIME types (`application/gzip` or `application/x-gzip`), preventing any unintended behavioral changes.

3. **Consensus Safety**: Returns original content unchanged for all non-SVG gzipped files, ensuring no stamps will be reclassified differently.

## Implementation Details

```python
def detect_and_decompress_svg(content_bytes):
    # Only decompress if it's likely to be SVG
    if is_svg_content(content_bytes):
        return content_bytes, True, "image/svg+xml"

    # Get magic MIME type first (preserves old behavior)
    try:
        magic_mime = magic.from_buffer(content_bytes, mime=True)
    except Exception:
        magic_mime = "application/octet-stream"

    # Only try decompression for explicit gzip MIME types
    if magic_mime in ("application/gzip", "application/x-gzip"):
        decompressed = try_decompress(content_bytes)
        if decompressed and is_svg_content(decompressed):
            return decompressed, True, "image/svg+xml"

    # Return original for all other cases (preserves consensus)
    return content_bytes, False, magic_mime
```

## Testing

All existing tests pass, confirming that:
- Plain SVG files are detected correctly
- SVGZ (gzipped SVG) files are detected and decompressed
- Gzipped non-SVG content returns unchanged (preserving consensus)
- Corrupted gzip data is handled gracefully

## Impact

This change ensures:
- No historical stamps will be reclassified
- No consensus disruption across different node versions
- Improved SVG/SVGZ detection for future stamps
- Maintains backward compatibility