### PR TITLE
test: trigger claude-review CI check [skip-version]

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -1,3 +1,5 @@
+"""Bitcoin Stamps Indexer configuration module."""
+
 import logging
 import os
 import re


### PR DESCRIPTION
## Summary
- Adds module docstring to `config.py`
- Test PR to verify claude-review works after migrating to `claude-code-action@v1` in #667

## Test plan
- [ ] Verify `claude-review` CI check passes (no more "version 1.0.67 needs update" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)