### PR TITLE
fix: replace fatal exit with rollback-and-retry on reorg duplicate block

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -46,6 +46,7 @@ from index_core.database import (  # update_src20_token_stats,  # Now handled by
     insert_into_stamp_table,
     insert_transactions,
     is_prev_block_parsed,
+    log_reorg_event,
     next_tx_index,
     purge_block_db,
     rebuild_balances,
@@ -1376,7 +1377,7 @@ def follow(
                         logger.debug(f"Block {block_index} has no stamp issuances - this is normal")
 
                     # Check for orphan blocks
-                    if block_tip - block_index < 100 and not reparse_mode:
+                    if not reparse_mode:
                         requires_rollback = False
                         while True:
                             if block_index == config.BLOCK_FIRST:
@@ -1420,6 +1421,14 @@ def follow(
                                     error_message=f"Detected rollback loop at block {block_index}", block_index=block_index
                                 )
 
+                            log_reorg_event(
+                                db,
+                                block_index=block_index,
+                                old_block_hash=db_parent,
+                                new_block_hash=backend_parent,
+                                rollback_depth=0,
+                                detection_method="orphan_block_check",
+                            )
                             block_index = rollback_to_block(db, block_index, "Chain reorganization detected")
                             if cp_pipeline_instance:
                                 logger.info(f"Resetting CP pipeline after chain reorg to block {block_index}")
@@ -1517,9 +1526,31 @@ def follow(
                             difficulty,
                         )
                     except BlockAlreadyExistsError as e:
-                        logger.warning(e)
+                        logger.warning(f"Block {block_index} already exists - likely reorg. Initiating rollback. {e}")
                         db.rollback()
-                        sys.exit(f"Exiting due to block already existing. {e}")
+                        rollback_target = block_index - 1
+                        if check_rollback_loop(rollback_target):
+                            logger.error("Exiting due to rollback loop detection")
+                            handle_rollback_loop_failure(
+                                error_message=f"Detected rollback loop at block {rollback_target}",
+                                block_index=rollback_target,
+                            )
+                        log_reorg_event(
+                            db,
+                            block_index=block_index,
+                            old_block_hash=None,
+                            new_block_hash=block_hash,
+                            rollback_depth=0,
+                            detection_method="block_already_exists",
+                        )
+                        block_index = rollback_to_block(
+                            db, rollback_target, "Chain reorganization detected (block already exists)"
+                        )
+                        if cp_pipeline_instance:
+                            cp_pipeline_instance.reset(block_index)
+                        stamp_issuances_list = None
+                        time.sleep(10)
+                        continue
                     except DatabaseInsertError as e:
                         logger.error(e)
                         db.rollback()

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -3046,6 +3046,35 @@ def get_current_versions(db) -> List[Dict]:
         cursor.close()
 
 
+def log_reorg_event(
+    db: Connection,
+    block_index: int,
+    old_block_hash: Optional[str],
+    new_block_hash: Optional[str],
+    rollback_depth: int,
+    detection_method: str,
+) -> None:
+    """Log a blockchain reorganization event for observability."""
+    try:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            INSERT INTO reorg_events (block_index, old_block_hash, new_block_hash, rollback_depth, detection_method)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (block_index, old_block_hash, new_block_hash, rollback_depth, detection_method),
+        )
+        db.commit()
+        cursor.close()
+        logger.info(f"Logged reorg event at block {block_index} (method={detection_method})")
+    except Exception as e:
+        logger.warning(f"Failed to log reorg event (non-fatal): {e}")
+        try:
+            db.rollback()
+        except Exception:
+            pass
+
+
 def initialize_tables(db):
     """Initialize database tables from schema file."""
     try:
@@ -3075,6 +3104,7 @@ def initialize_tables(db):
             "src20_token_stats",
             "stamp_views",
             "node_version_history",
+            "reorg_events",
         ]
 
         # Only include market data tables if the scheduler is enabled

--- a/indexer/table_schema.sql
+++ b/indexer/table_schema.sql
@@ -917,5 +917,22 @@ CREATE TABLE IF NOT EXISTS `node_version_history` (
 COMMENT='Tracks current and historical versions of system components for frontend consumption';
 
 -- =====================================================================
+-- REORG EVENT TRACKING
+-- =====================================================================
+-- Tracks blockchain reorganization events for observability and debugging
+
+CREATE TABLE IF NOT EXISTS `reorg_events` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `detected_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `block_index` INT NOT NULL,
+  `old_block_hash` VARCHAR(64),
+  `new_block_hash` VARCHAR(64),
+  `rollback_depth` INT NOT NULL,
+  `detection_method` VARCHAR(64) NOT NULL COMMENT 'orphan_block_check or block_already_exists',
+  INDEX `idx_block_index` (`block_index`),
+  INDEX `idx_detected_at` (`detected_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_as_ci COMMENT='Tracks blockchain reorganization events for observability';
+
+-- =====================================================================
 -- END OF SCHEMA
 -- =====================================================================


### PR DESCRIPTION
## Summary

Fixes a production incident (April 15, 2026) where a 1-block Bitcoin reorg at block 945189 caused the indexer to hard-exit and stay down until manual intervention.

- **Replace `sys.exit()` with rollback-and-retry** in `BlockAlreadyExistsError` handler — now rolls back and continues like the existing orphan block handler instead of crashing
- **Remove 100-block proximity threshold** from reorg detection — ensures reorgs that happened while the indexer was down are caught during catch-up, not just when near the chain tip
- **Add `reorg_events` table** for observability — logs all detected reorg events with block index, hashes, and detection method

## Test plan

- [x] All 1749 existing tests pass
- [x] All linters pass (isort, black, flake8, mypy, bandit)
- [x] Indexer restarted successfully — `reorg_events` table auto-created on startup (`Found 28/29 tables, executing full schema...`)
- [x] Indexer processing blocks normally at chain tip after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)