### PR TITLE
fix: truncate raw HTML error responses in log output

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -621,7 +621,7 @@ def notify_api_cache_invalidation(block_height: int, block_hash: str) -> None:
         if response.status_code == 200:
             logger.info(f"✅ API cache invalidated for block {block_height}")
         else:
-            logger.warning(f"API cache invalidation returned status {response.status_code}: {response.text}")
+            logger.warning(f"API cache invalidation returned status {response.status_code}: {response.text[:200]}")
     except requests.exceptions.Timeout:
         logger.warning(f"API cache invalidation webhook timed out for block {block_height}")
     except requests.exceptions.SSLError as e:

--- a/indexer/src/index_core/fetch_utils.py
+++ b/indexer/src/index_core/fetch_utils.py
@@ -629,6 +629,8 @@ async def fetch_xcp_async(
                                 return data
                             else:
                                 error_text = await response.text()
+                                # Truncate to avoid dumping raw HTML error pages into logs
+                                error_preview = error_text[:200] if error_text else ""
 
                                 # Verbose logging for all non-200 responses to help with debugging
                                 if response.status == 429:
@@ -639,7 +641,7 @@ async def fetch_xcp_async(
                                         f"⏳ Node {node['name']} returned 503 (Service Unavailable) for {endpoint}\n"
                                         f"   URL: {url}\n"
                                         f"   Params: {params}\n"
-                                        f"   Response: {error_text}\n"
+                                        f"   Response: {error_preview}\n"
                                         f"   This typically means Counterparty is still catching up to this block"
                                     )
                                 else:
@@ -648,12 +650,12 @@ async def fetch_xcp_async(
                                         f"❌ Node {node['name']} returned HTTP {response.status} for {endpoint}\n"
                                         f"   URL: {url}\n"
                                         f"   Params: {params}\n"
-                                        f"   Response: {error_text}"
+                                        f"   Response: {error_preview}"
                                     )
 
                                 health_tracker = node_health_tracker.get(node["name"])
                                 if health_tracker:
-                                    health_tracker.mark_failure(f"HTTP {response.status}: {error_text}")
+                                    health_tracker.mark_failure(f"HTTP {response.status}: {error_preview}")
                                 endpoint_circuit_breakers.record_failure(node["name"])
 
                 except RuntimeError as re:
@@ -826,8 +828,9 @@ def fetch_xcp(
                     health_tracker.mark_success()
                 return data
             else:
-                error_body = response.text
-                logger.warning(f"Error response from {node['name']}: {error_body}")
+                # Truncate to avoid dumping raw HTML error pages into logs
+                error_body = response.text[:200] if response.text else ""
+                logger.warning(f"Error response from {node['name']}: HTTP {response.status_code}: {error_body}")
                 last_error = f"HTTP {response.status_code}: {error_body}"
                 # Mark node failure
                 health_tracker = node_health_tracker.get(node["name"])

--- a/indexer/src/index_core/openstamp_client.py
+++ b/indexer/src/index_core/openstamp_client.py
@@ -95,7 +95,9 @@ class OpenStampClient:
             response = self.session.get(url, timeout=DEFAULT_TIMEOUT)
 
             if response.status_code != 200:
-                raise OpenStampApiError(f"OpenStamp API request failed with status {response.status_code}: {response.text}")
+                # Truncate response body to avoid dumping raw HTML error pages into logs
+                body_preview = response.text[:200] if response.text else ""
+                raise OpenStampApiError(f"OpenStamp API request failed with status {response.status_code}: {body_preview}")
 
             response_data = response.json()
 


### PR DESCRIPTION
## Summary
- API error responses (especially 429 Too Many Requests from CDN/proxy servers) return full HTML pages that pollute log output and make it unreadable
- Truncates response bodies to 200 chars in all error logging paths:
  - `openstamp_client.py`: Exception message included full `response.text` HTML body
  - `fetch_utils.py`: Async XCP fetch logged full error body for 503 and other errors; sync fallback logged full error body
  - `blocks.py`: Webhook cache invalidation logged full response body

## Test plan
- [x] All 58 market data / openstamp tests pass
- [x] 905/906 full suite pass (1 pre-existing flaky test)
- [x] flake8 clean
- [x] black formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)