### PR TITLE
fix: correct bump2version canary restore for main→dev merges [skip-version]

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: write
     env:
       GIT_USER_NAME: GitHub Action
       GIT_USER_EMAIL: action@github.com
@@ -176,6 +177,27 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ github.ref == 'refs/heads/dev' }}
+
+      - name: Sync version back to dev
+        if: env.SKIP == 'false' && env.NEW_VERSION && github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          # Check if a PR from main to dev already exists
+          EXISTING_PR=$(gh pr list --base dev --head main --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "PR #${EXISTING_PR} from main to dev already exists, skipping creation"
+          else
+            echo "Creating PR to sync v${NEW_VERSION} back to dev"
+            PR_URL=$(gh pr create \
+              --base dev \
+              --head main \
+              --title "chore: sync v${NEW_VERSION} to dev" \
+              --body "Automated version sync after release v${NEW_VERSION}. When merged, the workflow converts the version to canary format (\`${NEW_VERSION}+canary.1\`) for continued development.")
+            echo "Created PR: $PR_URL"
+            # Enable auto-merge so it merges once required checks pass
+            gh pr merge "$PR_URL" --merge --auto 2>/dev/null || echo "Auto-merge not available — merge manually to restore canary versioning on dev"
+          fi
 
   manual-versioning:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -133,9 +133,15 @@ jobs:
       - name: Handle PR merge to dev
         if: env.SKIP == 'false' && github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == 'dev'
         run: |
-          # If merging from main to dev, convert to canary
+          # If merging from main to dev, convert production version to canary format
           if [[ "${{ github.head_ref }}" == "main" ]]; then
-            bump2version release --new-version canary --verbose --allow-dirty
+            CURRENT_VERSION=$(cat VERSION)
+            if [[ "$CURRENT_VERSION" != *"+canary"* ]]; then
+              # Convert production version (e.g., 1.9.0) to canary (1.9.0+canary.1)
+              CANARY_VERSION="${CURRENT_VERSION}+canary.1"
+              echo "Converting ${CURRENT_VERSION} to canary: ${CANARY_VERSION}"
+              bump2version --new-version "${CANARY_VERSION}" --verbose --allow-dirty release
+            fi
             printf 'NEW_VERSION=%s\n' "$(cat VERSION)" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
## Summary

Two fixes to the `bump-version.yml` workflow for the release cycle:

1. **Fix canary restore on main→dev merge** — the previous `bump2version` command was broken
2. **Auto-create main→dev sync PR after release** — seamless version restore without manual intervention

## Fix 1: Canary version restore

**The bug:**
```bash
# Old (broken) — "canary" is not a valid full version string
bump2version release --new-version canary --verbose --allow-dirty
```

**The fix:**
```bash
# New — constructs the full canary version string
CURRENT_VERSION=$(cat VERSION)  # e.g., 1.9.0
CANARY_VERSION="${CURRENT_VERSION}+canary.1"
bump2version --new-version "${CANARY_VERSION}" --verbose --allow-dirty release
```

This correctly updates all 4 tracked files: `VERSION`, `.bumpversion.cfg`, `pyproject.toml`, `config.py`.

## Fix 2: Auto-create sync PR

After a release is created on main, the workflow now automatically:
1. Creates a PR from main→dev titled `chore: sync v1.9.0 to dev`
2. Attempts to enable auto-merge (merges once required checks pass)
3. Falls back gracefully if auto-merge is not available in the repo

Uses `secrets.PAT` via `GH_TOKEN` and checks for existing PRs to avoid duplicates.

## Complete automated release flow

```
1. Merge dev→main (PR #495)
   → Workflow: strip canary → [minor] bump → 1.9.0
   → Push to main + create GitHub Release
   → Auto-create PR: main→dev (with auto-merge)

2. main→dev PR merges (automatic or manual)
   → Workflow: reads VERSION = 1.9.0
   → Converts to 1.9.0+canary.1
   → Pushes to dev

3. Subsequent dev pushes
   → Build number increments: 1.9.0+canary.2, .3, etc.
```

## Test plan

- [ ] CI passes on this PR
- [ ] After merging PR #495 (dev→main), verify:
  - [ ] Release v1.9.0 created on GitHub
  - [ ] main→dev sync PR auto-created
  - [ ] After sync PR merge, dev VERSION = `1.9.0+canary.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)