### PR TITLE
feat: activate SRC-101 P2WSH/OLGA encoding at block 940000

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -359,7 +359,7 @@ CP_SRC721_GENESIS_BLOCK: int = 792370  # block height of first SRC-721
 
 BTC_SRC101_GENESIS_BLOCK: int = 870652  # block height of first SRC-101
 BTC_SRC101_IMG_OPTIONAL_BLOCK: int = 872200
-BTC_SRC101_OLGA_BLOCK: int = 0
+BTC_SRC101_OLGA_BLOCK: int = 940000  # P2WSH/OLGA encoding for SRC-101 (~March 2026)
 
 CP_SRC20_END_BLOCK: int = 796000  # The last SRC-20 on CP  - We IGNORE ALL SRC-20 on counterparty AFTER THIS BLOCK
 CP_BMN_FEAT_BLOCK_START: int = 815130  # BMN audio file support


### PR DESCRIPTION
## Summary

- Set `BTC_SRC101_OLGA_BLOCK` from `0` (disabled) to `940000` (~March 2026, ~1 month from current tip 935809)
- Enables P2WSH/OLGA encoding for SRC-101 transactions at the specified block height

## What this activates

The P2WSH data collection pipeline already works for SRC-101 (active since block 865000). The only gated piece is the `destination_nvalue` extraction from `vout[0].nValue` in `transaction_utils.py:501`:

```python
if config.BTC_SRC101_OLGA_BLOCK != 0 and block_index >= config.BTC_SRC101_OLGA_BLOCK:
    src_destination_nvalue = ctx.vout[0].nValue
```

Without this activation, P2WSH SRC-101 transactions get `destination_nvalue = 0`, which causes **IRV (Invalid Recipient Value)** failures in `src101.py:560` and `src101.py:816` where `destination_nvalue` is validated against `needValue`.

**Before block 940000:** SRC-101 continues to work via MULTISIG encoding only
**After block 940000:** SRC-101 can use both MULTISIG and P2WSH/OLGA encoding

## Block height rationale

| Metric | Value |
|--------|-------|
| Current tip | 935,809 |
| Blocks per day | ~144 |
| Target lead time | ~1 month (30 days) |
| Activation block | **940,000** |
| Estimated date | ~March 2026 |

## Test plan

- [x] Verify lint passes
- [x] Verify existing SRC-101 tests still pass (no behavioral change before block 940000)
- [x] No reindexing required — this only affects future blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)