### PR TITLE
chore: align dev MySQL temp-table ceilings with RDS + add storage/connection alarms

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,6 +9,8 @@ services:
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_unicode_ci
       --innodb-buffer-pool-size=3G
+      --tmp-table-size=268435456
+      --max-heap-table-size=268435456
       --mysql-native-password=ON
     volumes:
       - ./db_data:/var/lib/mysql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - .env.mysql
     # environment:
     #   - MYSQL_DATABASE=${RDS_DATABASE:-btc_stamps}
-    command: --bind-address=0.0.0.0 --innodb_data_file_path=ibdata1:10M:autoextend --innodb-buffer-pool-size=3G
+    command: --bind-address=0.0.0.0 --innodb_data_file_path=ibdata1:10M:autoextend --innodb-buffer-pool-size=3G --tmp-table-size=268435456 --max-heap-table-size=268435456
     ports:
       - "3306:3306"
     healthcheck:

--- a/indexer/docker-compose.local.yml
+++ b/indexer/docker-compose.local.yml
@@ -6,6 +6,9 @@ services:
     image: mysql:8.4.0
     command: >
       --bind-address=0.0.0.0
+      --innodb-buffer-pool-size=3G
+      --tmp-table-size=268435456
+      --max-heap-table-size=268435456
     volumes:
       - ./db_data:/var/lib/mysql
       - ./table_schema.sql:/docker-entrypoint-initdb.d/table_schema.sql

--- a/ops/RDS_PARAMETERS.md
+++ b/ops/RDS_PARAMETERS.md
@@ -1,0 +1,39 @@
+# RDS Parameter Parity
+
+Production RDS (`stamps-mysql-8-4` parameter group) and local Docker MySQL
+must share the same MySQL tuning so that dev/CI behavior matches prod and
+operations like `OPTIMIZE TABLE` don't hit a quiet behavioral gap.
+
+## Parameters
+
+| Parameter | Value | Notes |
+| --- | --- | --- |
+| `innodb_buffer_pool_size` | `3G` | Set in Docker compose; on RDS this is sized by instance class. |
+| `tmp_table_size` | `268435456` (256 MB) | Covers observed temp-table spikes from `OPTIMIZE TABLE stamp_holder_cache`. |
+| `max_heap_table_size` | `268435456` (256 MB) | Must equal `tmp_table_size` — MySQL caps in-memory temp tables to the smaller of the two. |
+
+## Where they are configured
+
+- **Production (RDS)**: parameter group `stamps-mysql-8-4`. Both parameters
+  are dynamic; `ApplyMethod=immediate` works, no reboot required.
+- **Local / dev**: passed as MySQL command-line flags in:
+  - `docker-compose.local.yml`
+  - `indexer/docker-compose.local.yml`
+  - `docker/docker-compose.yml`
+
+## Operational alarms
+
+The `stampminter` SNS topic
+(`arn:aws:sns:us-east-1:947253282047:stampminter`) receives SMS + email for
+existing RDS alarms. New alarms added in this PR:
+
+- `stamps-4-storage-low` — `FreeStorageSpace` < 10 GB
+- `stamps-4-database-connections-very-high` — `DatabaseConnections` > 500
+
+These complement the existing `stamps-4-database-connections-high` (>400)
+alarm to give earlier warning of pool-exhaustion incidents.
+
+## Maintenance follow-up
+
+After parameter group update, run `OPTIMIZE TABLE stamp_holder_cache`
+during a maintenance window to reclaim ~3.4 GB of unused space.

--- a/ops/RDS_PARAMETERS.md
+++ b/ops/RDS_PARAMETERS.md
@@ -23,9 +23,9 @@ operations like `OPTIMIZE TABLE` don't hit a quiet behavioral gap.
 
 ## Operational alarms
 
-The `stampminter` SNS topic
-(`arn:aws:sns:us-east-1:947253282047:stampminter`) receives SMS + email for
-existing RDS alarms. New alarms added in this PR:
+CloudWatch alarms on the production RDS instance route to the existing
+ops SNS topic (SMS + email). Topic ARN and subscriber list are managed
+out-of-band (see internal ops runbook). New alarms added in this PR:
 
 - `stamps-4-storage-low` — `FreeStorageSpace` < 10 GB
 - `stamps-4-database-connections-very-high` — `DatabaseConnections` > 500


### PR DESCRIPTION
## Summary
- Add `--tmp-table-size=268435456` and `--max-heap-table-size=268435456` (256 MB) to all three local `docker-compose` MySQL services so dev/CI match the prod RDS `stamps-mysql-8-4` parameter group ceilings being set in tandem with this PR.
- Also align `indexer/docker-compose.local.yml` to the same `innodb-buffer-pool-size=3G` already used by the other two compose files (it previously only set `--bind-address`).
- New `ops/RDS_PARAMETERS.md` documents the prod/dev parity contract and the SNS-routed alarms being added on the AWS side.

## Live AWS changes paired with this PR
Executed against prod alongside merging:
1. `stamps-mysql-8-4` parameter group: `tmp_table_size` and `max_heap_table_size` → `268435456` (256 MB), `ApplyMethod=immediate` (both dynamic — no reboot).
2. CloudWatch alarm `stamps-4-storage-low`: `FreeStorageSpace` < 10 GB → `stampminter` SNS topic (SMS + email, consistent with existing `stamps-4-database-connections-high`).
3. CloudWatch alarm `stamps-4-database-connections-very-high`: `DatabaseConnections` > 500 → same `stampminter` topic, complementing the existing >400 alarm with an earlier pool-exhaustion warning.

Maintenance follow-up (separate window): `OPTIMIZE TABLE stamp_holder_cache` to reclaim ~3.4 GB.

## Test plan
- [ ] `docker compose -f docker-compose.local.yml --profile with-db config` parses cleanly
- [ ] `docker compose -f indexer/docker-compose.local.yml --profile with-db config` parses cleanly
- [ ] `docker compose -f docker/docker-compose.yml config` parses cleanly
- [ ] Verify on prod RDS: `SHOW VARIABLES LIKE 'tmp_table_size'` and `LIKE 'max_heap_table_size'` both return `268435456`
- [ ] Verify both new CloudWatch alarms exist and have `stampminter` as the alarm action

🤖 Generated with [Claude Code](https://claude.com/claude-code)