### PR TITLE
fix: rollback clears fallback state and startup safety uses indexer height

### DIFF
--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -48,7 +48,7 @@ from index_core.exceptions import BlockAlreadyExistsError, BlockUpdateError, Dat
 from index_core.memory_manager import memory_manager
 from index_core.stamp_types import NO_DEPLOY, DeployResult
 
-from .fallback_state import load_failed_blocks
+from .reprocessing_queue import ReprocessingQueue
 
 logger = logging.getLogger(__name__)
 log.set_logger(logger)
@@ -1283,15 +1283,17 @@ def perform_complete_rollback(block_index: int, force: bool = False) -> None:
 
         logger.info(f"✅ Complete rollback finished to block {block_index}")
 
-        # Check if we should clear fallback state
-        failed_blocks = load_failed_blocks()
-        if failed_blocks:
-            fallback_start_block = min(failed_blocks.keys())  # Get min instead of manager
-            if fallback_start_block and block_index <= fallback_start_block:
+        # Check if we should clear fallback state.
+        # Query the fallback session directly via ReprocessingQueue rather than
+        # load_failed_blocks(), which depends on util.CURRENT_BLOCK_INDEX and silently
+        # returns {} when called from the rollback CLI (CURRENT_BLOCK_INDEX is None there).
+        fallback_start_block = ReprocessingQueue.get_instance().get_oldest_failed_block()
+        if fallback_start_block:
+            if block_index <= fallback_start_block:
                 logger.info(f"Clearing fallback state (started at block {fallback_start_block})...")
                 from .fallback_state import clear_fallback_state
 
-                clear_fallback_state(fallback_start_block)  # Or clear_all_fallbacks() if available
+                clear_fallback_state(fallback_start_block)
             else:
                 logger.info(f"Note: Fallback mode is active (started at block {fallback_start_block})")
                 logger.info(f"To clear fallback state, rollback to block {fallback_start_block} or earlier")

--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -904,11 +904,40 @@ class CPBlocksPipeline:
             try:
                 validate_block_number(target_block, "rollback target")
 
-                # Get current block for distance validation
-                current_block = backend_instance.getblockcount()
-                validate_rollback_distance(current_block, target_block)
+                # Use the indexer's last-processed block (not the bitcoin tip) for the
+                # distance check. The safety bound is about how much *indexed state* we
+                # are discarding — bitcoin advancing while the indexer was offline is
+                # irrelevant and would spuriously trip the limit after long downtime.
+                # Fall back to the bitcoin tip only if the DB height is unavailable.
+                from index_core.database import last_db_index
+                from index_core.database_manager import DatabaseManager
 
-                log_safety_check(f"Rollback validated: current={current_block}, target={target_block}")
+                try:
+                    db_manager = DatabaseManager()
+                    db = db_manager.connect()
+                    try:
+                        indexer_block = last_db_index(db)
+                    finally:
+                        db.close()
+                except Exception as db_err:
+                    logger.warning(
+                        f"Could not read indexer height for rollback distance check, "
+                        f"falling back to bitcoin tip: {db_err}"
+                    )
+                    indexer_block = backend_instance.getblockcount()
+
+                # If the DB is already at or below the target, the rollback is a no-op
+                # for state purposes; skip the distance check rather than tripping it.
+                if indexer_block <= target_block:
+                    log_safety_check(
+                        f"Rollback distance check skipped: indexer already at {indexer_block} "
+                        f"(target={target_block})"
+                    )
+                else:
+                    validate_rollback_distance(indexer_block, target_block)
+                    log_safety_check(
+                        f"Rollback validated: indexer={indexer_block}, target={target_block}"
+                    )
             except ReprocessSafetyError as e:
                 logger.error(f"SAFETY VIOLATION: Cannot perform rollback: {e}")
                 raise RuntimeError(f"Safety check failed: {e}")

--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -921,8 +921,7 @@ class CPBlocksPipeline:
                         db.close()
                 except Exception as db_err:
                     logger.warning(
-                        f"Could not read indexer height for rollback distance check, "
-                        f"falling back to bitcoin tip: {db_err}"
+                        f"Could not read indexer height for rollback distance check, " f"falling back to bitcoin tip: {db_err}"
                     )
                     indexer_block = backend_instance.getblockcount()
 
@@ -930,14 +929,11 @@ class CPBlocksPipeline:
                 # for state purposes; skip the distance check rather than tripping it.
                 if indexer_block <= target_block:
                     log_safety_check(
-                        f"Rollback distance check skipped: indexer already at {indexer_block} "
-                        f"(target={target_block})"
+                        f"Rollback distance check skipped: indexer already at {indexer_block} " f"(target={target_block})"
                     )
                 else:
                     validate_rollback_distance(indexer_block, target_block)
-                    log_safety_check(
-                        f"Rollback validated: indexer={indexer_block}, target={target_block}"
-                    )
+                    log_safety_check(f"Rollback validated: indexer={indexer_block}, target={target_block}")
             except ReprocessSafetyError as e:
                 logger.error(f"SAFETY VIOLATION: Cannot perform rollback: {e}")
                 raise RuntimeError(f"Safety check failed: {e}")


### PR DESCRIPTION
## Summary

Two compounding bugs left the indexer wedged after a CP-node-induced fallback session was rolled back manually:

1. **`perform_complete_rollback()` silently failed to clear the fallback session.** It used `load_failed_blocks()`, which reads `util.CURRENT_BLOCK_INDEX` — `None` when invoked from the `tools/rollback_db.py` CLI — so the helper returned `{}` and the `fallback_sessions` row was never deleted, even though the CLI printed "✓ Fallback state cleared (if applicable)". Fix: query `ReprocessingQueue.get_oldest_failed_block()` directly.

2. **`_perform_startup_rollback()` validated rollback distance against the bitcoin tip.** `backend_instance.getblockcount()` is the bitcoin chain tip, not the indexer's last processed block. After offline time long enough for bitcoin to advance past `MAX_ROLLBACK_BLOCKS` (1000), startup aborted with `SAFETY VIOLATION` even when the actual indexed state to discard was tiny (or zero). Fix: use `last_db_index(db)`, and skip the distance check when the DB height is already ≤ target.

Together these prevent the indexer from getting permanently wedged after a fallback session that has already been resolved by a manual rollback.

## Repro from incident

- CP nodes failed at block 947614 → fallback session persisted to SQLite.
- 258 blocks processed in fallback mode.
- Operator ran `poetry run rollback 947614` (succeeded — but did NOT clear `fallback_sessions` due to bug #1).
- On `poetry run indexer` restart, fallback state still present → startup rollback re-triggered → bug #2 trips on `949228 − 947614 = 1614 > 1000` → indexer aborts.

## Test plan

- [x] Verified fallback session is correctly identified via `get_oldest_failed_block()` in a CLI-rollback context (no `CURRENT_BLOCK_INDEX` set).
- [x] Verified startup proceeds when DB height ≤ rollback target (no-op skip).
- [x] Indexer started successfully after the SQLite fallback session was cleared, processed from 947613 to chain tip (949435) without re-triggering the safety violation.
- [ ] Reviewer to confirm `ReprocessingQueue.get_oldest_failed_block()` is the canonical way to discover an in-flight fallback session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)