### PR TITLE
fix: use CP issuer as creator instead of source (fee-payer)

### DIFF
--- a/indexer/src/index_core/aws.py
+++ b/indexer/src/index_core/aws.py
@@ -97,7 +97,8 @@ def update_s3_db_objects(db, filename, file_obj_md5):
 
         # Insert the new object
         cursor.execute(
-            "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) " "AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5",
+            "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) "
+            "AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5",
             (id, s3_file_path, file_obj_md5),
         )
 

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -126,6 +126,7 @@ class StampData:
     collection_onchain: Optional[bool] = None
     db: Optional[object] = None
     _lock: Optional[threading.Lock] = None
+    _cp_issuer: Optional[str] = None
 
     @staticmethod
     def check_custom_suffix(bytestring_data):
@@ -509,9 +510,12 @@ class StampData:
         self.locked = stamp.get("locked")
         self.divisible = stamp.get("divisible")
         self.message_index = stamp.get("message_index")
+        issuer = stamp.get("issuer")
+        if issuer:
+            self._cp_issuer = str(issuer)
 
     def update_stamp_hash_and_block_time(self):
-        self.creator = self.source
+        self.creator = self._cp_issuer if self._cp_issuer else self.source
         self.stamp_hash = create_base62_hash(self.tx_hash, str(self.block_index), 20)
         if isinstance(self.block_time, int):
             self.block_time = datetime.fromtimestamp(self.block_time, tz=timezone.utc)

--- a/indexer/tests/test_aws.py
+++ b/indexer/tests/test_aws.py
@@ -196,7 +196,8 @@ class TestAWSIntegration:
         cursor.executemany.assert_called_once()
         query, values = cursor.executemany.call_args[0]
         assert (
-            query == "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5"
+            query
+            == "INSERT INTO s3objects (id, path_key, md5) VALUES (%s, %s, %s) AS new_row ON DUPLICATE KEY UPDATE md5 = new_row.md5"
         )
         # Sort values for comparison since dict ordering might vary
         assert sorted(values) == sorted(expected_values)

--- a/indexer/tests/test_creator_fix.py
+++ b/indexer/tests/test_creator_fix.py
@@ -1,0 +1,134 @@
+"""Tests for creator field fix: use CP issuer instead of source (fee-payer)."""
+
+import json
+
+import pytest
+
+from index_core.models import StampData
+
+
+def make_stamp_data(**overrides):
+    """Helper to create a StampData with sensible defaults."""
+    defaults = dict(
+        tx_hash="abc123def456",
+        source="fee_payer_address",
+        prev_tx_hash="prev123",
+        destination="artist_address",
+        destination_nvalue=0,
+        btc_amount=0,
+        fee=1000,
+        data=json.dumps(
+            {
+                "cpid": "A1234567890",
+                "source": "fee_payer_address",
+                "issuer": "artist_address",
+                "quantity": 1,
+                "divisible": False,
+                "locked": True,
+                "description": "stamp:base64data",
+                "transfer": False,
+                "status": "valid",
+            }
+        ),
+        decoded_tx={},
+        keyburn=1,
+        tx_index=1,
+        block_index=800000,
+        block_time=1700000000,
+        is_op_return=False,
+        p2wsh_data=None,
+    )
+    defaults.update(overrides)
+    return StampData(**defaults)
+
+
+class TestCreatorFromIssuer:
+    """Test that creator is set from CP issuer, not source."""
+
+    def test_cp_stamp_creator_uses_issuer(self):
+        """For CP stamps, creator should be the issuer (artist), not the source (fee-payer)."""
+        stamp = make_stamp_data()
+        stamp_dict = json.loads(stamp.data)
+        stamp.update_stamp_data_rows_from_cp_asset(stamp_dict)
+        stamp.update_stamp_hash_and_block_time()
+        assert stamp.creator == "artist_address"
+        assert stamp.creator != "fee_payer_address"
+
+    def test_cp_stamp_same_source_and_issuer(self):
+        """When source == issuer (self-minted), creator should be correct."""
+        stamp = make_stamp_data(
+            source="artist_address",
+            data=json.dumps(
+                {
+                    "cpid": "A1234567890",
+                    "source": "artist_address",
+                    "issuer": "artist_address",
+                    "quantity": 1,
+                }
+            ),
+        )
+        stamp_dict = json.loads(stamp.data)
+        stamp.update_stamp_data_rows_from_cp_asset(stamp_dict)
+        stamp.update_stamp_hash_and_block_time()
+        assert stamp.creator == "artist_address"
+
+    def test_non_cp_stamp_creator_uses_source(self):
+        """For non-CP stamps (no issuer in data), creator should fall back to source."""
+        stamp = make_stamp_data(
+            data="raw_base64_data",
+        )
+        stamp.update_stamp_hash_and_block_time()
+        assert stamp.creator == "fee_payer_address"
+
+    def test_cp_stamp_data_without_issuer_key(self):
+        """Edge case: CP data dict without issuer key falls back to source."""
+        stamp = make_stamp_data(
+            data=json.dumps({"cpid": "A1234567890", "quantity": 1}),
+        )
+        stamp_dict = json.loads(stamp.data)
+        stamp.update_stamp_data_rows_from_cp_asset(stamp_dict)
+        stamp.update_stamp_hash_and_block_time()
+        assert stamp.creator == "fee_payer_address"
+
+    def test_list_stamp_type_not_dict(self):
+        """When stamp data is a list (JSON array), creator uses source."""
+        stamp = make_stamp_data()
+        stamp.update_stamp_data_rows_from_cp_asset([1, 2, 3])
+        stamp.update_stamp_hash_and_block_time()
+        assert stamp.creator == "fee_payer_address"
+
+    def test_fairmint_uses_asset_issuer(self):
+        """FAIRMINT stamps should use the asset issuer as creator."""
+        stamp = make_stamp_data(
+            source="minter_address",
+            data=json.dumps(
+                {
+                    "cpid": "A9999999999",
+                    "source": "minter_address",
+                    "issuer": "original_deployer_address",
+                    "event_type": "NEW_FAIRMINT",
+                    "quantity": 100,
+                }
+            ),
+        )
+        stamp_dict = json.loads(stamp.data)
+        stamp.update_stamp_data_rows_from_cp_asset(stamp_dict)
+        stamp.update_stamp_hash_and_block_time()
+        assert stamp.creator == "original_deployer_address"
+        assert stamp.creator != "minter_address"
+
+    def test_issuer_not_carried_across_instances(self):
+        """Ensure _cp_issuer doesn't leak between different StampData instances."""
+        stamp1 = make_stamp_data()
+        stamp1_dict = json.loads(stamp1.data)
+        stamp1.update_stamp_data_rows_from_cp_asset(stamp1_dict)
+        stamp1.update_stamp_hash_and_block_time()
+        assert stamp1.creator == "artist_address"
+
+        stamp2 = make_stamp_data(
+            source="another_source",
+            data="raw_data_no_json",
+        )
+        stamp2.update_stamp_hash_and_block_time()
+        assert stamp2.creator == "another_source"
+        assert stamp2._cp_issuer is None


### PR DESCRIPTION
## Summary

- The `creator` field in StampTableV4 was incorrectly populated from `source` (the transaction signer / fee-paying wallet) instead of the Counterparty `issuer` (the actual artist/creator)
- This caused ~5,166 stamps to display stampmint service wallet addresses as their creator
- The fix extracts the `issuer` from the CP issuance data and uses it for creator attribution
- Non-CP stamps (BTC stamps, SRC-20 OLGA) correctly fall back to `source` since they have no CP issuer field

## Changes

**`src/index_core/models.py`** (3 surgical changes):
1. Added `_cp_issuer` private field to `StampData` dataclass
2. Extract `issuer` from stamp dict in `update_stamp_data_rows_from_cp_asset()`
3. Changed `update_stamp_hash_and_block_time()` to use `_cp_issuer` when available, falling back to `source`

**`tests/test_creator_fix.py`** (new):
- 7 unit tests covering: CP stamps, self-minted stamps, non-CP fallback, missing issuer, list data, FAIRMINT, instance isolation

## Safety

- The periodic CP sync (`update_assets_in_db`) only updates `locked`/`divisible`/`supply` — never touches `creator`
- The reissue check (`is_reissue`) ensures only the first issuance is stored, so issuer is always from the original issuance
- Non-CP stamps are unaffected: `_cp_issuer` remains `None` when no valid dict with `issuer` key is parsed

## Note

A one-time backfill migration will be needed to fix existing stamps in the database. The `transactions` table already stores the correct issuer as `destination`, so the backfill is a single `UPDATE ... JOIN` — no CP API calls required. This will be run separately outside of this PR.

Related: https://github.com/stampchain-io/stampchain.io/issues/674

## Test plan

- [x] 7 new unit tests pass
- [x] Full test suite: 1748 passed, 0 new failures (1 pre-existing from #712)
- [x] Black formatting clean
- [ ] Run backfill migration on production DB (separate operation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)