### PR TITLE
fix: connection leak in _store_source_data causing Too many connections

### DIFF
--- a/indexer/src/index_core/market_data_jobs.py
+++ b/indexer/src/index_core/market_data_jobs.py
@@ -483,7 +483,7 @@ class MarketDataJobScheduler:
 
                                 # Store source tracking data for effectiveness analysis
                                 source_data = {"openstamp": market_data}
-                                src20_worker._store_source_data(tick, source_data)
+                                src20_worker._store_source_data(tick, source_data, db=task_db)
 
                                 processed_count += 1
 
@@ -569,7 +569,7 @@ class MarketDataJobScheduler:
                                 market_data_service.update_src20_market_data(tick, aggregated_data, task_db)
 
                                 # Store source tracking data for effectiveness analysis
-                                src20_worker._store_source_data(tick, source_data)
+                                src20_worker._store_source_data(tick, source_data, db=task_db)
 
                                 processed_count += 1
 

--- a/indexer/src/index_core/src20_worker.py
+++ b/indexer/src/index_core/src20_worker.py
@@ -1308,19 +1308,21 @@ class SRC20Worker:
             logger.error(f"Error aggregating multi-source data for {tick}: {e}")
             return None
 
-    def _store_source_data(self, tick: str, source_data: Dict[str, Dict]) -> None:
+    def _store_source_data(self, tick: str, source_data: Dict[str, Dict], db=None) -> None:
         """
         Store individual source data in market_data_sources table for transparency.
 
         Args:
             tick: SRC-20 token ticker
             source_data: Dictionary mapping source names to their data
+            db: Optional database connection to reuse (avoids opening new connections)
         """
+        owns_connection = db is None
         try:
             from index_core.database import insert_market_data_source
 
-            # Get database connection
-            db = self.processor.db_manager.get_long_running_connection()
+            if owns_connection:
+                db = self.processor.db_manager.connect()
 
             for source, data in source_data.items():
                 # Calculate source confidence based on data quality
@@ -1350,10 +1352,14 @@ class SRC20Worker:
                 except Exception as e:
                     logger.warning(f"Failed to store source data for {tick} from {source}: {e}")
 
-            db.close()
-
         except Exception as e:
             logger.error(f"Error storing source data for {tick}: {e}")
+        finally:
+            if owns_connection and db is not None:
+                try:
+                    db.close()
+                except Exception:
+                    pass
 
     def _calculate_source_confidence(self, source: str, data: Dict) -> float:
         """

--- a/indexer/tests/test_market_data_source_tracking.py
+++ b/indexer/tests/test_market_data_source_tracking.py
@@ -479,7 +479,7 @@ class TestSourceDataIntegration:
 
         with patch("index_core.database.insert_market_data_source") as mock_insert:
             # Mock database connection
-            with patch.object(worker.processor.db_manager, "get_long_running_connection") as mock_get_db:
+            with patch.object(worker.processor.db_manager, "connect") as mock_get_db:
                 mock_get_db.return_value = self.mock_db
 
                 worker._store_source_data("STAMP", source_data)


### PR DESCRIPTION
## Summary
- **Root cause**: `SRC20Worker._store_source_data()` called `get_long_running_connection()` per token (~150+ tokens), opening a new DB connection each time. These connections accumulated because: (1) on error, `db.close()` was skipped (no `finally` block), and (2) `market_data_jobs.py` calls it in two loops (OpenStamp pass + multi-source pass), doubling the leak rate.
- **Fix**: Add optional `db` parameter to `_store_source_data()`. Callers in `market_data_jobs.py` now pass their existing `task_db`. When called standalone (from `src20_worker.py`), uses `connect()` with proper `finally` cleanup.

## Files Changed
| File | Change |
|------|--------|
| `src20_worker.py` | `_store_source_data()` accepts optional `db`, uses `connect()` with `finally` cleanup |
| `market_data_jobs.py` | Pass `task_db` to both `_store_source_data()` call sites |
| `test_market_data_source_tracking.py` | Update mock from `get_long_running_connection` to `connect` |

## Test plan
- [x] `poetry run lint --auto-fix` passes
- [x] `poetry run pytest tests/ -v -k "src20_worker or market_data"` — 131 pass, 0 fail
- [ ] Monitor production logs for absence of `(1040, Too many connections)` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)