### PR TITLE
fix: use INSERT IGNORE for creator bootstrap to preserve user changes

### DIFF
--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -3139,9 +3139,8 @@ def initialize_tables(db):
             "creator.csv",
             config.BOOTSTRAP_CREATOR_CSV_URL,
             """
-            INSERT INTO creator (address, creator)
+            INSERT IGNORE INTO creator (address, creator)
             VALUES (%s, %s)
-            ON DUPLICATE KEY UPDATE creator = VALUES(creator)
             """,
         )
         import_bootstrap_data(


### PR DESCRIPTION
## Summary
- Change creator CSV bootstrap from `ON DUPLICATE KEY UPDATE` to `INSERT IGNORE` so that user-submitted creator name changes in the production database are not overwritten on indexer restart
- Bootstrap still seeds new entries from the CSV on first run or when new rows are added to the CSV
- Existing rows in the DB (including user modifications) are never touched

## Context
Users can now update creator-to-BTC-address mappings in the production database directly. The previous `ON DUPLICATE KEY UPDATE` behavior would silently revert those changes every time the indexer restarted and re-imported `bootstrap/creator.csv`.

## Test plan
- [x] Verified `INSERT IGNORE` works correctly on MySQL 8.0.42 / InnoDB (existing rows silently skipped, 0 affected rows)
- [ ] Restart indexer and confirm creator table is unchanged
- [ ] Add a test creator row to DB, restart indexer, confirm it survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)