### PR TITLE
fix: release FOR UPDATE lock on unchanged version to prevent lock wait timeout

### DIFF
--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -2988,6 +2988,7 @@ def upsert_node_version(
         existing = cursor.fetchone()
 
         if existing and existing[1] == version_string:
+            db.commit()  # Release the FOR UPDATE lock
             return False
 
         if existing:

--- a/indexer/tests/test_node_version_tracking.py
+++ b/indexer/tests/test_node_version_tracking.py
@@ -46,7 +46,7 @@ class TestUpsertNodeVersion(unittest.TestCase):
         db.commit.assert_called_once()
 
     def test_no_change_skip(self):
-        """Same version_string should return False and not write."""
+        """Same version_string should return False, not write, but commit to release FOR UPDATE lock."""
         from index_core.database import upsert_node_version
 
         db, cursor = self._make_mock_db(fetchone_return=(42, "28.0.0"))
@@ -61,7 +61,8 @@ class TestUpsertNodeVersion(unittest.TestCase):
         # Only the SELECT, no INSERT or UPDATE
         calls = cursor.execute.call_args_list
         assert len(calls) == 1
-        db.commit.assert_not_called()
+        # Must commit to release the FOR UPDATE lock on pooled connections
+        db.commit.assert_called_once()
 
     def test_version_change_with_history(self):
         """Different version should supersede the old row and insert new."""


### PR DESCRIPTION
## Summary
- Fixes `Lock wait timeout exceeded` errors (1205) in `upsert_node_version()` that occur during periodic version checks
- The `SELECT ... FOR UPDATE` acquires a row-level lock, but the early-return path (version unchanged) never committed, leaving the lock held on the idle pooled connection
- The next periodic check (5 min later) would block on the same row for 50s before timing out

## Root Cause
`autocommit=False` on pooled connections means `SELECT FOR UPDATE` locks persist until explicit `COMMIT`/`ROLLBACK`. The "version changed" path already commits (line 3015), but the "no change" path returned `False` without releasing the lock. Since `db.close()` returns the connection to the pool (not a real close), the lock was held indefinitely.

## Fix
Add `db.commit()` before the early return to release the FOR UPDATE lock when the version is unchanged.

## Test plan
- [ ] Deploy and verify no more `Lock wait timeout exceeded` warnings in logs for version persistence
- [ ] Confirm version records still update correctly when actual version changes occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)