### PR TITLE
feat: add node_version_history table for frontend version queries

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -557,6 +557,8 @@ def update_version_globals(version_string: str):
 update_version_globals(VERSION_STRING)
 
 
+VERSION_CHECK_INTERVAL = int(os.environ.get("VERSION_CHECK_INTERVAL", "300"))  # 5 min default
+
 BTC_NAME = "Bitcoin"
 STAMPS_NAME = "btc_stamps"
 APP_NAME = STAMPS_NAME.lower()

--- a/indexer/src/index_core/backend.py
+++ b/indexer/src/index_core/backend.py
@@ -397,6 +397,14 @@ class Backend:
         self.blockcount_cache.invalidate("current")
         self.last_blockcount_time = 0
 
+    def getnetworkinfo(self) -> Optional[Dict]:
+        """Fetch Bitcoin Core network info including version."""
+        try:
+            return self.rpc("getnetworkinfo", [])
+        except Exception as e:
+            logger.warning(f"Failed to fetch getnetworkinfo: {e}")
+            return None
+
     def getblockhash(self, blockcount):
         return self.rpc("getblockhash", [blockcount])
 

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -817,6 +817,7 @@ def follow(
     # Initialize scheduler flag early to avoid UnboundLocalError in cleanup
     market_data_scheduler_started = False
     first_block_processed = False  # Track if we've processed at least one block
+    last_version_check_time = 0  # Track last version persistence time
 
     def handle_shutdown():
         """Callback for shutdown notification"""
@@ -1047,6 +1048,17 @@ def follow(
                             logger.info(f"Market data job scheduler started with {max_workers} workers")
                         except Exception as e:
                             logger.warning(f"Failed to start market data scheduler: {e}")
+
+                # Periodically persist node/indexer versions
+                if first_block_processed and time.time() - last_version_check_time >= config.VERSION_CHECK_INTERVAL:
+                    try:
+                        from index_core.node_health import persist_all_versions
+
+                        persist_all_versions()
+                        last_version_check_time = time.time()
+                    except Exception as e:
+                        logger.warning(f"Failed to persist node versions: {e}")
+                        last_version_check_time = time.time()  # Don't retry immediately on failure
 
                 # If we're close to the tip, increase the sleep interval to reduce load
                 pause_interval = config.BACKEND_POLL_INTERVAL

--- a/indexer/src/index_core/check.py
+++ b/indexer/src/index_core/check.py
@@ -433,6 +433,14 @@ def cp_version(log_connection=False):
     # Return the first successful connection for backward compatibility
     for result in version_results:
         if result["status"] == "connected":
+            # Persist all component versions to DB on startup
+            try:
+                from index_core.node_health import persist_all_versions
+
+                persist_all_versions()
+            except Exception as e:
+                logger.warning(f"Failed to persist node versions on startup: {e}")
+
             return result["version_string"], result["version_info"]
 
     logger.warning("Could not determine Counterparty version: All node connections failed.")

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -2967,6 +2967,89 @@ def import_csv_data(cursor, csv_url, insert_query, is_url=False):
         raise
 
 
+def upsert_node_version(
+    db,
+    component_name: str,
+    version_string: str,
+    version_major: Optional[int] = None,
+    version_minor: Optional[int] = None,
+    version_revision: Optional[int] = None,
+    version_suffix: Optional[str] = None,
+    extra_info: Optional[Dict] = None,
+) -> bool:
+    """Upsert a component version into node_version_history.
+
+    Uses the nullable boolean pattern: is_current=TRUE for the active row
+    (unique per component), is_current=NULL for historical rows.
+
+    Returns True if a new version was inserted, False if unchanged.
+    """
+    cursor = db.cursor()
+    try:
+        cursor.execute(
+            "SELECT id, version_string FROM node_version_history " "WHERE component_name = %s AND is_current = TRUE",
+            (component_name,),
+        )
+        existing = cursor.fetchone()
+
+        if existing and existing[1] == version_string:
+            return False
+
+        if existing:
+            cursor.execute(
+                "UPDATE node_version_history SET is_current = NULL, superseded_at = NOW() " "WHERE id = %s",
+                (existing[0],),
+            )
+
+        extra_info_json = json.dumps(extra_info) if extra_info else None
+        cursor.execute(
+            "INSERT INTO node_version_history "
+            "(component_name, version_string, version_major, version_minor, "
+            "version_revision, version_suffix, extra_info, is_current) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, TRUE)",
+            (
+                component_name,
+                version_string,
+                version_major,
+                version_minor,
+                version_revision,
+                version_suffix,
+                extra_info_json,
+            ),
+        )
+        db.commit()
+        logger.info(f"Version updated for {component_name}: {version_string}")
+        return True
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        cursor.close()
+
+
+def get_current_versions(db) -> List[Dict]:
+    """Get all current component versions for frontend API use."""
+    cursor = db.cursor()
+    try:
+        cursor.execute(
+            "SELECT component_name, version_string, version_major, version_minor, "
+            "version_revision, version_suffix, extra_info, detected_at "
+            "FROM node_version_history WHERE is_current = TRUE "
+            "ORDER BY component_name"
+        )
+        columns = [desc[0] for desc in cursor.description]
+        rows = cursor.fetchall()
+        results = []
+        for row in rows:
+            row_dict = dict(zip(columns, row))
+            if row_dict.get("extra_info") and isinstance(row_dict["extra_info"], str):
+                row_dict["extra_info"] = json.loads(row_dict["extra_info"])
+            results.append(row_dict)
+        return results
+    finally:
+        cursor.close()
+
+
 def initialize_tables(db):
     """Initialize database tables from schema file."""
     try:
@@ -2995,6 +3078,7 @@ def initialize_tables(db):
             "src101price",
             "src20_token_stats",
             "stamp_views",
+            "node_version_history",
         ]
 
         # Only include market data tables if the scheduler is enabled

--- a/indexer/src/index_core/node_health.py
+++ b/indexer/src/index_core/node_health.py
@@ -852,3 +852,124 @@ def get_next_healthy_node_round_robin():
         # All nodes appear unhealthy
         logger.error("Round-robin: All nodes appear unhealthy after checking")
         return None
+
+
+def persist_counterparty_versions():
+    """Persist current Counterparty node versions to DB."""
+    from index_core.database import upsert_node_version
+    from index_core.database_manager import DatabaseManager
+    from index_core.fetch_utils import fetch_node_version_v2
+
+    db_manager = DatabaseManager()
+    db = db_manager.connect()
+    try:
+        for node in config.NODES:
+            node_name = node.get("name", "unknown")
+            node_url = node.get("url", "")
+            try:
+                version, version_info = fetch_node_version_v2(node_url)
+                if not version or not version_info:
+                    logger.debug(f"Could not fetch version for CP node {node_name}")
+                    continue
+
+                upsert_node_version(
+                    db,
+                    component_name=f"counterparty:{node_name}",
+                    version_string=version,
+                    version_major=version_info.get("version_major"),
+                    version_minor=version_info.get("version_minor"),
+                    version_revision=version_info.get("version_revision"),
+                    extra_info={
+                        "last_block": version_info.get("last_block"),
+                        "last_message_index": version_info.get("last_message_index"),
+                        "network": version_info.get("network"),
+                        "server_ready": version_info.get("server_ready"),
+                    },
+                )
+            except Exception as e:
+                logger.warning(f"Failed to persist version for CP node {node_name}: {e}")
+    finally:
+        db.close()
+
+
+def persist_bitcoin_core_version():
+    """Persist current Bitcoin Core version to DB."""
+    from index_core.database import upsert_node_version
+    from index_core.database_manager import DatabaseManager
+
+    network_info = Backend().getnetworkinfo()
+    if not network_info:
+        logger.debug("Could not fetch Bitcoin Core network info")
+        return
+
+    version_int = network_info.get("version", 0)
+    major = version_int // 10000
+    minor = (version_int % 10000) // 100
+    revision = version_int % 100
+    version_string = f"{major}.{minor}.{revision}"
+
+    db_manager = DatabaseManager()
+    db = db_manager.connect()
+    try:
+        upsert_node_version(
+            db,
+            component_name="bitcoin_core",
+            version_string=version_string,
+            version_major=major,
+            version_minor=minor,
+            version_revision=revision,
+            extra_info={
+                "subversion": network_info.get("subversion"),
+                "protocolversion": network_info.get("protocolversion"),
+                "connections": network_info.get("connections"),
+            },
+        )
+    finally:
+        db.close()
+
+
+def persist_indexer_version():
+    """Persist current indexer version to DB."""
+    import re
+
+    from index_core.database import upsert_node_version
+    from index_core.database_manager import DatabaseManager
+
+    version_string = config.VERSION_STRING
+    if not version_string:
+        return
+
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)(?:\+(.+))?", version_string)
+    if not match:
+        logger.warning(f"Could not parse indexer version: {version_string}")
+        return
+
+    major, minor, revision, suffix = int(match.group(1)), int(match.group(2)), int(match.group(3)), match.group(4)
+
+    db_manager = DatabaseManager()
+    db = db_manager.connect()
+    try:
+        upsert_node_version(
+            db,
+            component_name="stamps_indexer",
+            version_string=version_string,
+            version_major=major,
+            version_minor=minor,
+            version_revision=revision,
+            version_suffix=suffix,
+        )
+    finally:
+        db.close()
+
+
+def persist_all_versions():
+    """Persist all component versions. Each component is independent — one failure won't block others."""
+    for name, func in [
+        ("bitcoin_core", persist_bitcoin_core_version),
+        ("counterparty", persist_counterparty_versions),
+        ("stamps_indexer", persist_indexer_version),
+    ]:
+        try:
+            func()
+        except Exception as e:
+            logger.warning(f"Failed to persist {name} version: {e}")

--- a/indexer/table_schema.sql
+++ b/indexer/table_schema.sql
@@ -890,5 +890,32 @@ CREATE TABLE IF NOT EXISTS `sales_history_checkpoints` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Tracks progress of sales history processing';
 
 -- =====================================================================
+-- NODE VERSION TRACKING
+-- =====================================================================
+-- Tracks current and historical versions of system components
+-- (bitcoin_core, counterparty:local, counterparty:public, stamps_indexer)
+-- for frontend consumption. Uses nullable boolean pattern:
+-- is_current=TRUE for active row (unique per component), NULL for history.
+
+CREATE TABLE IF NOT EXISTS `node_version_history` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `component_name` VARCHAR(100) NOT NULL COMMENT 'e.g. bitcoin_core, counterparty:local, stamps_indexer',
+  `version_string` VARCHAR(100) NOT NULL COMMENT 'Human-readable version (e.g. 28.0.0, 11.0.3)',
+  `version_major` INT NULL,
+  `version_minor` INT NULL,
+  `version_revision` INT NULL,
+  `version_suffix` VARCHAR(50) NULL COMMENT 'e.g. canary.252, rc1',
+  `extra_info` JSON NULL COMMENT 'Component-specific metadata',
+  `is_current` BOOLEAN NULL DEFAULT TRUE COMMENT 'TRUE=active, NULL=historical (nullable for unique key pattern)',
+  `detected_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `superseded_at` TIMESTAMP NULL COMMENT 'When replaced by newer version',
+
+  UNIQUE KEY `unique_current_component` (`component_name`, `is_current`) COMMENT 'At most one current row per component',
+  INDEX `idx_component_history` (`component_name`, `detected_at` DESC),
+  INDEX `idx_current_versions` (`is_current`) COMMENT 'Fast lookup of all current versions'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Tracks current and historical versions of system components for frontend consumption';
+
+-- =====================================================================
 -- END OF SCHEMA
 -- =====================================================================

--- a/indexer/tests/test_node_version_tracking.py
+++ b/indexer/tests/test_node_version_tracking.py
@@ -244,18 +244,16 @@ class TestPersistBitcoinCoreVersion(unittest.TestCase):
     """Test persist_bitcoin_core_version() with mocked RPC."""
 
     @patch("index_core.database_manager.DatabaseManager")
-    @patch("index_core.backend.Backend")
-    def test_persist_bitcoin_core_version(self, mock_backend_cls, mock_db_mgr_cls):
+    @patch("index_core.backend.Backend.getnetworkinfo")
+    def test_persist_bitcoin_core_version(self, mock_getnetworkinfo, mock_db_mgr_cls):
         from index_core.node_health import persist_bitcoin_core_version
 
-        mock_backend = MagicMock()
-        mock_backend.getnetworkinfo.return_value = {
+        mock_getnetworkinfo.return_value = {
             "version": 280000,
             "subversion": "/Satoshi:28.0.0/",
             "protocolversion": 70016,
             "connections": 10,
         }
-        mock_backend_cls.return_value = mock_backend
 
         mock_db = MagicMock()
         mock_cursor = MagicMock()
@@ -275,13 +273,11 @@ class TestPersistBitcoinCoreVersion(unittest.TestCase):
         assert params[4] == 0  # revision
         mock_db.close.assert_called_once()
 
-    @patch("index_core.backend.Backend")
-    def test_skips_when_rpc_fails(self, mock_backend_cls):
+    @patch("index_core.backend.Backend.getnetworkinfo")
+    def test_skips_when_rpc_fails(self, mock_getnetworkinfo):
         from index_core.node_health import persist_bitcoin_core_version
 
-        mock_backend = MagicMock()
-        mock_backend.getnetworkinfo.return_value = None
-        mock_backend_cls.return_value = mock_backend
+        mock_getnetworkinfo.return_value = None
 
         # Should not raise
         persist_bitcoin_core_version()

--- a/indexer/tests/test_node_version_tracking.py
+++ b/indexer/tests/test_node_version_tracking.py
@@ -1,0 +1,377 @@
+"""
+Tests for node version tracking
+================================
+
+Tests for upsert_node_version(), get_current_versions(), version parsing,
+and persist_all_versions() orchestration.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestUpsertNodeVersion(unittest.TestCase):
+    """Test upsert_node_version() insert, skip, and version change behavior."""
+
+    def _make_mock_db(self, fetchone_return=None):
+        db = MagicMock()
+        cursor = MagicMock()
+        db.cursor.return_value = cursor
+        cursor.fetchone.return_value = fetchone_return
+        return db, cursor
+
+    def test_new_insert(self):
+        """First insert for a component should INSERT with is_current=TRUE."""
+        from index_core.database import upsert_node_version
+
+        db, cursor = self._make_mock_db(fetchone_return=None)
+
+        result = upsert_node_version(
+            db,
+            component_name="bitcoin_core",
+            version_string="28.0.0",
+            version_major=28,
+            version_minor=0,
+            version_revision=0,
+        )
+
+        assert result is True
+        # Should not UPDATE (no existing row)
+        calls = cursor.execute.call_args_list
+        assert len(calls) == 2  # SELECT + INSERT
+        assert "INSERT" in calls[1][0][0]
+        db.commit.assert_called_once()
+
+    def test_no_change_skip(self):
+        """Same version_string should return False and not write."""
+        from index_core.database import upsert_node_version
+
+        db, cursor = self._make_mock_db(fetchone_return=(42, "28.0.0"))
+
+        result = upsert_node_version(
+            db,
+            component_name="bitcoin_core",
+            version_string="28.0.0",
+        )
+
+        assert result is False
+        # Only the SELECT, no INSERT or UPDATE
+        calls = cursor.execute.call_args_list
+        assert len(calls) == 1
+        db.commit.assert_not_called()
+
+    def test_version_change_with_history(self):
+        """Different version should supersede the old row and insert new."""
+        from index_core.database import upsert_node_version
+
+        db, cursor = self._make_mock_db(fetchone_return=(42, "27.0.0"))
+
+        result = upsert_node_version(
+            db,
+            component_name="bitcoin_core",
+            version_string="28.0.0",
+            version_major=28,
+            version_minor=0,
+            version_revision=0,
+        )
+
+        assert result is True
+        calls = cursor.execute.call_args_list
+        assert len(calls) == 3  # SELECT + UPDATE old + INSERT new
+        # UPDATE should set is_current=NULL and superseded_at
+        update_sql = calls[1][0][0]
+        assert "is_current = NULL" in update_sql
+        assert "superseded_at" in update_sql
+        # INSERT should have is_current=TRUE
+        insert_sql = calls[2][0][0]
+        assert "INSERT" in insert_sql
+        db.commit.assert_called_once()
+
+    def test_extra_info_serialized_as_json(self):
+        """extra_info dict should be serialized to JSON string."""
+        from index_core.database import upsert_node_version
+
+        db, cursor = self._make_mock_db(fetchone_return=None)
+
+        extra = {"subversion": "/Satoshi:28.0.0/", "connections": 10}
+        upsert_node_version(
+            db,
+            component_name="bitcoin_core",
+            version_string="28.0.0",
+            extra_info=extra,
+        )
+
+        insert_call = cursor.execute.call_args_list[1]
+        params = insert_call[0][1]
+        # extra_info_json should be at index 6
+        assert json.loads(params[6]) == extra
+
+    def test_rollback_on_error(self):
+        """DB errors during insert should trigger rollback."""
+        from index_core.database import upsert_node_version
+
+        db, cursor = self._make_mock_db(fetchone_return=None)
+        # Make the INSERT fail
+        cursor.execute.side_effect = [None, Exception("DB error")]
+
+        with pytest.raises(Exception, match="DB error"):
+            upsert_node_version(
+                db,
+                component_name="bitcoin_core",
+                version_string="28.0.0",
+            )
+
+        db.rollback.assert_called_once()
+
+
+class TestGetCurrentVersions(unittest.TestCase):
+    """Test get_current_versions() returns correctly formatted data."""
+
+    def test_returns_formatted_rows(self):
+        from index_core.database import get_current_versions
+
+        db = MagicMock()
+        cursor = MagicMock()
+        db.cursor.return_value = cursor
+        cursor.description = [
+            ("component_name",),
+            ("version_string",),
+            ("version_major",),
+            ("version_minor",),
+            ("version_revision",),
+            ("version_suffix",),
+            ("extra_info",),
+            ("detected_at",),
+        ]
+        cursor.fetchall.return_value = [
+            ("bitcoin_core", "28.0.0", 28, 0, 0, None, '{"connections": 10}', "2025-01-01"),
+            ("stamps_indexer", "1.8.26+canary.252", 1, 8, 26, "canary.252", None, "2025-01-01"),
+        ]
+
+        results = get_current_versions(db)
+
+        assert len(results) == 2
+        assert results[0]["component_name"] == "bitcoin_core"
+        assert results[0]["extra_info"] == {"connections": 10}
+        assert results[1]["extra_info"] is None
+
+
+class TestBitcoinCoreVersionParsing(unittest.TestCase):
+    """Test Bitcoin Core version integer parsing (e.g. 280000 -> 28.0.0)."""
+
+    def test_standard_version(self):
+        """280000 should parse to 28.0.0."""
+        version_int = 280000
+        major = version_int // 10000
+        minor = (version_int % 10000) // 100
+        revision = version_int % 100
+        assert (major, minor, revision) == (28, 0, 0)
+
+    def test_version_with_minor_and_revision(self):
+        """250201 should parse to 25.2.1."""
+        version_int = 250201
+        major = version_int // 10000
+        minor = (version_int % 10000) // 100
+        revision = version_int % 100
+        assert (major, minor, revision) == (25, 2, 1)
+
+    def test_version_270100(self):
+        """270100 should parse to 27.1.0."""
+        version_int = 270100
+        major = version_int // 10000
+        minor = (version_int % 10000) // 100
+        revision = version_int % 100
+        assert (major, minor, revision) == (27, 1, 0)
+
+
+class TestIndexerVersionParsing(unittest.TestCase):
+    """Test indexer semver+suffix parsing."""
+
+    def test_version_with_suffix(self):
+        import re
+
+        version_string = "1.8.26+canary.252"
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)(?:\+(.+))?", version_string)
+        assert match is not None
+        assert (int(match.group(1)), int(match.group(2)), int(match.group(3))) == (1, 8, 26)
+        assert match.group(4) == "canary.252"
+
+    def test_version_without_suffix(self):
+        import re
+
+        version_string = "2.0.0"
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)(?:\+(.+))?", version_string)
+        assert match is not None
+        assert (int(match.group(1)), int(match.group(2)), int(match.group(3))) == (2, 0, 0)
+        assert match.group(4) is None
+
+
+class TestPersistAllVersions(unittest.TestCase):
+    """Test persist_all_versions() orchestration."""
+
+    @patch("index_core.node_health.persist_indexer_version")
+    @patch("index_core.node_health.persist_bitcoin_core_version")
+    @patch("index_core.node_health.persist_counterparty_versions")
+    def test_calls_all_persist_functions(self, mock_cp, mock_btc, mock_idx):
+        from index_core.node_health import persist_all_versions
+
+        persist_all_versions()
+
+        mock_btc.assert_called_once()
+        mock_cp.assert_called_once()
+        mock_idx.assert_called_once()
+
+    @patch("index_core.node_health.persist_indexer_version")
+    @patch("index_core.node_health.persist_bitcoin_core_version")
+    @patch("index_core.node_health.persist_counterparty_versions")
+    def test_one_failure_doesnt_block_others(self, mock_cp, mock_btc, mock_idx):
+        """If bitcoin_core persistence fails, counterparty and indexer should still run."""
+        from index_core.node_health import persist_all_versions
+
+        mock_btc.side_effect = Exception("RPC down")
+
+        persist_all_versions()
+
+        mock_btc.assert_called_once()
+        mock_cp.assert_called_once()
+        mock_idx.assert_called_once()
+
+
+class TestPersistBitcoinCoreVersion(unittest.TestCase):
+    """Test persist_bitcoin_core_version() with mocked RPC."""
+
+    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.backend.Backend")
+    def test_persist_bitcoin_core_version(self, mock_backend_cls, mock_db_mgr_cls):
+        from index_core.node_health import persist_bitcoin_core_version
+
+        mock_backend = MagicMock()
+        mock_backend.getnetworkinfo.return_value = {
+            "version": 280000,
+            "subversion": "/Satoshi:28.0.0/",
+            "protocolversion": 70016,
+            "connections": 10,
+        }
+        mock_backend_cls.return_value = mock_backend
+
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = None  # No existing row
+        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+
+        persist_bitcoin_core_version()
+
+        # Verify INSERT was called with correct version
+        insert_call = mock_cursor.execute.call_args_list[1]
+        params = insert_call[0][1]
+        assert params[0] == "bitcoin_core"
+        assert params[1] == "28.0.0"
+        assert params[2] == 28  # major
+        assert params[3] == 0  # minor
+        assert params[4] == 0  # revision
+        mock_db.close.assert_called_once()
+
+    @patch("index_core.backend.Backend")
+    def test_skips_when_rpc_fails(self, mock_backend_cls):
+        from index_core.node_health import persist_bitcoin_core_version
+
+        mock_backend = MagicMock()
+        mock_backend.getnetworkinfo.return_value = None
+        mock_backend_cls.return_value = mock_backend
+
+        # Should not raise
+        persist_bitcoin_core_version()
+
+
+class TestPersistIndexerVersion(unittest.TestCase):
+    """Test persist_indexer_version() with mocked config."""
+
+    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.node_health.config")
+    def test_persist_indexer_version(self, mock_config, mock_db_mgr_cls):
+        from index_core.node_health import persist_indexer_version
+
+        mock_config.VERSION_STRING = "1.8.26+canary.252"
+
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = None
+        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+
+        persist_indexer_version()
+
+        insert_call = mock_cursor.execute.call_args_list[1]
+        params = insert_call[0][1]
+        assert params[0] == "stamps_indexer"
+        assert params[1] == "1.8.26+canary.252"
+        assert params[2] == 1  # major
+        assert params[3] == 8  # minor
+        assert params[4] == 26  # revision
+        assert params[5] == "canary.252"  # suffix
+        mock_db.close.assert_called_once()
+
+
+class TestPersistCounterpartyVersions(unittest.TestCase):
+    """Test persist_counterparty_versions() with mocked fetch."""
+
+    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.fetch_utils.fetch_node_version_v2")
+    @patch("index_core.node_health.config")
+    def test_persist_counterparty_versions(self, mock_config, mock_fetch, mock_db_mgr_cls):
+        from index_core.node_health import persist_counterparty_versions
+
+        mock_config.NODES = [
+            {"name": "local", "url": "http://localhost:4000/v2"},
+        ]
+
+        mock_fetch.return_value = (
+            "11.0.3",
+            {
+                "version_major": 11,
+                "version_minor": 0,
+                "version_revision": 3,
+                "last_block": 850000,
+                "last_message_index": 12345,
+                "network": "mainnet",
+                "server_ready": True,
+            },
+        )
+
+        mock_db = MagicMock()
+        mock_cursor = MagicMock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = None
+        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+
+        persist_counterparty_versions()
+
+        insert_call = mock_cursor.execute.call_args_list[1]
+        params = insert_call[0][1]
+        assert params[0] == "counterparty:local"
+        assert params[1] == "11.0.3"
+        mock_db.close.assert_called_once()
+
+    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.fetch_utils.fetch_node_version_v2")
+    @patch("index_core.node_health.config")
+    def test_skips_node_when_fetch_fails(self, mock_config, mock_fetch, mock_db_mgr_cls):
+        from index_core.node_health import persist_counterparty_versions
+
+        mock_config.NODES = [
+            {"name": "local", "url": "http://localhost:4000/v2"},
+        ]
+        mock_fetch.return_value = (None, None)
+
+        mock_db = MagicMock()
+        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+
+        persist_counterparty_versions()
+
+        # No cursor operations beyond the connection
+        mock_db.cursor.assert_not_called()
+        mock_db.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds `node_version_history` DB table to track Bitcoin Core, Counterparty node, and indexer versions for frontend API consumption
- Versions are persisted on startup and re-checked every 5 minutes (configurable via `VERSION_CHECK_INTERVAL`)
- Uses nullable boolean pattern (`is_current=TRUE` for active, `NULL` for historical) to maintain full upgrade history per component
- New `getnetworkinfo()` RPC method on `Backend` class fetches Bitcoin Core version
- Each component persists independently so one failure doesn't block others

## Components tracked
| `component_name` | Source |
|---|---|
| `bitcoin_core` | `getnetworkinfo` RPC (version int → semver) |
| `counterparty:local` | `fetch_node_version_v2()` per configured CP node |
| `counterparty:public` | `fetch_node_version_v2()` per configured CP node |
| `stamps_indexer` | `config.VERSION_STRING` |

## Files changed
- `table_schema.sql` — new `node_version_history` DDL
- `src/config.py` — `VERSION_CHECK_INTERVAL` constant
- `src/index_core/backend.py` — `getnetworkinfo()` RPC method
- `src/index_core/database.py` — `upsert_node_version()`, `get_current_versions()`, table registration
- `src/index_core/node_health.py` — `persist_*_version()` functions and `persist_all_versions()` orchestrator
- `src/index_core/check.py` — startup hook after `cp_version()`
- `src/index_core/blocks.py` — periodic re-check in `follow()` loop
- `tests/test_node_version_tracking.py` — 18 unit tests

## Frontend query
```sql
SELECT component_name, version_string, extra_info, detected_at
FROM node_version_history WHERE is_current = TRUE ORDER BY component_name;
```

## Test plan
- [x] `poetry run pytest tests/test_node_version_tracking.py -v` — 18/18 passing
- [x] `poetry run lint` — all linters pass (isort, black, flake8, mypy, bandit)
- [x] Verified on live DB after indexer restart — all 4 components populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)