### PR TITLE
fix: resolve multiple memory leaks in DB connections and thread management

### DIFF
--- a/indexer/src/index_core/database_manager.py
+++ b/indexer/src/index_core/database_manager.py
@@ -311,6 +311,7 @@ class DatabaseManager:
         query_preview = query[:100] + "..." if len(query) > 100 else query
         logger.debug(f"Executing query with retry: {query_preview}")
         start_time = time.time()
+        retry_connection = None
 
         for attempt in range(self.max_retries):
             try:
@@ -326,12 +327,25 @@ class DatabaseManager:
                         f"Query execution failed (attempt {attempt + 1}) after {elapsed_time:.2f}s: {e}. Retrying..."
                     )
                     try:
+                        # Close the previous retry connection if we obtained one
+                        if retry_connection is not None:
+                            try:
+                                retry_connection.close()
+                            except Exception:
+                                pass
                         # Get a new connection from the pool
-                        connection = self.connect()
-                        cursor = connection.cursor()
+                        retry_connection = self.connect()
+                        cursor = retry_connection.cursor()
                     except Exception as conn_error:
                         logger.error(f"Failed to get new connection: {conn_error}")
                         raise
+
+        # Clean up the last retry connection if we never succeeded
+        if retry_connection is not None:
+            try:
+                retry_connection.close()
+            except Exception:
+                pass
 
         elapsed_time = time.time() - start_time
         if last_error:

--- a/indexer/src/index_core/monitoring_logger.py
+++ b/indexer/src/index_core/monitoring_logger.py
@@ -78,6 +78,7 @@ class MonitoringLogger:
         error_message: Optional[str],
     ):
         """Log API call data to database table for frontend queries."""
+        db = None
         try:
             db = self.db_manager.connect()
             with db.cursor() as cursor:
@@ -93,6 +94,9 @@ class MonitoringLogger:
         except Exception as e:
             # Don't let monitoring failures break the main flow
             logger.warning(f"Failed to log API call to database: {e}")
+        finally:
+            if db is not None:
+                db.close()
 
     def log_processing_metric(self, metric_name: str, value: Any, **context: Any):
         """Log processing metrics with structured format."""

--- a/indexer/src/index_core/node_health.py
+++ b/indexer/src/index_core/node_health.py
@@ -101,6 +101,7 @@ class NodeHealth:
         self.version_info: Optional[Dict] = None
         self._lock = threading.Lock()
         self.minor_failures = 0  # Track less severe failures separately
+        self._last_health_update_time = 0.0  # Cooldown for health update thread spawning
         # Add missing attributes
         self.last_success = 0.0
         self.total_successes = 0
@@ -221,16 +222,17 @@ class NodeHealth:
                     )
 
                     # Trigger immediate health update to ensure other components use backup nodes
+                    # Rate-limited to at most once per 30 seconds to prevent thread storms
                     if self.minor_failures >= 5:
-                        logger.warning(f"Node {self.name} has persistent issues, triggering health update")
-                        try:
-                            # Import here to avoid circular imports
-                            import threading
-
-                            # Update health in a separate thread to not block
-                            threading.Thread(target=update_healthy_nodes, daemon=True).start()
-                        except Exception as health_update_error:
-                            logger.error(f"Failed to trigger health update: {health_update_error}")
+                        now = time.time()
+                        if now - self._last_health_update_time >= 30:
+                            self._last_health_update_time = now
+                            logger.warning(f"Node {self.name} has persistent issues, triggering health update")
+                            try:
+                                # Update health in a separate thread to not block
+                                threading.Thread(target=update_healthy_nodes, daemon=True).start()
+                            except Exception as health_update_error:
+                                logger.error(f"Failed to trigger health update: {health_update_error}")
         except Exception as e:
             logger.error(f"Error in mark_failure for {self.name}: {e}")
         finally:
@@ -857,10 +859,9 @@ def get_next_healthy_node_round_robin():
 def persist_counterparty_versions():
     """Persist current Counterparty node versions to DB."""
     from index_core.database import upsert_node_version
-    from index_core.database_manager import DatabaseManager
+    from index_core.database_manager import db_manager
     from index_core.fetch_utils import fetch_node_version_v2
 
-    db_manager = DatabaseManager()
     db = db_manager.connect()
     try:
         for node in config.NODES:
@@ -895,7 +896,7 @@ def persist_counterparty_versions():
 def persist_bitcoin_core_version():
     """Persist current Bitcoin Core version to DB."""
     from index_core.database import upsert_node_version
-    from index_core.database_manager import DatabaseManager
+    from index_core.database_manager import db_manager
 
     network_info = Backend().getnetworkinfo()
     if not network_info:
@@ -908,7 +909,6 @@ def persist_bitcoin_core_version():
     revision = version_int % 100
     version_string = f"{major}.{minor}.{revision}"
 
-    db_manager = DatabaseManager()
     db = db_manager.connect()
     try:
         upsert_node_version(
@@ -933,7 +933,7 @@ def persist_indexer_version():
     import re
 
     from index_core.database import upsert_node_version
-    from index_core.database_manager import DatabaseManager
+    from index_core.database_manager import db_manager
 
     version_string = config.VERSION_STRING
     if not version_string:
@@ -946,7 +946,6 @@ def persist_indexer_version():
 
     major, minor, revision, suffix = int(match.group(1)), int(match.group(2)), int(match.group(3)), match.group(4)
 
-    db_manager = DatabaseManager()
     db = db_manager.connect()
     try:
         upsert_node_version(

--- a/indexer/tests/test_node_version_tracking.py
+++ b/indexer/tests/test_node_version_tracking.py
@@ -243,9 +243,9 @@ class TestPersistAllVersions(unittest.TestCase):
 class TestPersistBitcoinCoreVersion(unittest.TestCase):
     """Test persist_bitcoin_core_version() with mocked RPC."""
 
-    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.database_manager.db_manager")
     @patch("index_core.backend.Backend.getnetworkinfo")
-    def test_persist_bitcoin_core_version(self, mock_getnetworkinfo, mock_db_mgr_cls):
+    def test_persist_bitcoin_core_version(self, mock_getnetworkinfo, mock_db_mgr):
         from index_core.node_health import persist_bitcoin_core_version
 
         mock_getnetworkinfo.return_value = {
@@ -259,7 +259,7 @@ class TestPersistBitcoinCoreVersion(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_db.cursor.return_value = mock_cursor
         mock_cursor.fetchone.return_value = None  # No existing row
-        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+        mock_db_mgr.connect.return_value = mock_db
 
         persist_bitcoin_core_version()
 
@@ -286,9 +286,9 @@ class TestPersistBitcoinCoreVersion(unittest.TestCase):
 class TestPersistIndexerVersion(unittest.TestCase):
     """Test persist_indexer_version() with mocked config."""
 
-    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.database_manager.db_manager")
     @patch("index_core.node_health.config")
-    def test_persist_indexer_version(self, mock_config, mock_db_mgr_cls):
+    def test_persist_indexer_version(self, mock_config, mock_db_mgr):
         from index_core.node_health import persist_indexer_version
 
         mock_config.VERSION_STRING = "1.8.26+canary.252"
@@ -297,7 +297,7 @@ class TestPersistIndexerVersion(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_db.cursor.return_value = mock_cursor
         mock_cursor.fetchone.return_value = None
-        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+        mock_db_mgr.connect.return_value = mock_db
 
         persist_indexer_version()
 
@@ -315,10 +315,10 @@ class TestPersistIndexerVersion(unittest.TestCase):
 class TestPersistCounterpartyVersions(unittest.TestCase):
     """Test persist_counterparty_versions() with mocked fetch."""
 
-    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.database_manager.db_manager")
     @patch("index_core.fetch_utils.fetch_node_version_v2")
     @patch("index_core.node_health.config")
-    def test_persist_counterparty_versions(self, mock_config, mock_fetch, mock_db_mgr_cls):
+    def test_persist_counterparty_versions(self, mock_config, mock_fetch, mock_db_mgr):
         from index_core.node_health import persist_counterparty_versions
 
         mock_config.NODES = [
@@ -342,7 +342,7 @@ class TestPersistCounterpartyVersions(unittest.TestCase):
         mock_cursor = MagicMock()
         mock_db.cursor.return_value = mock_cursor
         mock_cursor.fetchone.return_value = None
-        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+        mock_db_mgr.connect.return_value = mock_db
 
         persist_counterparty_versions()
 
@@ -352,10 +352,10 @@ class TestPersistCounterpartyVersions(unittest.TestCase):
         assert params[1] == "11.0.3"
         mock_db.close.assert_called_once()
 
-    @patch("index_core.database_manager.DatabaseManager")
+    @patch("index_core.database_manager.db_manager")
     @patch("index_core.fetch_utils.fetch_node_version_v2")
     @patch("index_core.node_health.config")
-    def test_skips_node_when_fetch_fails(self, mock_config, mock_fetch, mock_db_mgr_cls):
+    def test_skips_node_when_fetch_fails(self, mock_config, mock_fetch, mock_db_mgr):
         from index_core.node_health import persist_counterparty_versions
 
         mock_config.NODES = [
@@ -364,7 +364,7 @@ class TestPersistCounterpartyVersions(unittest.TestCase):
         mock_fetch.return_value = (None, None)
 
         mock_db = MagicMock()
-        mock_db_mgr_cls.return_value.connect.return_value = mock_db
+        mock_db_mgr.connect.return_value = mock_db
 
         persist_counterparty_versions()
 


### PR DESCRIPTION
## Summary
- **MonitoringLogger**: Added missing `db.close()` in `_log_to_database()` — was leaking a pooled DB connection on every API call logged
- **execute_with_retry**: Track and properly close retry connections — was leaking a pooled connection per retry attempt
- **persist_* functions**: Use the existing global `db_manager` instead of creating throwaway `DatabaseManager()` instances (each with its own 3-10 connection pool) on every version check interval
- **mark_failure**: Rate-limit health update thread spawning to once per 30 seconds — was spawning unbounded daemon threads during sustained node failures

## Test plan
- [x] All 18 `test_node_version_tracking` tests pass (updated mocks for new `db_manager` import pattern)
- [x] Full lint suite passes (isort, black, flake8, mypy, bandit)
- [x] 1737 tests pass, 51 skipped, 1 pre-existing unrelated failure (`test_rollback_functionality`)
- [ ] Monitor memory usage after deploying to production indexer — verify connection pool and RSS stabilize over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)