### PR TITLE
fix: improve CP node connection error and rate limit logging [skip-version]

### DIFF
--- a/indexer/src/index_core/fetch_utils.py
+++ b/indexer/src/index_core/fetch_utils.py
@@ -613,7 +613,9 @@ async def fetch_xcp_async(
                                 error_text = await response.text()
 
                                 # Verbose logging for all non-200 responses to help with debugging
-                                if response.status == 503:
+                                if response.status == 429:
+                                    logger.warning(f"⏳ Node {node['name']} returned 429 (Too Many Requests) for {endpoint}")
+                                elif response.status == 503:
                                     logger.warning(
                                         f"⏳ Node {node['name']} returned 503 (Service Unavailable) for {endpoint}\n"
                                         f"   URL: {url}\n"
@@ -656,6 +658,12 @@ async def fetch_xcp_async(
                 health_tracker = node_health_tracker.get(node["name"])
                 if health_tracker:
                     health_tracker.mark_failure(f"ServerDisconnectedError: {sde}")
+                endpoint_circuit_breakers.record_failure(node["name"])
+            except aiohttp.ClientConnectorError as cce:
+                logger.warning(f"Connection failed to {node['name']} for {url}: {cce}")
+                health_tracker = node_health_tracker.get(node["name"])
+                if health_tracker:
+                    health_tracker.mark_failure(f"ClientConnectorError: {cce}")
                 endpoint_circuit_breakers.record_failure(node["name"])
             except Exception as inner_get_exc:
                 logger.error(


### PR DESCRIPTION
## Summary

- Add dedicated `ClientConnectorError` handler for node connection failures (WARNING, no stack trace)
- Add dedicated HTTP 429 handler for rate limiting (clean one-line warning)

## Problem

Connection refused errors (e.g., node is down) fell into the generic `except Exception` handler, producing ERROR-level logs with full stack traces for expected scenarios:

```
[ERROR] Exception during session.get for http://fakefull.art:4000/...
Traceback (most recent call last):
  ... 20+ lines of stack trace ...
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host...
```

429 (Too Many Requests) responses logged the raw HTML body:
```
[WARNING] Error response from public: <!doctype html><meta charset="utf-8">...429 Too Many Requests
```

## Fix

**Connection errors** — new `aiohttp.ClientConnectorError` handler at the same level as the existing `TimeoutError` and `ServerDisconnectedError` handlers:
```
[WARNING] Connection failed to fakefull for /v2/blocks/935840/transactions: Cannot connect to host...
```

**Rate limiting** — new HTTP 429 handler with clean output:
```
[WARNING] ⏳ Node public returned 429 (Too Many Requests) for /v2/blocks/...
```

## Additional note

The `.env` file (gitignored) should also remove unavailable nodes from `CP_NODE_POOL`. With only 2 nodes configured (local + public), round-robin is disabled (`len(nodes) > 2` check), so the indexer uses local as primary and public as fallback only — reducing 429s from the public API.

## Test plan

- [x] CI passes
- [x] Verify connection failures log at WARNING without stack traces
- [x] Verify 429 responses show clean one-line warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)