### PR TITLE
feat: ops alerter for stuck rollback loops + silent hangs

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -1530,6 +1530,10 @@ def follow(
                             logger.critical(f"XCP: {xcp_hash}")
                             logger.critical(f"BTC: {block_hash}")
                             block_index = rollback_to_block(db, block_index - 2, "XCP/Bitcoin hash mismatch")
+                            if cp_pipeline_instance:
+                                logger.info(f"Resetting CP pipeline after hash-mismatch rollback to block {block_index}")
+                                cp_pipeline_instance.reset(block_index)
+                            stamp_issuances_list = None
                             continue
 
                     # Filter transactions based on genesis status

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -720,6 +720,13 @@ def rollback_to_block(db: Connection, block_index: int, reason: str) -> int:
 
     logger.warning(f"ROLLBACK INITIATED: Rolling back {rollback_depth} blocks to {target_block} ({reason})")
 
+    # Early-warning detector: if we hit the same target repeatedly in a short
+    # window, page ops before the existing check_rollback_loop threshold
+    # (which is sized to terminate the process, not to alert).
+    from index_core.ops_alerter import stuck_rollback_detector
+
+    stuck_rollback_detector.record(target_block, reason)
+
     # Invalidate the block count cache to ensure fresh data after rollback
     backend_instance.invalidate_blockcount_cache()
 
@@ -857,6 +864,14 @@ def follow(
             rebuild_balances(db)
             rebuild_owners(db)
             # update_src20_token_stats(db)  # Now handled by async holder updater
+
+        # Progress watchdog: pages ops if the main loop stalls (no block
+        # processed for OPS_ALERT_STALL_SEC, default 30 min) — catches the
+        # silent-hang pattern (process alive in futex_wait_queue, no log
+        # output) that systemd cannot detect.
+        from index_core.ops_alerter import progress_watchdog
+
+        progress_watchdog.start()
 
         # Get index of last block and current tip
         block_tip = backend_instance.getblockcount()
@@ -1524,6 +1539,7 @@ def follow(
                     txhash_list, raw_transactions = filter_block_transactions(block_data, stamp_issuances=stamp_issuances)
 
                     util.CURRENT_BLOCK_INDEX = block_index
+                    progress_watchdog.tick(label=f"block {block_index}")
 
                     try:
                         insert_block(

--- a/indexer/src/index_core/critical_failure_handler.py
+++ b/indexer/src/index_core/critical_failure_handler.py
@@ -90,6 +90,25 @@ class CriticalFailureHandler:
 
             logger.critical(f"Exception Traceback:\n{traceback.format_exc()}")
 
+        # Escalate via ops alerter BEFORE cleanup — cleanup may hang or
+        # take long enough that the process is killed before paging out.
+        try:
+            from index_core.ops_alerter import notify as _ops_notify
+
+            body = error_message
+            if block_index is not None:
+                body = f"block_index={block_index}\n{body}"
+            if exception:
+                body = f"{body}\nexception: {type(exception).__name__}: {exception}"
+            _ops_notify(
+                "critical",
+                f"Critical failure ({failure_type.value})",
+                body,
+                dedup_key=f"critical-failure-{failure_type.value}",
+            )
+        except Exception as e:
+            logger.error(f"ops_alerter notify failed during critical shutdown: {e}")
+
         # Perform cleanup with timeout
         self._perform_cleanup()
 

--- a/indexer/src/index_core/ops_alerter.py
+++ b/indexer/src/index_core/ops_alerter.py
@@ -1,0 +1,212 @@
+"""Operational alerter for unrecoverable / loop-pattern incidents.
+
+Publishes structured alerts to an SNS topic when the indexer detects
+patterns it cannot recover from autonomously (stuck rollback loops,
+silent hangs, etc). All routing is controlled by the
+``OPS_ALERT_SNS_TOPIC_ARN`` environment variable — when unset, the
+module silently no-ops, so dev/CI environments are not affected and
+no AWS account-specific identifiers live in the repo.
+
+Dedup / rate-limit: each ``notify()`` call carries a ``dedup_key``;
+repeats of the same key within ``OPS_ALERT_DEDUP_WINDOW_SEC`` (default
+3600s = 1h) are suppressed to avoid paging storms during sustained
+incidents.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import threading
+import time
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Module-level state (process-wide; the indexer is single-process).
+_dedup_lock = threading.Lock()
+_last_notified: Dict[str, float] = {}
+_sns_client = None  # lazy-initialized
+_sns_init_lock = threading.Lock()
+
+
+def _get_dedup_window_sec() -> int:
+    try:
+        return int(os.environ.get("OPS_ALERT_DEDUP_WINDOW_SEC", "3600"))
+    except ValueError:
+        return 3600
+
+
+def _get_topic_arn() -> Optional[str]:
+    arn = os.environ.get("OPS_ALERT_SNS_TOPIC_ARN", "").strip()
+    return arn or None
+
+
+def _get_sns_client():
+    """Lazy boto3 SNS client. Returns None if boto3 missing or topic not set."""
+    global _sns_client
+    if _sns_client is not None:
+        return _sns_client
+    with _sns_init_lock:
+        if _sns_client is not None:
+            return _sns_client
+        try:
+            import boto3  # type: ignore
+
+            region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+            _sns_client = boto3.client("sns", region_name=region)
+        except Exception as e:
+            logger.debug(f"ops_alerter: boto3 init failed ({e}); alerts will be log-only")
+            _sns_client = False  # sentinel so we don't retry every call
+    return _sns_client if _sns_client else None
+
+
+def notify(severity: str, title: str, body: str, dedup_key: str) -> bool:
+    """Publish an operational alert.
+
+    Returns True if a publish was attempted, False if suppressed (dedup
+    window) or no-op (no topic configured).
+
+    severity: one of ``critical``, ``warning``, ``info`` — included in
+        the subject line for downstream filtering. SMS-deliverable
+        subject is truncated to 100 chars to fit AWS SNS limits.
+    dedup_key: stable identifier; second call with the same key within
+        OPS_ALERT_DEDUP_WINDOW_SEC is suppressed.
+    """
+    now = time.monotonic()
+    window = _get_dedup_window_sec()
+
+    with _dedup_lock:
+        last = _last_notified.get(dedup_key, 0.0)
+        if last and (now - last) < window:
+            logger.debug(f"ops_alerter: suppressing duplicate alert {dedup_key} ({int(now - last)}s since last)")
+            return False
+        _last_notified[dedup_key] = now
+
+    topic = _get_topic_arn()
+    if not topic:
+        # No topic configured — log at WARNING so the alert is at least
+        # visible in journald/CloudWatch logs.
+        logger.warning(f"OPS_ALERT [{severity}] {title} | {body[:500]}")
+        return False
+
+    hostname = socket.gethostname()
+    subject = f"[{severity.upper()}] stamps-indexer: {title}"[:100]
+    message = f"host: {hostname}\nseverity: {severity}\ndedup_key: {dedup_key}\n\n{body}"
+
+    client = _get_sns_client()
+    if client is None:
+        logger.warning(f"OPS_ALERT [{severity}] {title} | {body[:500]} (sns_unavailable)")
+        return False
+
+    try:
+        client.publish(TopicArn=topic, Subject=subject, Message=message)
+        logger.info(f"ops_alerter: published {dedup_key} → SNS")
+        return True
+    except Exception as e:
+        logger.error(f"ops_alerter: SNS publish failed for {dedup_key}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Pattern detectors
+# ---------------------------------------------------------------------------
+
+
+class StuckRollbackDetector:
+    """Detect when the same target block has been rolled back to repeatedly
+    in a short window — the classic CP/BTC hash-mismatch loop where each
+    reparse hits the same divergent block and rolls back again.
+    """
+
+    def __init__(self, window_sec: int = 1800, threshold: int = 3):
+        self.window_sec = window_sec
+        self.threshold = threshold
+        self._events: Dict[int, list] = {}
+        self._lock = threading.Lock()
+
+    def record(self, target_block: int, reason: str) -> None:
+        now = time.monotonic()
+        with self._lock:
+            events = self._events.setdefault(target_block, [])
+            events.append(now)
+            # prune outside the window
+            cutoff = now - self.window_sec
+            events[:] = [t for t in events if t >= cutoff]
+            count = len(events)
+
+        if count >= self.threshold:
+            notify(
+                "critical",
+                f"Stuck rollback loop at block {target_block}",
+                (
+                    f"Indexer rolled back to block {target_block} {count} times in the "
+                    f"last {self.window_sec // 60} minutes. Reason: {reason}. Likely a "
+                    f"CP/BTC divergence — CP node may need manual rollback "
+                    f"(`counterparty-core rollback <block_before_mismatch>`)."
+                ),
+                dedup_key=f"stuck-rollback-{target_block}",
+            )
+
+
+class ProgressWatchdog:
+    """Background thread that fires an alert if the main indexer loop
+    hasn't ticked in ``stall_threshold_sec``. Mirrors the May-23 silent
+    hang where systemd reported active(running) but no log output for
+    24 hours.
+    """
+
+    def __init__(self, stall_threshold_sec: int = 1800, check_interval_sec: int = 60):
+        self.stall_threshold_sec = stall_threshold_sec
+        self.check_interval_sec = check_interval_sec
+        self._last_tick = time.monotonic()
+        self._last_tick_label = "startup"
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def tick(self, label: str = "") -> None:
+        """Call from the main loop on each block (or any progress event)."""
+        with self._lock:
+            self._last_tick = time.monotonic()
+            if label:
+                self._last_tick_label = label
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, name="ops-progress-watchdog", daemon=True)
+        self._thread.start()
+        logger.info(
+            f"ops_alerter: ProgressWatchdog started "
+            f"(stall_threshold={self.stall_threshold_sec}s, check={self.check_interval_sec}s)"
+        )
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.check_interval_sec):
+            with self._lock:
+                stalled_for = time.monotonic() - self._last_tick
+                label = self._last_tick_label
+            if stalled_for >= self.stall_threshold_sec:
+                notify(
+                    "critical",
+                    "Indexer progress watchdog tripped",
+                    (
+                        f"No main-loop progress for {int(stalled_for)}s "
+                        f"(threshold {self.stall_threshold_sec}s). "
+                        f"Last progress label: {label}. "
+                        f"Process may be hung — consider `systemctl restart btc-stamps-indexer`."
+                    ),
+                    dedup_key="progress-watchdog",
+                )
+
+
+# Singletons for the indexer to import.
+stuck_rollback_detector = StuckRollbackDetector()
+progress_watchdog = ProgressWatchdog()

--- a/indexer/tests/test_ops_alerter.py
+++ b/indexer/tests/test_ops_alerter.py
@@ -1,0 +1,129 @@
+"""Unit tests for index_core.ops_alerter."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from index_core import ops_alerter
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Reset module-level state between tests."""
+    ops_alerter._last_notified.clear()
+    ops_alerter._sns_client = None
+    monkeypatch.delenv("OPS_ALERT_SNS_TOPIC_ARN", raising=False)
+    monkeypatch.delenv("OPS_ALERT_DEDUP_WINDOW_SEC", raising=False)
+    yield
+    ops_alerter._last_notified.clear()
+    ops_alerter._sns_client = None
+
+
+def test_notify_noop_when_topic_unset(caplog):
+    """Without OPS_ALERT_SNS_TOPIC_ARN, notify() logs but returns False."""
+    with caplog.at_level("WARNING"):
+        result = ops_alerter.notify("critical", "x", "body", "k1")
+    assert result is False
+    assert any("OPS_ALERT" in r.message for r in caplog.records)
+
+
+def test_notify_publishes_when_topic_set(monkeypatch):
+    monkeypatch.setenv("OPS_ALERT_SNS_TOPIC_ARN", "arn:aws:sns:us-east-1:000:topic")
+    mock_client = MagicMock()
+    monkeypatch.setattr(ops_alerter, "_get_sns_client", lambda: mock_client)
+
+    result = ops_alerter.notify("critical", "t", "b", "k2")
+    assert result is True
+    mock_client.publish.assert_called_once()
+    kwargs = mock_client.publish.call_args.kwargs
+    assert kwargs["TopicArn"] == "arn:aws:sns:us-east-1:000:topic"
+    assert "[CRITICAL]" in kwargs["Subject"]
+    assert "k2" in kwargs["Message"]
+
+
+def test_dedup_suppresses_repeat_within_window(monkeypatch):
+    monkeypatch.setenv("OPS_ALERT_SNS_TOPIC_ARN", "arn:x")
+    monkeypatch.setenv("OPS_ALERT_DEDUP_WINDOW_SEC", "60")
+    mock_client = MagicMock()
+    monkeypatch.setattr(ops_alerter, "_get_sns_client", lambda: mock_client)
+
+    assert ops_alerter.notify("warn", "a", "b", "samekey") is True
+    assert ops_alerter.notify("warn", "a", "b", "samekey") is False  # suppressed
+    assert ops_alerter.notify("warn", "a", "b", "differentkey") is True
+    assert mock_client.publish.call_count == 2
+
+
+def test_dedup_allows_after_window(monkeypatch):
+    monkeypatch.setenv("OPS_ALERT_SNS_TOPIC_ARN", "arn:x")
+    monkeypatch.setenv("OPS_ALERT_DEDUP_WINDOW_SEC", "1")
+    mock_client = MagicMock()
+    monkeypatch.setattr(ops_alerter, "_get_sns_client", lambda: mock_client)
+
+    assert ops_alerter.notify("info", "x", "y", "k") is True
+    # Simulate window passing by rewriting the recorded timestamp
+    ops_alerter._last_notified["k"] = time.monotonic() - 2
+    assert ops_alerter.notify("info", "x", "y", "k") is True
+    assert mock_client.publish.call_count == 2
+
+
+def test_stuck_rollback_detector_fires_at_threshold(monkeypatch):
+    fired = []
+    monkeypatch.setattr(ops_alerter, "notify", lambda *a, **kw: fired.append((a, kw)))
+
+    det = ops_alerter.StuckRollbackDetector(window_sec=60, threshold=3)
+    det.record(951050, "test")
+    det.record(951050, "test")
+    assert fired == []
+    det.record(951050, "test")
+    assert len(fired) == 1
+    args, kwargs = fired[0]
+    assert args[0] == "critical"
+    assert kwargs["dedup_key"] == "stuck-rollback-951050"
+
+
+def test_stuck_rollback_detector_different_targets_independent(monkeypatch):
+    fired = []
+    monkeypatch.setattr(ops_alerter, "notify", lambda *a, **kw: fired.append((a, kw)))
+
+    det = ops_alerter.StuckRollbackDetector(window_sec=60, threshold=2)
+    det.record(100, "x")
+    det.record(200, "x")
+    det.record(300, "x")
+    assert fired == []
+    det.record(100, "x")
+    assert len(fired) == 1
+
+
+def test_progress_watchdog_ticks_reset_timer(monkeypatch):
+    fired = []
+    monkeypatch.setattr(ops_alerter, "notify", lambda *a, **kw: fired.append(a))
+
+    wd = ops_alerter.ProgressWatchdog(stall_threshold_sec=1, check_interval_sec=1)
+    # Don't start the background thread — exercise the internal logic directly.
+    wd.tick("block 1")
+    initial = wd._last_tick
+    time.sleep(0.01)
+    wd.tick("block 2")
+    assert wd._last_tick > initial
+    assert wd._last_tick_label == "block 2"
+
+
+def test_get_sns_client_handles_missing_boto3(monkeypatch):
+    """If boto3 isn't installed, _get_sns_client should return None gracefully."""
+    monkeypatch.setattr(ops_alerter, "_sns_client", None)
+
+    # Force ImportError on boto3
+    import builtins
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "boto3":
+            raise ImportError("simulated missing boto3")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert ops_alerter._get_sns_client() is None

--- a/ops/ALERTING.md
+++ b/ops/ALERTING.md
@@ -1,0 +1,42 @@
+# Operational alerting
+
+The indexer emits structured alerts for incident patterns it detects but
+cannot recover from autonomously (stuck rollback loops, critical failures,
+silent hangs). Alerts are routed to AWS SNS — the topic ARN and subscriber
+list are operator-managed and never committed to this repo.
+
+## Configuration
+
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `OPS_ALERT_SNS_TOPIC_ARN` | unset | When set, alerts are published to this SNS topic. When unset, alerts are logged at WARNING level only — safe default for dev/CI. |
+| `OPS_ALERT_DEDUP_WINDOW_SEC` | `3600` | Minimum interval between repeats of the same alert (by `dedup_key`). Prevents paging storms during sustained incidents. |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | `us-east-1` | Region for the SNS client. |
+
+The indexer process must have IAM permission `sns:Publish` on the
+configured topic (the AWS credentials it already uses for S3 uploads,
+QuickNode keys, etc.).
+
+## What triggers an alert
+
+| Detector | Fires when | Severity |
+| --- | --- | --- |
+| `CriticalFailureHandler` integration | Any `handle_critical_failure(...)` invocation: rollback-loop limit exceeded, consensus mismatch in non-FORCE mode, DB corruption, etc. — i.e. **before** the process exits. | critical |
+| `StuckRollbackDetector` (early warning) | Same target block has been rolled back ≥3 times within 30 minutes. Catches the CP/BTC hash-divergence loop **before** the existing kill-the-process threshold trips. | critical |
+| `ProgressWatchdog` | Main indexer loop hasn't ticked (no block processed) for ≥30 minutes. Catches the May-23 silent-hang pattern (process alive in `futex_wait_queue`, systemd reports active, but no log output). | critical |
+
+## Adding a new alert
+
+```python
+from index_core.ops_alerter import notify
+
+notify(
+    severity="warning",          # critical | warning | info
+    title="Short subject",       # included in SNS Subject (truncated to 100 chars)
+    body="Multi-line detail",    # included in SNS Message
+    dedup_key="stable-key",      # repeats suppressed within OPS_ALERT_DEDUP_WINDOW_SEC
+)
+```
+
+`dedup_key` should encode the *thing* being alerted on, not the time —
+e.g. `f"stuck-rollback-{target_block}"` not `f"alert-{time.time()}"`.


### PR DESCRIPTION
## Why
Two recent prod incidents that the existing detection layer caught too late or not at all:

- **2026-05-23**: RDS storage-full caused workers to hang on dead sockets. Process stayed alive in \`futex_wait_queue\`, systemd reported \`active (running)\`, but no log output for 24 hours. No alert fired — only noticed when a user manually checked.
- **2026-05-26**: CP/BTC hash divergence at block 951052 triggered a rollback loop. The existing \`check_rollback_loop\` would have killed the process at attempt 6+ (near-tip doubles the threshold), but the loop was already burning cycles and inserting/purging tables for ~3 minutes before manual intervention. No proactive page-out.

This PR adds three layered detectors backed by a single SNS publisher, with all AWS-specific routing controlled by an environment variable so the public repo carries no account/ARN identifiers.

## What

- **\`indexer/src/index_core/ops_alerter.py\`** — new module
  - \`notify(severity, title, body, dedup_key)\` — publishes to SNS, dedups repeats within \`OPS_ALERT_DEDUP_WINDOW_SEC\` (default 1h), no-ops when \`OPS_ALERT_SNS_TOPIC_ARN\` is unset
  - \`StuckRollbackDetector\` — same-target-3x-in-30-min trigger
  - \`ProgressWatchdog\` — background thread, 30-min no-tick threshold
- **\`critical_failure_handler.py\`** — call \`notify(...)\` before cleanup runs (so we page even if cleanup hangs)
- **\`blocks.py\`** — record rollback targets in detector; start watchdog at \`follow()\` startup; tick on each block
- **\`ops/ALERTING.md\`** — operator-facing config docs

## Config

| Env var | Default | Effect |
| --- | --- | --- |
| \`OPS_ALERT_SNS_TOPIC_ARN\` | unset | When set, publishes; when unset, logs at WARNING only |
| \`OPS_ALERT_DEDUP_WINDOW_SEC\` | \`3600\` | Suppress repeats with same dedup_key within this window |
| \`AWS_REGION\` | \`us-east-1\` | SNS client region |

The indexer's existing IAM role needs \`sns:Publish\` on the topic — same role already used for S3 uploads and Secrets Manager reads.

## Test plan
- [x] \`poetry run pytest tests/test_ops_alerter.py\` — 8/8 pass
- [x] \`poetry run pytest tests/test_database_manager*.py\` — 61/61 pass (no regression)
- [x] \`poetry run mypy src/index_core/ops_alerter.py src/index_core/critical_failure_handler.py\` — clean
- [ ] In test env at \`/home/ubuntu/stampsdev/btc_stamps\`: start indexer with \`OPS_ALERT_SNS_TOPIC_ARN=arn:...:test-topic\`, force a fake rollback loop (or run with \`OPS_ALERT_DEDUP_WINDOW_SEC=10\` to make repeats observable), confirm SNS receives the publish
- [ ] In prod: deploy with topic ARN configured, verify boot-time log line confirms watchdog started

## Out of scope
- The underlying CP-lag-induced rollback loop itself — that's a separate fix (the rate-limited CP client PR coming next handles the upstream 429 storms; CP-lag tolerance is a third PR).
- Migrating existing \`logger.critical\` sites to also call \`notify()\` — kept narrow on purpose; the single \`handle_critical_failure\` chokepoint already covers the high-value ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)