### PR TITLE
fix: share DatabaseManager pool across components

### DIFF
--- a/indexer/src/index_core/database_manager.py
+++ b/indexer/src/index_core/database_manager.py
@@ -183,14 +183,36 @@ class ConnectionPool:
 
 
 class DatabaseManager:
+    # Process-wide singleton: every `DatabaseManager()` call returns the same
+    # instance so the connection pool is shared across all components. Without
+    # this, each of the ~17 callers spun up its own ConnectionPool with its own
+    # min_connections eager-init, multiplying total connections by ~17x and
+    # exhausting RDS max_connections.
+    _instance: Optional["DatabaseManager"] = None
+    _singleton_lock = threading.Lock()
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._singleton_lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+
     def __init__(self):
-        self.max_retries = 5
-        self.retry_delay = 5
-        self.connect_timeout = 30
-        self.read_timeout = 3600
-        self.write_timeout = 3600
-        self.pool = None
-        self._initialize_pool()
+        if self.__class__._initialized:
+            return
+        with self.__class__._singleton_lock:
+            if self.__class__._initialized:
+                return
+            self.max_retries = 5
+            self.retry_delay = 5
+            self.connect_timeout = 30
+            self.read_timeout = 3600
+            self.write_timeout = 3600
+            self.pool = None
+            self._initialize_pool()
+            self.__class__._initialized = True
 
     def _initialize_pool(self):
         """Initialize the connection pool with parameters from environment."""
@@ -224,7 +246,11 @@ class DatabaseManager:
             "charset": "utf8mb4",
             "autocommit": False,
             "client_flag": pymysql.constants.CLIENT.MULTI_STATEMENTS,
-            "init_command": "SET SESSION wait_timeout=28800, max_execution_time=3600000",
+            # Do NOT override SESSION wait_timeout — let the server's global
+            # wait_timeout reap idle pool connections. Previously this forced
+            # 8h per-session, which made idle/leaked connections immortal until
+            # the indexer process restarted.
+            "init_command": "SET SESSION max_execution_time=3600000",
         }
 
         return params
@@ -247,7 +273,10 @@ class DatabaseManager:
             {
                 "read_timeout": 86400,
                 "write_timeout": 86400,
-                "init_command": "SET SESSION wait_timeout=86400, max_execution_time=8640000",
+                # Long-running ops legitimately need longer than the default
+                # server wait_timeout. 2h covers reparse/snapshot/rebuild paths
+                # without making leaks immortal (was 24h).
+                "init_command": "SET SESSION wait_timeout=7200, max_execution_time=8640000",
             }
         )
         return pymysql.connect(**params)

--- a/indexer/src/index_core/database_manager.py
+++ b/indexer/src/index_core/database_manager.py
@@ -214,6 +214,18 @@ class DatabaseManager:
             self._initialize_pool()
             self.__class__._initialized = True
 
+    @classmethod
+    def _reset_for_testing(cls) -> None:
+        """Clear singleton state. Test-only — production code must not call this."""
+        with cls._singleton_lock:
+            if cls._instance is not None and getattr(cls._instance, "pool", None) is not None:
+                try:
+                    cls._instance.pool.close_all()
+                except Exception:
+                    pass
+            cls._instance = None
+            cls._initialized = False
+
     def _initialize_pool(self):
         """Initialize the connection pool with parameters from environment."""
         # Skip pool initialization if we're in test mode with mock DB

--- a/indexer/tests/test_database_manager.py
+++ b/indexer/tests/test_database_manager.py
@@ -195,8 +195,14 @@ class TestDatabaseManager:
         os.environ["MOCK_DB"] = "1"
         os.environ["USE_TEST_DB"] = "1"
 
+        # DatabaseManager is a process-wide singleton; clear it so each test
+        # exercises a fresh init path instead of reusing state from prior tests.
+        DatabaseManager._reset_for_testing()
+
     def teardown_method(self):
         """Clean up after each test"""
+        DatabaseManager._reset_for_testing()
+
         # Restore original environment values
         if self._original_mock_db is not None:
             os.environ["MOCK_DB"] = self._original_mock_db

--- a/indexer/tests/test_database_manager_migrated.py
+++ b/indexer/tests/test_database_manager_migrated.py
@@ -187,8 +187,14 @@ class TestDatabaseManagerMigrated:
         os.environ["MOCK_DB"] = "1"
         os.environ["USE_TEST_DB"] = "1"
 
+        # DatabaseManager is a process-wide singleton; clear it so each test
+        # exercises a fresh init path instead of reusing state from prior tests.
+        DatabaseManager._reset_for_testing()
+
     def teardown_method(self):
         """Clean up after each test."""
+        DatabaseManager._reset_for_testing()
+
         # Restore original environment values
         if self._original_mock_db is not None:
             os.environ["MOCK_DB"] = self._original_mock_db


### PR DESCRIPTION
## Summary

The indexer process was holding ~13× more RDS connections than configured, contributing materially to global `max_connections=630` saturation on the shared RDS instance (`stamps-4`) during recent `1040: Too many connections` incidents.

### 1. `DatabaseManager` is now a process-wide singleton

Every call to `DatabaseManager()` (~17 call sites: `market_data_jobs`, `holder_count_catchup_job`, `monitoring_logger`, `src20_market_processor`, `stamp_market_processor`, `database.py` module-level, `pipeline_utils`, `source_reliability_service`, `async_upload`, `sales_history_processor`, `market_data_service`, `src20_holder_updater`, `reparse/snapshot`, `reparse/validator`, `dispense_processor`, plus the module-level instance in `database_manager.py` itself) previously created its own `ConnectionPool` with its own `min_connections=10` eager init.

At idle that meant ~17 × 10 = ~130 sockets just to satisfy mins, and far more under load. `__new__` + an `_initialized` guard (under a class lock) means all 17 call sites continue to work unchanged and now share one pool.

### 2. Drop the per-session `wait_timeout` override

`get_connection_params()` previously set `SESSION wait_timeout=28800` (8h) via `init_command`, overriding whatever the server's global was. This made any leaked idle pool connection immortal until process restart — defeating server-side reaping, which is the only safety net on a shared instance.

`get_long_running_connection()` still extends `wait_timeout`, but lowered from `86400s` (24h) to `7200s` (2h) — covers reparse/snapshot/rebuild paths without keeping orphans alive for a full day.

## Verification (live)

| | Before | After |
|---|---|---|
| `stamps_indexer` conns | **130** | **10** |
| Indexer DB load | 21% of cluster cap | 3% of cluster cap |

Indexer restarted on this commit, ran through bootstrap/balance rebuild, caught up to chain tip (949435), and held steady at exactly `DB_MIN_CONNECTIONS=10` — confirming there is now exactly one pool instead of 17.

## Test plan

- [x] `DatabaseManager() is DatabaseManager()` → `True` (verified via smoke test).
- [x] Pool object identity preserved across instantiations.
- [x] Flake8 clean.
- [x] Indexer runs end-to-end: startup → balance rebuild → block-following → ZMQ tip-tracking.
- [ ] Reviewer to confirm no caller depends on multiple independent pools (none found — all call sites treat `DatabaseManager()` as cheap-to-construct).
- [ ] Reviewer to confirm dropping `SESSION wait_timeout=28800` won't break long-running operations that bypass `get_long_running_connection()` (audit suggests none do; the long-running path is explicit).

## Related

Surfaced during the `2026-05-14` `1040: Too many connections` incident on `stamps-4`. RDS-side parameter group was set to `wait_timeout=600` (Path A), which only helps if clients don't override per-session — this PR is the indexer's half of that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)