### PR TITLE
fix: rollback CLI test mock + PyNaCl 1.6.2 security update

### DIFF
--- a/indexer/poetry.lock
+++ b/indexer/poetry.lock
@@ -1255,7 +1255,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" or implementation_name == \"pypy\"", dev = "platform_python_implementation != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" or implementation_name == \"pypy\"", arweave = "platform_python_implementation != \"PyPy\"", dev = "platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -3801,7 +3801,7 @@ files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\" or implementation_name == \"pypy\"", arweave = "implementation_name != \"PyPy\"", dev = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\" or implementation_name == \"pypy\"", arweave = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", dev = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pycryptodome"
@@ -4013,30 +4013,45 @@ rsa = ["cryptography"]
 
 [[package]]
 name = "pynacl"
-version = "1.5.0"
+version = "1.6.2"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["arweave"]
 files = [
-    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
-    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
-    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
+    {file = "pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14"},
+    {file = "pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444"},
+    {file = "pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b"},
+    {file = "pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145"},
+    {file = "pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590"},
+    {file = "pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2"},
+    {file = "pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6"},
+    {file = "pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e"},
+    {file = "pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577"},
+    {file = "pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa"},
+    {file = "pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0"},
+    {file = "pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c"},
+    {file = "pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c"},
 ]
 
 [package.dependencies]
-cffi = ">=1.4.1"
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\" and python_version >= \"3.9\""}
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
-tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
+docs = ["sphinx (<7)", "sphinx_rtd_theme"]
+tests = ["hypothesis (>=3.27.0)", "pytest (>=7.4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 
 [[package]]
 name = "pytest"
@@ -5383,4 +5398,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "ed7feb0727af2d8005295375618a47f8b48a0513096640836638160c80556dcb"
+content-hash = "e23353b5d9d8e47456d6ec1aecb70a14be17b6154bcb9532b21935cdfcaa7514"

--- a/indexer/pyproject.toml
+++ b/indexer/pyproject.toml
@@ -54,6 +54,7 @@ redis = "^6.2.0"
 
 [tool.poetry.group.arweave.dependencies]
 arweave-python-client = "1.0.19"
+pynacl = ">=1.6.2"
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.13.0"

--- a/indexer/src/index_core/aws.py
+++ b/indexer/src/index_core/aws.py
@@ -97,7 +97,8 @@ def update_s3_db_objects(db, filename, file_obj_md5):
 
         # Insert the new object
         cursor.execute(
-            "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) " "AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5",
+            "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) "
+            "AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5",
             (id, s3_file_path, file_obj_md5),
         )
 

--- a/indexer/tests/test_aws.py
+++ b/indexer/tests/test_aws.py
@@ -196,7 +196,8 @@ class TestAWSIntegration:
         cursor.executemany.assert_called_once()
         query, values = cursor.executemany.call_args[0]
         assert (
-            query == "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5"
+            query
+            == "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5"
         )
         # Sort values for comparison since dict ordering might vary
         assert sorted(values) == sorted(expected_values)

--- a/indexer/tests/test_rollback_functionality.py
+++ b/indexer/tests/test_rollback_functionality.py
@@ -173,8 +173,21 @@ def test_rollback_tool_command_line_interface():
             mock_args.force = False  # Explicitly set force to False
             mock_parse.return_value = mock_args
 
-            # Mock the perform_complete_rollback function
-            with patch("rollback_db.perform_complete_rollback") as mock_rollback:
+            # Mock safety-check dependencies so the force=False path works without a real DB
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = (900000,)
+            mock_conn = Mock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_db_manager = Mock()
+            mock_db_manager.connect.return_value = mock_conn
+
+            with (
+                patch("index_core.database_manager.DatabaseManager", return_value=mock_db_manager),
+                patch("rollback_db.validate_block_number"),
+                patch("rollback_db.validate_rollback_distance"),
+                patch("rollback_db.perform_complete_rollback") as mock_rollback,
+                patch("builtins.print"),
+            ):
                 main()
                 mock_rollback.assert_called_with(12000, force=False)
 

--- a/indexer/tests/test_rollback_functionality.py
+++ b/indexer/tests/test_rollback_functionality.py
@@ -96,12 +96,12 @@ def test_indexer_rollback_method_integration(temp_db, clean_singleton):
             mock_db_manager_class.return_value = mock_db_manager
 
             # Mock the actual rollback operations
-            with patch("src.index_core.database.purge_block_db") as mock_purge, patch(
-                "src.index_core.database.clear_all_caches"
-            ) as mock_clear_caches, patch("src.index_core.database.rebuild_balances") as mock_rebuild_balances, patch(
-                "src.index_core.database.rebuild_owners"
-            ) as mock_rebuild_owners, patch(
-                "src.index_core.backend.Backend"
+            with (
+                patch("src.index_core.database.purge_block_db") as mock_purge,
+                patch("src.index_core.database.clear_all_caches") as mock_clear_caches,
+                patch("src.index_core.database.rebuild_balances") as mock_rebuild_balances,
+                patch("src.index_core.database.rebuild_owners") as mock_rebuild_owners,
+                patch("src.index_core.backend.Backend"),
             ):
 
                 # Call the indexer's rollback method
@@ -128,12 +128,12 @@ def test_bitcoin_block_rollback_not_affected():
         mock_db_manager_class.return_value = mock_db_manager
 
         # Mock reorg detection and rollback
-        with patch("src.index_core.database.purge_block_db") as mock_purge, patch(
-            "src.index_core.database.clear_all_caches"
-        ) as mock_clear_caches, patch("src.index_core.database.rebuild_balances") as mock_rebuild_balances, patch(
-            "src.index_core.database.rebuild_owners"
-        ) as mock_rebuild_owners, patch(
-            "src.index_core.backend.Backend"
+        with (
+            patch("src.index_core.database.purge_block_db") as mock_purge,
+            patch("src.index_core.database.clear_all_caches") as mock_clear_caches,
+            patch("src.index_core.database.rebuild_balances") as mock_rebuild_balances,
+            patch("src.index_core.database.rebuild_owners") as mock_rebuild_owners,
+            patch("src.index_core.backend.Backend"),
         ):
 
             # Simulate a Bitcoin reorg requiring rollback to block 12000
@@ -254,9 +254,13 @@ def test_fallback_state_integration_with_rollback(temp_db, clean_singleton):
             mock_db_manager.connect.return_value = mock_conn
             mock_db_manager_class.return_value = mock_db_manager
 
-            with patch("src.index_core.database.purge_block_db"), patch("src.index_core.database.clear_all_caches"), patch(
-                "src.index_core.database.rebuild_balances"
-            ), patch("src.index_core.database.rebuild_owners"), patch("src.index_core.backend.Backend"):
+            with (
+                patch("src.index_core.database.purge_block_db"),
+                patch("src.index_core.database.clear_all_caches"),
+                patch("src.index_core.database.rebuild_balances"),
+                patch("src.index_core.database.rebuild_owners"),
+                patch("src.index_core.backend.Backend"),
+            ):
                 # Perform rollback to block before fallback started
                 perform_complete_rollback(12000)
 


### PR DESCRIPTION
## Summary
- **Fix failing test**: `test_rollback_tool_command_line_interface` failed because `force=False` triggers safety-check code that calls `DatabaseManager.connect()`, which returns `None` without a real DB. Added mocks for `DatabaseManager`, `validate_block_number`, and `validate_rollback_distance` so the test passes in isolation.
- **Dependabot #58 (PyNaCl)**: Bumped `pynacl` from 1.5.0 → 1.6.2 to fix CVE-2025-69277 (libsodium incomplete input validation). Added as direct dep in `[tool.poetry.group.arweave.dependencies]` to force the transitive upgrade.
- **Dependabot #42 (ecdsa)**: Dismissed as tolerable risk — we only use `VerifyingKey` (verification), not `sign_digest()` (signing), which is the only affected code path per CVE-2024-23342.

## Test plan
- [x] `poetry run pytest tests/test_rollback_functionality.py -v` — 6/6 passed
- [x] `poetry run pytest tests/ -q` — 1742 passed, 0 failed (was 1741 passed, 1 failed)
- [x] `poetry show pynacl` — confirmed 1.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)