### PR TITLE
fix: recover gracefully from RDS restart instead of hanging on dead sockets

### DIFF
--- a/indexer/src/index_core/database_manager.py
+++ b/indexer/src/index_core/database_manager.py
@@ -23,7 +23,7 @@ def _apply_socket_keepalive(connection: Connection) -> None:
     long past the application read_timeout.
     """
     try:
-        sock = connection._sock  # noqa: SLF001 — pymysql doesn't expose this
+        sock = connection._sock  # type: ignore[attr-defined]  # pymysql doesn't expose this in stubs
         if sock is None:
             return
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)

--- a/indexer/src/index_core/database_manager.py
+++ b/indexer/src/index_core/database_manager.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import queue
+import socket
 import threading
 import time
 from typing import Dict, Optional
@@ -12,6 +13,29 @@ from pymysql.connections import Connection
 from pymysql.cursors import Cursor
 
 logger = logging.getLogger(__name__)
+
+
+def _apply_socket_keepalive(connection: Connection) -> None:
+    """Enable TCP keepalive on a pymysql connection so the kernel detects
+    a dead RDS endpoint within minutes instead of waiting for the default
+    ~2-hour Linux idle timeout. Without this, a worker mid-recv() when RDS
+    is killed (e.g. storage-full shutdown) can hang on the dead socket
+    long past the application read_timeout.
+    """
+    try:
+        sock = connection._sock  # noqa: SLF001 — pymysql doesn't expose this
+        if sock is None:
+            return
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        # Idle 60s → first probe; probes every 10s × 6 → ~2 min to FIN a dead peer.
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+        if hasattr(socket, "TCP_KEEPCNT"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6)
+    except Exception as e:
+        logger.debug(f"Could not apply TCP keepalive to connection: {e}")
 
 
 class PooledConnection:
@@ -65,6 +89,7 @@ class ConnectionPool:
         """Create a new database connection."""
         try:
             connection = pymysql.connect(**self.connection_params)
+            _apply_socket_keepalive(connection)
             with self._lock:
                 self._active_connections[id(connection)] = connection
             return connection
@@ -78,11 +103,13 @@ class ConnectionPool:
             # Try to get a connection from the pool
             connection = self._pool.get(timeout=self.timeout)
 
-            # Verify the connection is still alive
+            # Verify the connection is still alive. Pre-ping with a tight
+            # timeout so a half-dead socket (e.g. RDS killed without sending
+            # RST) doesn't hang the borrower for the full read_timeout.
             try:
-                connection.ping(reconnect=True)
-            except Exception:
-                # Connection is dead, remove it and create a new one
+                connection.ping(reconnect=False)
+            except Exception as e:
+                logger.info(f"Pool: evicting stale connection ({e}); reconnecting")
                 self._remove_connection(connection)
                 connection = self._create_connection()
 
@@ -108,11 +135,14 @@ class ConnectionPool:
             return
 
         try:
-            # Verify the connection is still usable
-            connection.ping(reconnect=True)
+            # Verify the connection is still usable before returning to pool.
+            # reconnect=False — if the socket is dead we'd rather evict than
+            # block the returner on a re-handshake; the next borrower will
+            # create a fresh connection via _create_connection().
+            connection.ping(reconnect=False)
             self._pool.put(connection, timeout=self.timeout)
         except Exception as e:
-            logger.debug(f"Connection ping failed: {str(e)}")
+            logger.info(f"Pool: ping failed on return ({e}); evicting")
             self._remove_connection(connection)
 
     def _remove_connection(self, connection: Connection):
@@ -208,8 +238,13 @@ class DatabaseManager:
             self.max_retries = 5
             self.retry_delay = 5
             self.connect_timeout = 30
-            self.read_timeout = 3600
-            self.write_timeout = 3600
+            # Pool connections handle short queries (market data, lookups,
+            # block-loop writes). A 1-hour read_timeout used to mask dead
+            # sockets — when RDS was killed mid-recv(), workers hung up to
+            # an hour. 5 min covers every legitimate pool query; long ops
+            # (reparse, rebuild, sales_history) use get_long_running_connection().
+            self.read_timeout = int(os.environ.get("DB_READ_TIMEOUT", "300"))
+            self.write_timeout = int(os.environ.get("DB_WRITE_TIMEOUT", "300"))
             self.pool = None
             self._initialize_pool()
             self.__class__._initialized = True
@@ -291,7 +326,9 @@ class DatabaseManager:
                 "init_command": "SET SESSION wait_timeout=7200, max_execution_time=8640000",
             }
         )
-        return pymysql.connect(**params)
+        connection = pymysql.connect(**params)
+        _apply_socket_keepalive(connection)
+        return connection
 
     def connect(self) -> Connection:
         """Get a connection from the pool with retries."""

--- a/indexer/src/index_core/reparse/db_manager.py
+++ b/indexer/src/index_core/reparse/db_manager.py
@@ -6,6 +6,8 @@ import pymysql
 from pymysql.connections import Connection
 from pymysql.cursors import Cursor, DictCursor
 
+from index_core.database_manager import _apply_socket_keepalive
+
 logger = logging.getLogger(__name__)
 
 
@@ -78,6 +80,7 @@ class ReparseDBManager:
 
             # Connect to existing database
             self.connection = pymysql.connect(**params)
+            _apply_socket_keepalive(self.connection)
 
             # Create temporary tables
             with self.connection.cursor() as cursor:

--- a/indexer/tests/test_database_manager.py
+++ b/indexer/tests/test_database_manager.py
@@ -221,8 +221,8 @@ class TestDatabaseManager:
         assert db_manager.max_retries == 5
         assert db_manager.retry_delay == 5
         assert db_manager.connect_timeout == 30
-        assert db_manager.read_timeout == 3600
-        assert db_manager.write_timeout == 3600
+        assert db_manager.read_timeout == 300
+        assert db_manager.write_timeout == 300
 
     def test_database_manager_mock_mode(self):
         """Test DatabaseManager behavior in mock mode"""

--- a/indexer/tests/test_database_manager_migrated.py
+++ b/indexer/tests/test_database_manager_migrated.py
@@ -213,8 +213,8 @@ class TestDatabaseManagerMigrated:
         assert db_manager.max_retries == 5
         assert db_manager.retry_delay == 5
         assert db_manager.connect_timeout == 30
-        assert db_manager.read_timeout == 3600
-        assert db_manager.write_timeout == 3600
+        assert db_manager.read_timeout == 300
+        assert db_manager.write_timeout == 300
 
     def test_database_manager_mock_mode(self):
         """Test DatabaseManager behavior in mock mode."""


### PR DESCRIPTION
## Summary
On 2026-05-23 the indexer hung silently for 24 hours after an RDS storage-full auto-restart. systemd reported `active (running)` but PID 103850 sat in `futex_wait_queue` with no log output past 13:55:43. Root cause: worker threads holding pooled MySQL connections at the moment of the outage were blocked in `recv()` on dead TCP sockets, with no mechanism to detect the peer was gone short of the 1-hour application `read_timeout` or the ~2-hour Linux TCP keepalive default. The pool's pre-ping correctly evicts stale connections on *borrow*, but workers mid-query never get back to the borrow path.

This PR adds three layered defenses so RDS restarts recover within minutes instead of hours.

## Changes
- **Lower pool `read_timeout` / `write_timeout` from 3600s → 300s** (env-overridable via `DB_READ_TIMEOUT` / `DB_WRITE_TIMEOUT`). Every legitimate pool query completes in seconds; long-running ops (reparse, rebuild, sales_history, dispense) already use `get_long_running_connection()` which keeps its 24h timeout.
- **TCP `SO_KEEPALIVE` on every pymysql socket** (pool + long-running + reparse) with tuned timers: idle 60s, probes every 10s × 6 → kernel FINs a dead socket in ~2 min. Catches the case where RDS disappears without sending RST.
- **Pool pre-ping / return-ping switched to `reconnect=False`** so a half-dead socket can't block the borrower or returner on a re-handshake; eviction + a fresh `_create_connection()` is faster and now logs at INFO for visibility.

## Why these specifically
| Failure mode | What protects us now |
| --- | --- |
| RDS sends RST mid-query | recv() raises immediately → caller retry path engages |
| RDS sends FIN cleanly | recv() returns EOF → existing eviction works |
| RDS goes away with no signal (storage-full kill, network blackhole) | TCP keepalive FINs socket in ~2 min OR read_timeout fires in 5 min — whichever is first |
| Idle pool conn left across outage | Pre-ping on borrow catches it (already worked, now faster) |

## Test plan
- [x] `poetry run pytest tests/test_database_manager.py` — 38 passed
- [ ] Deploy to prod, monitor `journalctl -u btc-stamps-indexer -f` across the next planned/unplanned RDS event for clean recovery
- [ ] Confirm no false-positive evictions during normal operation (watch INFO log "Pool: evicting stale connection")
- [ ] Sanity: market-data workers continue to log token processing without `RuntimeError: Failed to acquire database connection` cascades

## Related
- Companion to #743 (`chore/rds-temp-table-tuning-and-storage-alarm`) — the storage alarm there would have paged 24h before the crash; this PR makes the *recovery* automatic so paging is informational rather than mandatory intervention.
- Builds on `c11c79f0` and `f7ad6eab` which handled the `follow()` main loop; this PR addresses the worker-thread leg of the same incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)