### PR TITLE
docs: update docker-compose to docker compose (Compose V2 syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,17 +158,17 @@ cp indexer/.env.sample indexer/.env
 
 Choose one of these methods to run the services:
 
-##### Option 1: Using docker-compose commands
+##### Option 1: Using docker compose commands
 
 ```shell
 # Start all services
-cd docker && docker-compose up -d
+cd docker && docker compose up -d
 
 # View indexer logs
-docker-compose logs -f indexer
+docker compose logs -f indexer
 
 # Shutdown services
-docker-compose down
+docker compose down
 ```
 
 ##### Option 2: Using make commands


### PR DESCRIPTION
Docker Compose V1 was officially deprecated by Docker in June 2023 and is no longer included in new Docker installations. The `docker-compose` command with a hyphen has been replaced by `docker compose` (two words, space-separated) as part of the Docker CLI.

This updates the README to use the current Compose V2 syntax, so new users following the installation instructions don't encounter "command not found" errors on recent Docker installations.

Reference: https://docs.docker.com/compose/migrate/

---

## Verification

The change is limited to the README.md file and does not affect any code or
configuration. The commands in Option 2 (`make` commands) are unchanged since
they already abstract the underlying docker command via the Makefile.

No functional changes — documentation only.