### PR TITLE
fix: show target database in rollback confirmation prompt

### DIFF
--- a/indexer/tools/rollback_db.py
+++ b/indexer/tools/rollback_db.py
@@ -106,6 +106,12 @@ def main() -> None:
 
     # Safety confirmation unless --confirm is used
     if not args.confirm:
+        # Show which database will be affected
+        db_host = os.environ.get("RDS_HOSTNAME", "localhost")
+        db_name = os.environ.get("RDS_DATABASE", "btc_stamps")
+        db_port = os.environ.get("RDS_PORT", "3306")
+        print(f"📊 Target Database: {db_host}:{db_port}/{db_name}")
+        print()
         print(f"⚠️  WARNING: This will delete all data from block {args.block_index} onwards!")
         print("This includes:")
         print("  - All transactions and blocks")


### PR DESCRIPTION
## Summary
- Display the database host, port, and name before the rollback confirmation prompt so operators can verify they are rolling back the correct database (e.g., production RDS vs local dev)

## Test plan
- [ ] Run `poetry run rollback <block>` and verify the target database info is displayed before the confirmation prompt
- [ ] Verify correct values shown when `RDS_HOSTNAME` is set to RDS endpoint vs localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)