### PR TITLE
docs(env): document DB_*_TIMEOUT (#744) and OPS_ALERT_* (#745)

### DIFF
--- a/indexer/.env.sample
+++ b/indexer/.env.sample
@@ -148,6 +148,12 @@ RDS_PORT=3306
 DB_MIN_CONNECTIONS=3
 DB_MAX_CONNECTIONS=10
 DB_POOL_TIMEOUT=30
+# Per-query read/write timeout for pool connections (seconds). Long-running
+# ops (reparse, rebuild, sales_history) use a separate connection with its
+# own 24h timeout. Default 300s is enough for every legitimate pool query
+# and keeps dead-socket detection tight after an RDS restart.
+DB_READ_TIMEOUT=300
+DB_WRITE_TIMEOUT=300
 
 # Production Database Settings (for comparison tools)
 # ST3_HOSTNAME=your_prod_host
@@ -307,3 +313,17 @@ ENABLE_ASYNC_HOLDER_UPDATES=false
 
 # Block configuration for testnet
 # BLOCK_FIRST_TESTNET=2979826
+
+# =============================================================================
+# OPERATIONAL ALERTING (SNS)
+# =============================================================================
+# When set, the indexer publishes critical alerts (stuck rollback loops,
+# silent hangs, consensus failures) to this SNS topic. When unset, alerts
+# are logged at WARNING level only — safe default for dev/CI.
+# The indexer's IAM role must have sns:Publish on this topic.
+# Topic ARN is operator-managed; never commit a real ARN to the repo.
+# OPS_ALERT_SNS_TOPIC_ARN=arn:aws:sns:us-east-1:000000000000:your-topic
+
+# Dedup window for repeat alerts (seconds). Repeats of the same dedup_key
+# within this window are suppressed to avoid paging storms.
+OPS_ALERT_DEDUP_WINDOW_SEC=3600


### PR DESCRIPTION
Both #744 and #745 introduced env vars that didn't make it into \`indexer/.env.sample\`. This PR catches up the sample file so new operators have a complete reference.

## Added

| Var | Source | Default | Purpose |
| --- | --- | --- | --- |
| \`DB_READ_TIMEOUT\` | #744 | \`300\` | Pool connection per-query read timeout (seconds). Long-running ops use a separate 24h connection. |
| \`DB_WRITE_TIMEOUT\` | #744 | \`300\` | Same, for writes. |
| \`OPS_ALERT_SNS_TOPIC_ARN\` | #745 | unset | When set, publishes critical alerts (stuck rollback loops, silent hangs, consensus failures). When unset, alerts log at WARNING only. |
| \`OPS_ALERT_DEDUP_WINDOW_SEC\` | #745 | \`3600\` | Repeat-suppression window for same dedup_key. |

Sample ARN in the file uses \`000000000000\` placeholder — operators substitute their real ARN at deployment time, never committed.

## Test plan
- [x] Diff matches the env vars actually read in source (\`DatabaseManager.__init__\`, \`ops_alerter._get_topic_arn\`, etc.)
- [ ] Spot-check on \`/home/ubuntu/stampsdev/btc_stamps\`: cp .env.sample .env, fill blanks, indexer boots without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)