### PR TITLE
fix: remove flaky timing assertion in dispenser cache test

### DIFF
--- a/indexer/tests/test_dispenser_bulk_fetcher_integration.py
+++ b/indexer/tests/test_dispenser_bulk_fetcher_integration.py
@@ -116,8 +116,9 @@ class TestDispenserBulkFetcherIntegration:
             second_call_time = time.time() - start_time
             assert refreshed2 is False  # Should use cache
 
-            # Second call should be much faster (cache hit)
-            assert second_call_time < first_call_time * 0.5  # At least 2x faster
+            # Cache behavior is verified by refreshed2 == False above.
+            # Timing assertions removed: both calls are sub-microsecond mocked calls,
+            # making time comparisons unreliable in CI environments.
 
             # Results should be identical
             assert dispensers1 == dispensers2


### PR DESCRIPTION
## Summary
- Removes unreliable timing assertion in `test_dispenser_cache_behavior` that compared sub-microsecond mocked calls
- Both calls are mocked (instant), so `second_call_time < first_call_time * 0.5` is a coin flip in CI
- Cache behavior is already verified by `assert refreshed2 is False`

## Test plan
- [x] `poetry run pytest tests/test_dispenser_bulk_fetcher_integration.py -v` passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)