### PR TITLE
docs: fix whitepaper SIP accuracy, add SIP-0008, update roadmap

### DIFF
--- a/docs/whitepaper/future.md
+++ b/docs/whitepaper/future.md
@@ -21,19 +21,28 @@ This roadmap prioritizes **backward compatibility**, **security-first design**, 
 ### 9.1.1 Timeline (2026-2028)
 
 ```
-2026 Q2: SIP-0005 Binary Data Format
-    ↓ (40-60% cost reduction for stamp creation)
+Phase 1 — Foundation (2026 Q2):
+  SIP-0005 Binary Transfer Format (40-60% cost reduction)
+  SIP-0001 Conditional Transfers / HTLC (escrows, atomic swaps)
+  SIP-0008 Dual Transaction Parsing (combined stamp + SRC-20 ops)
 
-2026 Q3: SIP-0003 Cross-Chain Bridges (testnet)
-    ↓ (Lightning Network, Liquid Network integration)
+Phase 2 — Core Trading (2026 Q3):
+  SIP-0006 Native SRC-20 AMM (on-chain liquidity pools)
+    ↓ Gating: SIP-0001 live for 2000+ blocks
 
-2027 Q1: SIP-0001 Conditional Transfers
-    ↓ (Escrows, time-locked transfers, atomic swaps)
+Phase 3 — Cross-Chain (2026 Q3-Q4):
+  SIP-0003 Cross-Chain Bridges (testnet → limited mainnet)
+    ↓ Gating: SIP-0006 Phase 1 stable for 1000+ blocks
 
-2027 Q2-Q4: SIP-0004 Privacy Enhancements (phased rollout)
+Phase 4 — Wrapped Assets (2027 Q1-Q2):
+  SIP-0007 Wrapped Asset Standard (wBTC/wUSDT mint/burn)
+    ↓ Gating: SIP-0003 bridge operational + security audit
+
+Phase 5 — Privacy (independent track):
+  SIP-0004 Privacy Enhancements (phased rollout)
     ↓ (Confidential amounts → Stealth addresses → Full privacy)
 
-2028: Advanced research (zk-SNARKs, DLC integration, rollups)
+2028+: Advanced research (zk-SNARKs, DLC integration, rollups)
 ```
 
 ### 9.1.2 Design Principles for Future Development

--- a/docs/whitepaper/improvement-proposals.md
+++ b/docs/whitepaper/improvement-proposals.md
@@ -365,45 +365,6 @@ Example (0.3% fee tier):
 
 **Activation Timeline**: TBD pending community review and Phase 1 implementation.
 
-### 6.2.6 SIP-0008: Dual Transaction Parsing — Combined SRC-20 Transfer + Stamp Issuance
-
-**GitHub Issue**: [#692](https://github.com/stampchain-io/btc_stamps/issues/692) (originated from [#554](https://github.com/stampchain-io/btc_stamps/issues/554))
-
-**Author**: DerpHerpenstein
-
-**Status**: Draft
-
-**Phase**: 1 (Foundation) | **Estimated Effort**: 2-3 weeks
-
-**Motivation**: Currently, a single Bitcoin transaction can only perform one stamp operation — either issue a new stamp OR execute an SRC-20 transfer. Users who want to do both must create two separate transactions, paying double the fees. SIP-0008 enables a single transaction to contain both a stamp issuance and an SRC-20 transfer, reducing costs and enabling new composable workflows.
-
-**Technical Design**:
-
-The indexer currently processes each transaction for a single stamp operation. SIP-0008 extends the transaction parser to detect and process multiple stamp payloads within a single transaction:
-
-```
-Transaction outputs:
-  Output 0: SRC-20 transfer payload (bare multisig or P2WSH)
-  Output 1: Stamp image data (bare multisig or P2WSH)
-  Output 2: Change output
-```
-
-**Parsing Rules**:
-1. **Output scanning**: Indexer scans all outputs for stamp-compatible payloads
-2. **Payload classification**: Each payload classified as SRC-20 operation or stamp issuance based on content type detection
-3. **Ordered execution**: SRC-20 transfers processed before stamp issuance (deterministic ordering)
-4. **Atomic processing**: Both operations succeed or both fail — no partial execution
-5. **Backward compatibility**: Single-operation transactions continue to work unchanged
-
-**Soft Dependency**: SIP-0005 (Binary Transfer Format) — binary encoding makes dual payloads more size-efficient, but SIP-0008 works with JSON encoding as well.
-
-**Use Cases**:
-- **Mint-and-transfer**: Create a stamp and immediately send SRC-20 tokens in one transaction
-- **Composable workflows**: Agent-driven pipelines that batch stamp operations for efficiency
-- **Fee optimization**: Single transaction fee instead of two for combined operations
-
-**Activation Timeline**: TBD pending community review and Phase 1 implementation.
-
 ## 6.3 Superseded SIPs
 
 ### 6.3.1 SIP-0002: SRC-20 UTXO Binding & Transfer Format v2.0
@@ -571,7 +532,6 @@ Transaction outputs:
 | **0004** | Shielded SRC-20 — Privacy Extension | Draft | [#687](https://github.com/stampchain-io/btc_stamps/issues/687) | 2027+ (phased) |
 | **0005** | Binary Transfer Format for SRC-20 | Draft | [#688](https://github.com/stampchain-io/btc_stamps/issues/688) | TBD |
 | **0006** | Native SRC-20 AMM (Automated Market Maker) | Draft | [#689](https://github.com/stampchain-io/btc_stamps/issues/689) | TBD |
-| **0008** | Dual Transaction Parsing | Draft | [#692](https://github.com/stampchain-io/btc_stamps/issues/692) | TBD |
 
 ---
 

--- a/docs/whitepaper/improvement-proposals.md
+++ b/docs/whitepaper/improvement-proposals.md
@@ -365,6 +365,45 @@ Example (0.3% fee tier):
 
 **Activation Timeline**: TBD pending community review and Phase 1 implementation.
 
+### 6.2.6 SIP-0008: Dual Transaction Parsing — Combined SRC-20 Transfer + Stamp Issuance
+
+**GitHub Issue**: [#692](https://github.com/stampchain-io/btc_stamps/issues/692) (originated from [#554](https://github.com/stampchain-io/btc_stamps/issues/554))
+
+**Author**: DerpHerpenstein
+
+**Status**: Draft
+
+**Phase**: 1 (Foundation) | **Estimated Effort**: 2-3 weeks
+
+**Motivation**: Currently, a single Bitcoin transaction can only perform one stamp operation — either issue a new stamp OR execute an SRC-20 transfer. Users who want to do both must create two separate transactions, paying double the fees. SIP-0008 enables a single transaction to contain both a stamp issuance and an SRC-20 transfer, reducing costs and enabling new composable workflows.
+
+**Technical Design**:
+
+The indexer currently processes each transaction for a single stamp operation. SIP-0008 extends the transaction parser to detect and process multiple stamp payloads within a single transaction:
+
+```
+Transaction outputs:
+  Output 0: SRC-20 transfer payload (bare multisig or P2WSH)
+  Output 1: Stamp image data (bare multisig or P2WSH)
+  Output 2: Change output
+```
+
+**Parsing Rules**:
+1. **Output scanning**: Indexer scans all outputs for stamp-compatible payloads
+2. **Payload classification**: Each payload classified as SRC-20 operation or stamp issuance based on content type detection
+3. **Ordered execution**: SRC-20 transfers processed before stamp issuance (deterministic ordering)
+4. **Atomic processing**: Both operations succeed or both fail — no partial execution
+5. **Backward compatibility**: Single-operation transactions continue to work unchanged
+
+**Soft Dependency**: SIP-0005 (Binary Transfer Format) — binary encoding makes dual payloads more size-efficient, but SIP-0008 works with JSON encoding as well.
+
+**Use Cases**:
+- **Mint-and-transfer**: Create a stamp and immediately send SRC-20 tokens in one transaction
+- **Composable workflows**: Agent-driven pipelines that batch stamp operations for efficiency
+- **Fee optimization**: Single transaction fee instead of two for combined operations
+
+**Activation Timeline**: TBD pending community review and Phase 1 implementation.
+
 ## 6.3 Superseded SIPs
 
 ### 6.3.1 SIP-0002: SRC-20 UTXO Binding & Transfer Format v2.0
@@ -532,6 +571,7 @@ Example (0.3% fee tier):
 | **0004** | Shielded SRC-20 — Privacy Extension | Draft | [#687](https://github.com/stampchain-io/btc_stamps/issues/687) | 2027+ (phased) |
 | **0005** | Binary Transfer Format for SRC-20 | Draft | [#688](https://github.com/stampchain-io/btc_stamps/issues/688) | TBD |
 | **0006** | Native SRC-20 AMM (Automated Market Maker) | Draft | [#689](https://github.com/stampchain-io/btc_stamps/issues/689) | TBD |
+| **0008** | Dual Transaction Parsing | Draft | [#692](https://github.com/stampchain-io/btc_stamps/issues/692) | TBD |
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to PR #690 (merged). Fixes accuracy issues found in post-merge audit:

- **Corrected SIP descriptions**: SIP-0001 (HTLC), SIP-0002 (UTXO Binding/superseded), SIP-0005 (44-byte binary format) — previous descriptions were fabricated by an agent without access to actual specs
- **Added SIP-0006**: Native SRC-20 AMM section (was missing entirely)
- **Added SIP-0008**: Dual Transaction Parsing by DerpHerpenstein (issue #692)
- **Updated future.md timeline**: Complete phased roadmap with all 7 active SIPs and gating criteria between phases
- **Updated summary table**: Now includes all SIPs through SIP-0008

## Files Changed
- `docs/whitepaper/improvement-proposals.md` — Corrected SIP specs, added SIP-0006, SIP-0008
- `docs/whitepaper/future.md` — Updated timeline with all phases and gating criteria
- `docs/whitepaper/index.md` — Updated reference range to "SIP-0001 through SIP-0008"

## Test plan
- [x] All SIP titles match sip-registry.yaml canonical data
- [x] SIP-0002 correctly marked superseded
- [x] SIP-0008 present in both section content and summary table
- [x] Timeline includes all 5 phases with gating criteria

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>