### PR TITLE
feat: persist encoding_method in StampTableV4

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -126,6 +126,7 @@ TxResult = namedtuple(
         "block_hash",
         "block_time",
         "p2wsh_data",
+        "is_olga",
     ],
 )
 
@@ -156,6 +157,13 @@ class BlockProcessor:
                     logger.error(f"🔍 DEBUG TX 95dca4dc: Data length = {len(result.data) if result.data else 0}")
                     logger.error(f"🔍 DEBUG TX 95dca4dc: Data preview = {result.data[:100] if result.data else 'None'}...")
 
+                # Derive encoding_method from parser signals
+                # Every valid stamp is either OLGA (P2WSH) or MULTISIG
+                if result.is_olga:
+                    encoding_method = "OLGA"
+                else:
+                    encoding_method = "MULTISIG"
+
                 initial_stamp_data = StampData(
                     tx_hash=result.tx_hash,
                     source=result.source,
@@ -173,6 +181,7 @@ class BlockProcessor:
                     block_time=result.block_time,
                     is_op_return=result.is_op_return,
                     p2wsh_data=result.p2wsh_data,
+                    encoding_method=encoding_method,
                 )
 
                 # DEBUG: Log before parsing

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -562,8 +562,9 @@ def insert_into_stamp_table(db, parsed_stamps: List):
                     stamp_mimetype, stamp_url, supply, block_time,
                     tx_hash, tx_index, ident, src_data,
                     stamp_hash, is_btc_stamp,
-                    file_hash, is_valid_base64, file_size_bytes
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    file_hash, is_valid_base64, file_size_bytes,
+                    encoding_method
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """  # nosec
 
             data = [
@@ -591,6 +592,7 @@ def insert_into_stamp_table(db, parsed_stamps: List):
                     parsed.file_hash,
                     parsed.is_valid_base64,
                     parsed.file_size_bytes,
+                    parsed.encoding_method,
                 )
                 for parsed in parsed_stamps
             ]
@@ -2720,6 +2722,18 @@ def apply_schema_updates(db, cursor):
             "indexes": [
                 ("idx_holder_calc", ["tick", "amt", "address"]),  # Optimized for holder count calculations
                 ("idx_balances_tick_amt", ["tick", "amt"]),  # Frontend team optimization
+            ],
+        },
+        "StampTableV4": {
+            "columns": [
+                (
+                    "encoding_method",
+                    "ENUM('MULTISIG', 'OLGA')",
+                    "Transaction encoding method detected during parsing",
+                ),
+            ],
+            "indexes": [
+                ("idx_encoding_method", ["encoding_method"]),
             ],
         },
     }

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -91,6 +91,7 @@ class StampData:
     block_time: Union[int, datetime]
     is_op_return: bool
     p2wsh_data: bytes
+    encoding_method: Optional[str] = None  # 'MULTISIG' or 'OLGA'
     stamp: Optional[int] = None
     creator: Optional[str] = None
     cpid: Optional[str] = None

--- a/indexer/src/index_core/transaction_utils.py
+++ b/indexer/src/index_core/transaction_utils.py
@@ -54,6 +54,7 @@ TxResult = namedtuple(
         "block_hash",
         "block_time",
         "p2wsh_data",
+        "is_olga",
     ],
 )
 
@@ -436,6 +437,7 @@ def get_tx_info(tx_hex, block_index=None, db=None, stamp_issuance=None):
             "keyburn",
             "is_op_return",
             "p2wsh_data",
+            "is_olga",
         ],
     )
 
@@ -474,6 +476,7 @@ def get_tx_info(tx_hex, block_index=None, db=None, stamp_issuance=None):
                 keyburn,
                 is_op_return,
                 p2wsh_data,
+                vout_info.is_olga,
             )
 
         # Handle P2WSH data chunks for SRC-20 transactions
@@ -555,10 +558,11 @@ def get_tx_info(tx_hex, block_index=None, db=None, stamp_issuance=None):
             keyburn,
             is_op_return,
             None,
+            vout_info.is_olga,
         )
 
     except (DecodeError, BTCOnlyError):
-        return TransactionInfo(b"", None, None, None, None, None, None, None, None, None, None)
+        return TransactionInfo(b"", None, None, None, None, None, None, None, None, None, None, False)
 
 
 def decode_checkmultisig(ctx, chunk):
@@ -614,6 +618,7 @@ def list_tx(db, block_index: int, tx_hash: str, tx_hex=None, stamp_issuance=None
     keyburn = getattr(transaction_info, "keyburn", None)
     is_op_return = getattr(transaction_info, "is_op_return", None)
     p2wsh_data = getattr(transaction_info, "p2wsh_data", None)
+    is_olga = getattr(transaction_info, "is_olga", False)
 
     if block_index != util.CURRENT_BLOCK_INDEX:
         raise ValueError(f"block_index does not match util.CURRENT_BLOCK_INDEX: {block_index} != {util.CURRENT_BLOCK_INDEX}")
@@ -641,11 +646,12 @@ def list_tx(db, block_index: int, tx_hash: str, tx_hex=None, stamp_issuance=None
             keyburn,
             is_op_return,
             p2wsh_data,
+            is_olga,
         )
 
     else:
         # skip_logger.debug("Skipping transaction: {}".format(tx_hash))
-        return tuple(None for _ in range(11))
+        return tuple(None for _ in range(12))
 
 
 def process_tx(db, tx_hash, block_index, stamp_issuances, raw_transactions):
@@ -687,6 +693,7 @@ def process_tx(db, tx_hash, block_index, stamp_issuances, raw_transactions):
             keyburn,
             is_op_return,
             p2wsh_data,
+            is_olga,
         ) = list_tx(db, block_index, tx_hash, tx_hex, stamp_issuance=stamp_issuance)
 
         # Calculate fee rate for this transaction
@@ -717,11 +724,29 @@ def process_tx(db, tx_hash, block_index, stamp_issuances, raw_transactions):
             None,
             None,
             p2wsh_data,
+            is_olga,
         )
     except Exception:
 
         return TxResult(
-            None, None, None, None, None, None, None, None, None, None, None, None, tx_hash, block_index, None, None, None
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            tx_hash,
+            block_index,
+            None,
+            None,
+            None,
+            None,
         )
 
 

--- a/indexer/table_schema.sql
+++ b/indexer/table_schema.sql
@@ -63,6 +63,8 @@ CREATE TABLE IF NOT EXISTS `StampTableV4` (
   `file_hash` varchar(255) DEFAULT NULL,
   `is_valid_base64` tinyint(1) DEFAULT NULL,
   `file_size_bytes` int DEFAULT NULL COMMENT 'Size of the decoded stamp file in bytes',
+  `encoding_method` ENUM('MULTISIG', 'OLGA') NULL
+    COMMENT 'Transaction encoding method detected during parsing',
   PRIMARY KEY (`stamp`),
   UNIQUE `tx_hash` (`tx_hash`),
   UNIQUE `stamp_hash` (`stamp_hash`),
@@ -78,6 +80,7 @@ CREATE TABLE IF NOT EXISTS `StampTableV4` (
   INDEX `idx_stamp_url_mimetype` (`stamp_url`(97), `stamp_mimetype`),
   INDEX `idx_stamp_file` (`stamp_hash`, `stamp_mimetype`, `stamp_url`(97)),
   INDEX `idx_cpid_ident` (`cpid`, `ident`),
+  INDEX `idx_encoding_method` (`encoding_method`),
   INDEX `idx_stamp_count` (`is_btc_stamp`, `ident`, `creator`(42)),
   INDEX `idx_stamp_details` (
     `stamp`,

--- a/indexer/tests/test_database.py
+++ b/indexer/tests/test_database.py
@@ -458,7 +458,7 @@ class TestStampOperations:
         args = mock_cursor.executemany.call_args[0]
         assert "INSERT INTO STAMPS" in args[0]
         assert len(args[1]) == 1  # One stamp
-        assert len(args[1][0]) == 23  # 23 fields
+        assert len(args[1][0]) == 24  # 24 fields (including encoding_method)
 
 
 class TestBalanceCalculations:

--- a/indexer/tests/test_transaction_processing.py
+++ b/indexer/tests/test_transaction_processing.py
@@ -381,7 +381,7 @@ class TestTransactionProcessing:
                 result = list_tx(mock_db, 900001, test_tx_hash, test_tx_hex)
 
                 # Verify result tuple structure matches original function return order
-                assert len(result) == 11
+                assert len(result) == 12
                 assert result[0] == "source_address"  # source
                 assert result[1] == b"prev_hash"  # prev_tx_hash (bytes from vin.prevout.hash)
                 assert result[2] == "dest_address"  # destination
@@ -423,7 +423,7 @@ class TestTransactionProcessing:
 
             # Should return tuple of None values
             assert isinstance(result, tuple)
-            assert len(result) == 11
+            assert len(result) == 12
             assert all(item is None for item in result)
 
     def test_process_tx_with_matching_issuance(self):
@@ -446,8 +446,8 @@ class TestTransactionProcessing:
         ) as mock_find_issuance:
 
             # Mock list_tx result in the original order:
-            # source, prev_tx_hash, destination, destination_nvalue, btc_amount, fee, data, decoded_tx, keyburn, is_op_return, p2wsh_data
-            mock_list_tx.return_value = ("source", None, "dest", None, 1000, 546, b"data", None, 0, False, None)
+            # source, prev_tx_hash, destination, destination_nvalue, btc_amount, fee, data, decoded_tx, keyburn, is_op_return, p2wsh_data, is_olga
+            mock_list_tx.return_value = ("source", None, "dest", None, 1000, 546, b"data", None, 0, False, None, False)
 
             # Mock find_issuance_by_tx_hash
             mock_find_issuance.return_value = {"cpid": "A5678"}

--- a/indexer/tools/backfill_encoding_method.py
+++ b/indexer/tools/backfill_encoding_method.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+"""
+Backfill encoding_method column in StampTableV4.
+
+This script populates the encoding_method column for existing stamps using a
+three-phase approach:
+
+Phase 1: Unambiguous SQL updates based on block ranges and keyburn values.
+Phase 2: Rust re-parse for ambiguous stamps (block_index >= 865000, keyburn=1).
+Phase 3: Verification queries.
+
+Usage:
+    cd indexer && poetry run python tools/backfill_encoding_method.py [--phase N] [--batch-size N] [--dry-run]
+
+The script can safely run alongside the live indexer (read-only RPC + single-column UPDATEs).
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+from dotenv import load_dotenv
+
+# Add src directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def get_db_connection():
+    """Create a database connection using environment variables."""
+    import pymysql
+
+    return pymysql.connect(
+        host=os.environ.get("MYSQL_HOST", "localhost"),
+        port=int(os.environ.get("MYSQL_PORT", 3306)),
+        user=os.environ.get("MYSQL_USER", "root"),
+        password=os.environ.get("MYSQL_PASSWORD", ""),
+        database=os.environ.get("MYSQL_DATABASE", "btc_stamps"),
+        charset="utf8mb4",
+        autocommit=False,
+    )
+
+
+def phase1_sql_updates(db, dry_run=False):
+    """Phase 1: Unambiguous SQL updates based on block ranges."""
+    cursor = db.cursor()
+
+    updates = [
+        (
+            "Pre-833000: all MULTISIG",
+            "UPDATE StampTableV4 SET encoding_method = 'MULTISIG' WHERE block_index < 833000 AND encoding_method IS NULL",
+        ),
+        (
+            "keyburn=NULL after 833000: CP-originated OLGA (P2WSH)",
+            "UPDATE StampTableV4 SET encoding_method = 'OLGA' WHERE keyburn IS NULL AND block_index >= 833000 AND encoding_method IS NULL",
+        ),
+        (
+            "833000-865000, keyburn=1: all MULTISIG (OLGA didn't exist yet)",
+            "UPDATE StampTableV4 SET encoding_method = 'MULTISIG' WHERE block_index >= 833000 AND block_index < 865000 AND keyburn = 1 AND encoding_method IS NULL",
+        ),
+    ]
+
+    for description, sql in updates:
+        logger.info(f"Phase 1: {description}")
+        if dry_run:
+            # Count affected rows
+            count_sql = sql.replace(
+                "UPDATE StampTableV4 SET encoding_method = 'MULTISIG'", "SELECT COUNT(*) FROM StampTableV4"
+            )
+            count_sql = count_sql.replace(
+                "UPDATE StampTableV4 SET encoding_method = 'OLGA'", "SELECT COUNT(*) FROM StampTableV4"
+            )
+            cursor.execute(count_sql)
+            count = cursor.fetchone()[0]
+            logger.info(f"  [DRY RUN] Would update {count} rows")
+        else:
+            cursor.execute(sql)
+            logger.info(f"  Updated {cursor.rowcount} rows")
+            db.commit()
+
+    cursor.close()
+
+
+def phase2_rust_reparse(db, batch_size=1000, dry_run=False):
+    """Phase 2: Re-parse ambiguous stamps with the Rust parser.
+
+    For stamps where block_index >= 865000 AND keyburn = 1 AND encoding_method IS NULL,
+    fetch the raw tx hex and check for OP_CHECKMULTISIG via the Rust parser.
+    """
+    try:
+        from btc_stamps_parser import FastTransactionParser
+    except ImportError:
+        logger.error("Rust parser (btc_stamps_parser) not available. Cannot run Phase 2.")
+        logger.error("Build it with: cd indexer && poetry run task build")
+        return
+
+    from index_core.backend import Backend
+
+    backend = Backend()
+    parser = FastTransactionParser()
+
+    cursor = db.cursor()
+
+    # Count total stamps to process
+    cursor.execute("SELECT COUNT(*) FROM StampTableV4 WHERE block_index >= 865000 AND keyburn = 1 AND encoding_method IS NULL")
+    total = cursor.fetchone()[0]
+    logger.info(f"Phase 2: {total} stamps to re-parse")
+
+    if total == 0:
+        cursor.close()
+        return
+
+    processed = 0
+    multisig_count = 0
+    olga_count = 0
+
+    while True:
+        cursor.execute(
+            "SELECT stamp, tx_hash FROM StampTableV4 "
+            "WHERE block_index >= 865000 AND keyburn = 1 AND encoding_method IS NULL "
+            "ORDER BY stamp LIMIT %s",
+            (batch_size,),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            break
+
+        tx_hashes = [row[1] for row in rows]
+        stamp_ids = {row[1]: row[0] for row in rows}
+
+        # Batch fetch raw transactions
+        try:
+            raw_txs = backend.getrawtransaction_batch(tx_hashes, verbose=False)
+        except Exception as e:
+            logger.error(f"Error fetching batch of {len(tx_hashes)} transactions: {e}")
+            # Fall back to one-by-one
+            raw_txs = {}
+            for tx_hash in tx_hashes:
+                try:
+                    raw_txs[tx_hash] = backend.getrawtransaction(tx_hash, verbose=False)
+                except Exception:
+                    logger.warning(f"Failed to fetch tx {tx_hash}, skipping")
+
+        multisig_stamps = []
+        olga_stamps = []
+
+        for tx_hash in tx_hashes:
+            tx_hex = raw_txs.get(tx_hash)
+            if tx_hex is None:
+                logger.warning(f"No raw tx data for {tx_hash} (stamp {stamp_ids[tx_hash]}), skipping")
+                continue
+
+            try:
+                tx_info = parser.deserialize_transaction(tx_hex)
+                has_multisig = any(output.has_op_checkmultisig for output in tx_info.outputs)
+
+                if has_multisig:
+                    multisig_stamps.append(stamp_ids[tx_hash])
+                    multisig_count += 1
+                else:
+                    olga_stamps.append(stamp_ids[tx_hash])
+                    olga_count += 1
+            except Exception as e:
+                logger.warning(f"Error parsing tx {tx_hash}: {e}, skipping")
+
+        # Batch update
+        if not dry_run:
+            if multisig_stamps:
+                placeholders = ",".join(["%s"] * len(multisig_stamps))
+                cursor.execute(
+                    f"UPDATE StampTableV4 SET encoding_method = 'MULTISIG' WHERE stamp IN ({placeholders})",
+                    multisig_stamps,
+                )
+            if olga_stamps:
+                placeholders = ",".join(["%s"] * len(olga_stamps))
+                cursor.execute(
+                    f"UPDATE StampTableV4 SET encoding_method = 'OLGA' WHERE stamp IN ({placeholders})",
+                    olga_stamps,
+                )
+            db.commit()
+
+        processed += len(rows)
+        logger.info(f"  Progress: {processed}/{total} stamps " f"(MULTISIG: {multisig_count}, OLGA: {olga_count})")
+
+    cursor.close()
+    logger.info(f"Phase 2 complete: {multisig_count} MULTISIG, {olga_count} OLGA")
+
+
+def phase3_verification(db):
+    """Phase 3: Verify the backfill results."""
+    cursor = db.cursor()
+
+    # Check for remaining NULLs
+    cursor.execute("SELECT COUNT(*) FROM StampTableV4 WHERE encoding_method IS NULL")
+    null_count = cursor.fetchone()[0]
+    logger.info(f"Verification: {null_count} stamps with NULL encoding_method")
+
+    # Distribution check
+    cursor.execute("SELECT encoding_method, COUNT(*) FROM StampTableV4 GROUP BY encoding_method ORDER BY encoding_method")
+    rows = cursor.fetchall()
+    logger.info("Distribution:")
+    for method, count in rows:
+        logger.info(f"  {method or 'NULL'}: {count}")
+
+    cursor.close()
+
+    if null_count > 0:
+        logger.warning("Some stamps still have NULL encoding_method!")
+    else:
+        logger.info("All stamps have encoding_method set.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill encoding_method in StampTableV4")
+    parser.add_argument("--phase", type=int, choices=[1, 2, 3], help="Run only a specific phase (default: all)")
+    parser.add_argument("--batch-size", type=int, default=1000, help="Batch size for Phase 2 (default: 1000)")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+    args = parser.parse_args()
+
+    db = get_db_connection()
+
+    try:
+        if args.phase is None or args.phase == 1:
+            logger.info("=== Phase 1: SQL-based updates ===")
+            start = time.time()
+            phase1_sql_updates(db, dry_run=args.dry_run)
+            logger.info(f"Phase 1 completed in {time.time() - start:.1f}s")
+
+        if args.phase is None or args.phase == 2:
+            logger.info("=== Phase 2: Rust re-parse ===")
+            start = time.time()
+            phase2_rust_reparse(db, batch_size=args.batch_size, dry_run=args.dry_run)
+            logger.info(f"Phase 2 completed in {time.time() - start:.1f}s")
+
+        if args.phase is None or args.phase == 3:
+            logger.info("=== Phase 3: Verification ===")
+            phase3_verification(db)
+
+    finally:
+        db.close()
+
+    logger.info("Backfill complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/tools/backfill_encoding_method.py
+++ b/indexer/tools/backfill_encoding_method.py
@@ -36,15 +36,15 @@ logger = logging.getLogger(__name__)
 
 
 def get_db_connection():
-    """Create a database connection using environment variables."""
+    """Create a database connection using environment variables (RDS_ or MYSQL_ prefix)."""
     import pymysql
 
     return pymysql.connect(
-        host=os.environ.get("MYSQL_HOST", "localhost"),
-        port=int(os.environ.get("MYSQL_PORT", 3306)),
-        user=os.environ.get("MYSQL_USER", "root"),
-        password=os.environ.get("MYSQL_PASSWORD", ""),
-        database=os.environ.get("MYSQL_DATABASE", "btc_stamps"),
+        host=os.environ.get("RDS_HOSTNAME", os.environ.get("MYSQL_HOST", "localhost")),
+        port=int(os.environ.get("RDS_PORT", os.environ.get("MYSQL_PORT", 3306))),
+        user=os.environ.get("RDS_USER", os.environ.get("MYSQL_USER", "root")),
+        password=os.environ.get("RDS_PASSWORD", os.environ.get("MYSQL_PASSWORD", "")),
+        database=os.environ.get("RDS_DATABASE", os.environ.get("MYSQL_DATABASE", "btc_stamps")),
         charset="utf8mb4",
         autocommit=False,
     )
@@ -54,36 +54,33 @@ def phase1_sql_updates(db, dry_run=False):
     """Phase 1: Unambiguous SQL updates based on block ranges."""
     cursor = db.cursor()
 
+    # Each entry: (description, update_sql, count_where) — count_where omits encoding_method for dry-run compatibility
     updates = [
         (
             "Pre-833000: all MULTISIG",
             "UPDATE StampTableV4 SET encoding_method = 'MULTISIG' WHERE block_index < 833000 AND encoding_method IS NULL",
+            "WHERE block_index < 833000",
         ),
         (
             "keyburn=NULL after 833000: CP-originated OLGA (P2WSH)",
             "UPDATE StampTableV4 SET encoding_method = 'OLGA' WHERE keyburn IS NULL AND block_index >= 833000 AND encoding_method IS NULL",
+            "WHERE keyburn IS NULL AND block_index >= 833000",
         ),
         (
             "833000-865000, keyburn=1: all MULTISIG (OLGA didn't exist yet)",
             "UPDATE StampTableV4 SET encoding_method = 'MULTISIG' WHERE block_index >= 833000 AND block_index < 865000 AND keyburn = 1 AND encoding_method IS NULL",
+            "WHERE block_index >= 833000 AND block_index < 865000 AND keyburn = 1",
         ),
     ]
 
-    for description, sql in updates:
+    for description, update_sql, count_where in updates:
         logger.info(f"Phase 1: {description}")
         if dry_run:
-            # Count affected rows
-            count_sql = sql.replace(
-                "UPDATE StampTableV4 SET encoding_method = 'MULTISIG'", "SELECT COUNT(*) FROM StampTableV4"
-            )
-            count_sql = count_sql.replace(
-                "UPDATE StampTableV4 SET encoding_method = 'OLGA'", "SELECT COUNT(*) FROM StampTableV4"
-            )
-            cursor.execute(count_sql)
+            cursor.execute(f"SELECT COUNT(*) FROM StampTableV4 {count_where}")  # nosec
             count = cursor.fetchone()[0]
             logger.info(f"  [DRY RUN] Would update {count} rows")
         else:
-            cursor.execute(sql)
+            cursor.execute(update_sql)
             logger.info(f"  Updated {cursor.rowcount} rows")
             db.commit()
 
@@ -111,7 +108,14 @@ def phase2_rust_reparse(db, batch_size=1000, dry_run=False):
     cursor = db.cursor()
 
     # Count total stamps to process
-    cursor.execute("SELECT COUNT(*) FROM StampTableV4 WHERE block_index >= 865000 AND keyburn = 1 AND encoding_method IS NULL")
+    # Use encoding_method IS NULL if column exists, otherwise count all in range
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM StampTableV4 WHERE block_index >= 865000 AND keyburn = 1 AND encoding_method IS NULL"
+        )
+    except Exception:
+        db.rollback()
+        cursor.execute("SELECT COUNT(*) FROM StampTableV4 WHERE block_index >= 865000 AND keyburn = 1")
     total = cursor.fetchone()[0]
     logger.info(f"Phase 2: {total} stamps to re-parse")
 


### PR DESCRIPTION
## Summary
- Threads the `is_olga` flag from the Rust/Python parser through the entire return chain (`process_vout` → `TransactionInfo` → `list_tx` → `TxResult` → `StampData`) so the encoding method reaches the database
- Adds `encoding_method` ENUM('MULTISIG', 'OLGA') column to StampTableV4 with auto-migration
- Includes a standalone backfill script for existing stamps (3-phase: SQL updates, Rust re-parse, verification)

Closes #682

## Why
The frontend currently uses `block_index < 833000` as an inaccurate proxy for encoding type. This change persists the actual encoding method detected during parsing for accurate filtering and analytics.

| encoding_method | keyburn | Meaning |
|---|---|---|
| OLGA | 1 | P2WSH encoding, always unspendable |
| MULTISIG | 1 | Multisig with burn address (unspendable) |
| MULTISIG | NULL | Multisig with spendable outputs |

## Files changed
| File | Change |
|------|--------|
| `transaction_utils.py` | Thread `is_olga` through TransactionInfo → list_tx → TxResult |
| `models.py` | Add `encoding_method` field to StampData |
| `blocks.py` | Derive encoding_method from is_olga flag, pass to StampData |
| `database.py` | Update INSERT + add schema migration entry |
| `table_schema.sql` | Add column + index to CREATE TABLE |
| `tools/backfill_encoding_method.py` | New: one-time backfill script |

## Test plan
- [x] All 1749 tests pass, 51 skipped (pre-existing)
- [x] All linters pass (isort, black, flake8, mypy, bandit)
- [x] Run backfill `--dry-run` to audit numbers
- [x] Restart indexer — confirm schema auto-migration adds column
- [x] Verify new blocks get encoding_method populated
- [x] Run backfill, verify distribution with `SELECT encoding_method, COUNT(*) FROM StampTableV4 GROUP BY encoding_method`

🤖 Generated with [Claude Code](https://claude.com/claude-code)