### PR TITLE
fix: use SELECT FOR UPDATE in version upsert to prevent duplicate key error

### DIFF
--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -2981,7 +2981,8 @@ def upsert_node_version(
     cursor = db.cursor()
     try:
         cursor.execute(
-            "SELECT id, version_string FROM node_version_history " "WHERE component_name = %s AND is_current = TRUE",
+            "SELECT id, version_string FROM node_version_history "
+            "WHERE component_name = %s AND is_current = TRUE FOR UPDATE",
             (component_name,),
         )
         existing = cursor.fetchone()


### PR DESCRIPTION
## Summary
- Add `FOR UPDATE` to the SELECT in `upsert_node_version()` to prevent duplicate key errors under concurrent access

## Root Cause
MySQL `REPEATABLE-READ` isolation (the default) means each transaction reads a snapshot from when it started. When `persist_all_versions()` runs concurrently (e.g. startup in `check.py` overlapping with the periodic check in `follow()`), both transactions can SELECT the same existing row, both UPDATE it to `is_current=NULL`, and both try to INSERT a new row with `is_current=TRUE` — the second INSERT hits the unique constraint:

```
(1062, "Duplicate entry 'stamps_indexer-1' for key 'node_version_history.unique_current_component'")
```

## Fix
`SELECT ... FOR UPDATE` acquires a row-level lock and reads the latest committed state regardless of the transaction snapshot, serializing concurrent upserts for the same component.

## Test plan
- [ ] Restart indexer and verify no duplicate key errors in logs
- [ ] Verify `node_version_history` table still shows correct current versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)