### PR TITLE
feat: add systemd supervision for indexer + tmux log companion

### DIFF
--- a/ops/INDEXER_SUPERVISION.md
+++ b/ops/INDEXER_SUPERVISION.md
@@ -1,0 +1,201 @@
+# Indexer supervision
+
+The `btc-stamps-indexer.service` systemd unit owns and supervises the
+`poetry run indexer` process. It replaces the previous workflow of running
+the indexer manually inside a tmux session — which had the side-effect
+that closing or losing the tmux session killed the indexer with no
+automatic restart. Under systemd, the indexer is restarted automatically
+on crash and on host reboot, and the tmux session becomes a purely
+read-only log viewer.
+
+This directory contains the unit file, the `indexer-logs` companion
+script, and this runbook.
+
+```
+ops/
+├── INDEXER_SUPERVISION.md           ← you are here
+├── systemd/
+│   └── btc-stamps-indexer.service   ← systemd unit (owns the process)
+└── bin/
+    └── indexer-logs                 ← tmux + journalctl log viewer
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ systemd (PID 1)                                                  │
+│   └─ btc-stamps-indexer.service                                  │
+│        └─ /home/ubuntu/.local/bin/poetry run indexer  ← actual   │
+│             └─ Python: index_core.server etc.            process │
+│                                                                  │
+│   logs → journald                                                │
+└────────────────────────────────────────┬─────────────────────────┘
+                                         │
+                                         ▼
+                         (read-only)
+                ┌────────────────────────────┐
+                │ indexer-logs (tmux session)│
+                │   journalctl -u … -f       │
+                └────────────────────────────┘
+                  attach/detach freely;
+                  closing it does NOT stop the indexer
+```
+
+## Initial install — one-time cutover
+
+> **Important:** the indexer is currently running inside a manual tmux
+> session named `indexer`. That manual process must be stopped first,
+> otherwise both the old manual indexer and the new systemd-supervised
+> indexer would compete for the same DB pool slots.
+
+```bash
+# 1. Copy the unit file + helper script into place
+sudo cp ops/systemd/btc-stamps-indexer.service /etc/systemd/system/
+sudo cp ops/bin/indexer-logs                  /usr/local/bin/
+sudo chmod +x /usr/local/bin/indexer-logs
+
+# 2. Tell systemd about the new unit
+sudo systemctl daemon-reload
+
+# 3. Stop the manual tmux indexer (one-time cutover) — graceful: lets the
+#    indexer flush uploads and close cleanly before the next process takes
+#    over.
+tmux send-keys -t indexer C-c
+# wait a few seconds for clean shutdown messages, then:
+tmux kill-session -t indexer
+
+# 4. Enable + start the systemd-supervised indexer
+sudo systemctl enable --now btc-stamps-indexer
+
+# 5. Verify it's running and tail the logs
+sudo systemctl status btc-stamps-indexer       # expect: active (running)
+indexer-logs                                    # opens tmux log viewer
+#  Inside the tmux session: Ctrl-b d to detach (indexer keeps running)
+```
+
+## Branch switch protocol
+
+The systemd unit's `WorkingDirectory` is `/home/ubuntu/btc_stamps/indexer`
+— it always runs whatever branch is checked out. To switch:
+
+```bash
+sudo systemctl stop btc-stamps-indexer
+cd /home/ubuntu/btc_stamps
+git checkout <branch>     # e.g., dev, main, fix/foo
+git pull
+cd indexer
+poetry install            # rebuild .venv if dependencies changed
+sudo systemctl start btc-stamps-indexer
+indexer-logs              # tail the new run
+```
+
+## Daily operations
+
+```bash
+# Live log tail (attach to tmux session)
+indexer-logs
+
+# Historical
+journalctl -u btc-stamps-indexer --since '1 hour ago'
+journalctl -u btc-stamps-indexer --since '2026-05-19 23:00' --until '2026-05-19 23:30'
+
+# Status
+sudo systemctl status btc-stamps-indexer
+
+# Manual restart
+sudo systemctl restart btc-stamps-indexer
+
+# Stop (e.g. for maintenance)
+sudo systemctl stop btc-stamps-indexer
+sudo systemctl start btc-stamps-indexer
+
+# After a restart-burst lockout (StartLimitBurst exceeded)
+sudo systemctl reset-failed btc-stamps-indexer
+sudo systemctl start btc-stamps-indexer
+```
+
+## Restart semantics
+
+| Setting | Value | Effect |
+|---|---|---|
+| `Restart` | `always` | Restarts on ANY exit (clean exit, crash, OOM, signal). |
+| `RestartSec` | `30s` | Wait 30s after exit before restarting. Lets transient issues clear. |
+| `StartLimitBurst` | `5` | At most 5 restarts within `StartLimitIntervalSec`. |
+| `StartLimitIntervalSec` | `300s` | The 5-restart window. |
+| `KillSignal` | `SIGTERM` | Graceful shutdown signal — indexer catches via `server.shutdown_flag`. |
+| `TimeoutStopSec` | `120s` | If cleanup hangs past 120s, SIGKILL. |
+
+If the indexer crashes 5 times in 5 minutes, systemd marks the unit as
+failed and stops restarting. Use `systemctl reset-failed` to clear after
+fixing the underlying cause.
+
+## Troubleshooting
+
+**Unit fails to start, status shows `failed`:**
+
+```bash
+journalctl -u btc-stamps-indexer --since '10 min ago' | tail -50
+```
+Look for Python tracebacks, missing env vars, DB connect errors. The
+indexer's first ~30 seconds of startup logs are usually the diagnostic.
+
+**Restart loop / circuit-breaker tripped:**
+
+```bash
+systemctl status btc-stamps-indexer
+# look for: "start request repeated too quickly" / "scheduled restart job failed"
+sudo systemctl reset-failed btc-stamps-indexer
+sudo systemctl start btc-stamps-indexer
+indexer-logs    # observe what fails on the next attempt
+```
+
+**Long graceful shutdown — adjusting `TimeoutStopSec`:**
+
+If `systemctl stop` consistently times out and SIGKILLs the indexer, the
+async upload worker (or some other cleanup path) needs more than 120s to
+drain. Measure with:
+
+```bash
+time sudo systemctl stop btc-stamps-indexer
+```
+
+If you observe `real > 120s`, edit
+`/etc/systemd/system/btc-stamps-indexer.service`, raise `TimeoutStopSec`,
+then `sudo systemctl daemon-reload`. Update this file in the repo to
+match.
+
+**Reverting to manual tmux operation (emergency):**
+
+```bash
+sudo systemctl disable --now btc-stamps-indexer
+cd /home/ubuntu/btc_stamps/indexer
+tmux new-session -d -s indexer 'poetry run indexer 2>&1 | tee -a /tmp/indexer.log'
+tmux attach -t indexer
+```
+
+## Notifications (deferred)
+
+The unit file contains a commented `OnFailure=btc-stamps-indexer-alert.service`
+hook for future telegram-bot notification. To enable when ready:
+
+1. Write the alert sender (small bash one-liner using `curl` to
+   `https://api.telegram.org/bot<token>/sendMessage`).
+2. Create `/etc/systemd/system/btc-stamps-indexer-alert.service` as a
+   `Type=oneshot` that invokes the sender.
+3. Uncomment the `OnFailure=` line in the indexer unit.
+4. `sudo systemctl daemon-reload`.
+
+This is out of scope for the initial supervision PR.
+
+## What this design intentionally does NOT include
+
+- **Auto-pull on branch change.** Branch switches stay manual (stop, git,
+  install, start) — unattended `git pull` on a running production indexer
+  is unsafe.
+- **Health check endpoint / HTTP probe.** The indexer has no health
+  endpoint today. Could be added as a separate observability PR.
+- **Container deployment.** Counterparty and bitcoind already run in
+  containers on this host, but the indexer itself runs against the local
+  Python venv. systemd is simpler than containerizing for this use case;
+  branch switches don't require image rebuilds.

--- a/ops/bin/indexer-logs
+++ b/ops/bin/indexer-logs
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# indexer-logs — attach to a tmux session that live-tails the indexer's journald output.
+#
+# Same UX as the previous `poetry run indexer` foreground tail, except the
+# underlying indexer process is the systemd-supervised btc-stamps-indexer
+# service. Detaching from or closing this tmux session does NOT stop the
+# indexer; systemd owns the process lifecycle.
+#
+# Inside the session:
+#   Ctrl-b d        detach (indexer keeps running, session persists)
+#   q               quit journalctl (then session closes; indexer untouched)
+#   PgUp / PgDn     scroll history (tmux copy-mode: Ctrl-b [ then PgUp)
+#
+# Outside the session — manage the indexer itself:
+#   sudo systemctl status  btc-stamps-indexer
+#   sudo systemctl restart btc-stamps-indexer
+#   sudo systemctl stop    btc-stamps-indexer    # e.g. before branch switch
+#   sudo systemctl start   btc-stamps-indexer
+#   sudo systemctl reset-failed btc-stamps-indexer   # clear restart-burst lockout
+#
+# Branch switch:
+#   sudo systemctl stop btc-stamps-indexer
+#   cd /home/ubuntu/btc_stamps && git checkout <branch> && git pull
+#   cd indexer && poetry install
+#   sudo systemctl start btc-stamps-indexer
+#   indexer-logs
+
+set -euo pipefail
+
+SESSION="indexer-logs"
+UNIT="btc-stamps-indexer"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "ERROR: tmux is not installed. Falling back to direct journalctl tail." >&2
+  echo "       Install tmux with: sudo apt-get install tmux" >&2
+  exec journalctl -u "$UNIT" -f -n 500 --output=cat
+fi
+
+if ! systemctl list-unit-files "${UNIT}.service" >/dev/null 2>&1; then
+  echo "ERROR: systemd unit '${UNIT}.service' is not installed." >&2
+  echo "       See /home/ubuntu/btc_stamps/ops/INDEXER_SUPERVISION.md" >&2
+  exit 1
+fi
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+  tmux new-session -d -s "$SESSION" \
+    "journalctl -u '$UNIT' -f -n 500 --output=cat"
+fi
+
+exec tmux attach -t "$SESSION"

--- a/ops/systemd/btc-stamps-indexer.service
+++ b/ops/systemd/btc-stamps-indexer.service
@@ -1,0 +1,80 @@
+[Unit]
+Description=BTC Stamps Indexer
+Documentation=https://github.com/stampchain-io/btc_stamps
+Documentation=file:///home/ubuntu/btc_stamps/ops/INDEXER_SUPERVISION.md
+After=network-online.target docker.service
+Wants=network-online.target
+# Counterparty + bitcoind run as containers under docker on this host; wait
+# for the docker daemon so those backends are reachable when we start.
+Requires=docker.service
+
+# Restart-burst circuit breaker: 5 restarts in 5 min → systemd stops trying.
+# Clear with `sudo systemctl reset-failed btc-stamps-indexer` after fixing the
+# underlying cause. (These keys must be in [Unit], not [Service], per systemd
+# semantics; verified with systemd-analyze.)
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+# poetry run indexer is a foreground process — no daemonize/fork
+Type=simple
+User=ubuntu
+Group=ubuntu
+
+# WorkingDirectory is branch-agnostic — runs whichever branch is currently
+# checked out in /home/ubuntu/btc_stamps/indexer. Branch switching is:
+#   sudo systemctl stop btc-stamps-indexer
+#   cd /home/ubuntu/btc_stamps && git checkout <branch> && git pull
+#   cd indexer && poetry install
+#   sudo systemctl start btc-stamps-indexer
+WorkingDirectory=/home/ubuntu/btc_stamps/indexer
+ExecStart=/home/ubuntu/.local/bin/poetry run indexer
+
+# Graceful shutdown: SIGTERM first, then SIGKILL after TimeoutStopSec if the
+# cleanup hangs. The indexer's resource_manager runs ordered cleanup on
+# SIGTERM via server.shutdown_flag: closes CP pipeline → flushes async
+# uploads → closes DB pool → exits. 120s is a generous ceiling; typical
+# clean shutdown completes in under 30s. Raise if you observe legitimate
+# longer shutdowns (e.g., a large upload backlog drain).
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=120
+
+# Restart policy.
+#
+# Restart=always — restart on ANY exit (clean or crashed). We intentionally
+# do NOT use on-failure because there's no scenario where the indexer is
+# supposed to stay down voluntarily; a clean exit (e.g., from the new
+# follow() outage path after MAX_DB_OUTAGE_SECONDS expires) should still
+# trigger systemd to bring us back so we can retry once the DB is up again.
+#
+# RestartSec=30 — wait 30s before restarting, gives transient issues (RDS
+# failover, network blip) time to clear.
+#
+# Burst-limit settings live in the [Unit] section above per systemd semantics.
+Restart=always
+RestartSec=30
+
+# File-descriptor headroom for the DB pool + ZMQ + HTTP clients.
+LimitNOFILE=65536
+
+# Logs → journald, accessible via:
+#   journalctl -u btc-stamps-indexer -f          (live tail)
+#   journalctl -u btc-stamps-indexer --since 1h  (historical)
+#   indexer-logs                                  (tmux companion, see ops/bin/)
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=btc-stamps-indexer
+
+# Optional: override DB-outage tolerance during known maintenance windows.
+# Default is 1800s (30 min); applied inside blocks.py::follow() retry loop.
+# Environment=MAX_DB_OUTAGE_SECONDS=3600
+
+# Notification on failure (NOT WIRED IN THIS COMMIT — see ops/INDEXER_SUPERVISION.md).
+# Future scope: a small telegram-bot one-liner. To enable, write the script,
+# create btc-stamps-indexer-alert.service as a Type=oneshot trigger, then
+# uncomment the line below.
+# OnFailure=btc-stamps-indexer-alert.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Stages systemd-based supervision for the indexer process so a crash, RDS outage exceeding `MAX_DB_OUTAGE_SECONDS` (added in #741), or host reboot doesn't leave the indexer down indefinitely.

Currently the indexer runs in a manually-started tmux session. tmux is the de facto process supervisor — closing the session kills the indexer, and nothing restarts it. The 2026-05-19 storage-full incident exposed exactly this gap: the indexer exited cleanly when RDS briefly went down and stayed off ~38 hours until a human noticed.

This PR **only stages files in the repo**. The actual install + cutover is a manual operator step (one-time, documented in the runbook) because we must stop the currently-running manual indexer before enabling the systemd-supervised one to avoid two indexers competing for DB connections.

## Files

```
ops/
├── INDEXER_SUPERVISION.md           Full runbook (install, branch switch,
│                                    daily ops, troubleshooting, revert)
├── systemd/
│   └── btc-stamps-indexer.service   systemd unit
└── bin/
    └── indexer-logs                 tmux + journalctl log viewer
```

## Architecture

- **`btc-stamps-indexer.service`** owns the process. ExecStart literally runs `poetry run indexer` from `/home/ubuntu/btc_stamps/indexer`. WorkingDirectory is branch-agnostic — whichever branch is checked out is what runs.
- **`indexer-logs`** is a read-only log viewer using `journalctl -u btc-stamps-indexer -f` inside a tmux session. Same operator UX as today's `tmux indexer`, except detaching from this session does NOT stop the indexer (systemd owns the process lifecycle).

## Key design choices

- `Restart=always` — restart on any exit including clean exit code 0 (so the new follow() outage giveup path still gets a fresh attempt after a delay).
- `TimeoutStopSec=120` — generous ceiling on graceful cleanup (typical observed: <30s; raise if observed otherwise).
- `StartLimitBurst=5` in `StartLimitIntervalSec=300` — circuit breaker so a fundamentally-broken state can't tight-loop. `systemctl reset-failed` clears it.
- Branch switching stays an explicit operator step (stop → git → poetry install → start) — no auto-pull.
- Telegram-bot `OnFailure=` placeholder commented in the unit; deferred to future PR.

## Validation

- [x] `systemd-analyze verify ops/systemd/btc-stamps-indexer.service` — clean (only an unrelated snapd warning).
- [x] `bash -n ops/bin/indexer-logs` — syntax OK.
- [x] Poetry path `/home/ubuntu/.local/bin/poetry` confirmed reachable as user `ubuntu`.
- [x] Helper handles tmux-not-installed and unit-not-installed fallback paths.
- [ ] *Manual reviewer step*: read the runbook for the install/cutover procedure. The cutover requires stopping the running tmux indexer; do this in a quiet window.

## Cutover procedure (post-merge, manual)

See `ops/INDEXER_SUPERVISION.md` § "Initial install — one-time cutover". Summary:

```bash
sudo cp ops/systemd/btc-stamps-indexer.service /etc/systemd/system/
sudo cp ops/bin/indexer-logs /usr/local/bin/
sudo chmod +x /usr/local/bin/indexer-logs
sudo systemctl daemon-reload

# Stop manual tmux indexer first
tmux send-keys -t indexer C-c   # graceful
# wait for clean shutdown lines, then
tmux kill-session -t indexer

# Enable + start systemd-supervised indexer
sudo systemctl enable --now btc-stamps-indexer
indexer-logs   # tmux opens, live tail begins
```

Rollback to manual tmux is one command: `sudo systemctl disable --now btc-stamps-indexer` and start the tmux session again.

## Related

- #741 (merged): follow() now retries DB reconnects with backoff instead of exiting on first failure. systemd is the backstop for outages that exceed the retry window.
- Next operational follow-up (separate ticket): `OPTIMIZE TABLE stamp_holder_cache` + raise `tmp_table_size` in RDS parameter group, addresses the underlying cause of the 2026-05-19 storage-full event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)