### PR TITLE
fix: prevent canary tag collisions in version bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -141,7 +141,7 @@ jobs:
               # Convert production version (e.g., 1.9.0) to canary (1.9.0+canary.1)
               CANARY_VERSION="${CURRENT_VERSION}+canary.1"
               echo "Converting ${CURRENT_VERSION} to canary: ${CANARY_VERSION}"
-              bump2version --new-version "${CANARY_VERSION}" --verbose --allow-dirty release
+              bump2version --new-version "${CANARY_VERSION}" --no-tag --verbose --allow-dirty release
             fi
             printf 'NEW_VERSION=%s\n' "$(cat VERSION)" >> $GITHUB_ENV
           fi
@@ -150,8 +150,9 @@ jobs:
         if: env.SKIP == 'false' && github.ref == 'refs/heads/dev' && github.event_name == 'push'
         run: |
           # Only bump build number if already in canary format
+          # Use --no-tag to avoid tag collisions — canary tags are not consumed downstream
           if [[ "$(cat VERSION)" == *"+canary"* ]]; then
-            bump2version build --verbose --allow-dirty
+            bump2version build --no-tag --verbose --allow-dirty
             printf 'NEW_VERSION=%s\n' "$(cat VERSION)" >> $GITHUB_ENV
           fi
 
@@ -160,13 +161,16 @@ jobs:
         run: |
           if [ "$(git rev-parse HEAD)" != "${{ env.hash }}" ]; then
             git push origin HEAD:${{ github.ref }}
-            git push origin --tags
+            # Only push tags for production releases (main branch)
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              git push origin --tags
+            fi
           else
             echo "No new commit created, so no push."
           fi
 
       - name: Create Release
-        if: env.SKIP == 'false' && env.NEW_VERSION
+        if: env.SKIP == 'false' && env.NEW_VERSION && github.ref == 'refs/heads/main'
         id: create_release
         uses: softprops/action-gh-release@v1
         env:
@@ -176,7 +180,7 @@ jobs:
           name: Release ${{ env.NEW_VERSION }}
           generate_release_notes: true
           draft: false
-          prerelease: ${{ github.ref == 'refs/heads/dev' }}
+          prerelease: false
 
       - name: Sync version back to dev
         if: env.SKIP == 'false' && env.NEW_VERSION && github.event_name == 'pull_request' && github.base_ref == 'main'


### PR DESCRIPTION
## Summary
- Add `--no-tag` to `bump2version` calls for canary versions (dev push and main→dev sync) to prevent tag collision failures
- Restrict `git push --tags` and GitHub Release creation to production releases on `main` only
- Canary tags (250+ like `1.8.26+canary.1` through `1.8.26+canary.261`) are not consumed by any downstream workflow — Docker builds read from `pyproject.toml`, not git tags

## Context
PR #495 CI failed because tag `1.8.26+canary.262` already existed from a prior run, causing `bump2version` to error with `fatal: tag '1.8.26+canary.262' already exists`. The stale tag has been deleted to unblock #495.

## Changes
| Area | Before | After |
|------|--------|-------|
| Dev push bump | `bump2version build` (creates tag) | `bump2version build --no-tag` |
| Main→dev sync | `bump2version --new-version ... release` (creates tag) | `bump2version --new-version ... --no-tag ... release` |
| Tag pushing | Always `git push origin --tags` | Only on `refs/heads/main` |
| GitHub Release | Created for both dev (prerelease) and main | Only created for main (production) |

## Test plan
- [ ] Verify version bump workflow passes on dev push (no tag creation attempted)
- [ ] Verify production release flow still creates tags and GitHub Releases on PR merge to main
- [ ] Confirm canary version numbers still increment correctly in VERSION, pyproject.toml, and config.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)