### PR TITLE
fix(consensus): pin libmagic to 5.41 to anchor MIME classification

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,6 +1,23 @@
 # Build stage
 ARG PYTHON_VERSION=3.12
 ARG INSTALL_DEV=false
+
+# Consensus-anchor stage: libmagic 5.41 from Ubuntu 22.04.
+# The indexer's txlist_hash depends on libmagic's MIME classification of stamp
+# bytes (file_suffix flows into is_btc_stamp which is hashed). The CHECKPOINTS
+# in indexer/src/index_core/check.py were generated against libmagic 5.41;
+# python:3.12-slim's Debian trixie base ships 5.46 which classifies some
+# ambiguous content (e.g. truncated-ZIP-header stamps in block 783727) as
+# application/octet-stream instead of application/zip, flipping is_btc_stamp
+# and diverging txlist_hash from 783727 onward. We vendor the 5.41 binaries
+# from Ubuntu 22.04 into the runtime stage to lock the consensus classifier.
+# See magic_consensus.py for the startup assertion that fails loud on drift.
+FROM ubuntu:22.04 AS libmagic-anchor
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libmagic1=1:5.41-3ubuntu0.1 \
+    libmagic-mgc=1:5.41-3ubuntu0.1 \
+    && rm -rf /var/lib/apt/lists/*
+
 FROM python:${PYTHON_VERSION}-slim AS builder
 
 # Build arguments
@@ -70,10 +87,11 @@ ENV PYTHONPATH=/app:/app/src \
 
 WORKDIR /app
 
-# Install system/runtime dependencies
+# Install system/runtime dependencies.
+# NOTE: libmagic is NOT installed here — it's pulled from the libmagic-anchor
+# stage below to pin it to the consensus-anchor version (5.41). See top of file.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
-    libmagic1 \
     default-libmysqlclient-dev \
     default-mysql-client \
     libgmp-dev \
@@ -82,6 +100,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     netcat-traditional \
     && rm -rf /var/lib/apt/lists/*
+
+# Vendor libmagic 5.41 from the anchor stage. The .so and .mgc files together
+# define the consensus classifier; both must come from the same libmagic build
+# (the .mgc binary format is not forward-compatible across major versions —
+# verified: a 5.41 .mgc fails to load under 5.46 with "Size … not a multiple
+# of 432"). magic_consensus.py asserts the runtime version and the .mgc sha256
+# at startup, so any accidental drift fails loud rather than silently breaking
+# txlist_hash. amd64 hardcoded here; add an arm64 COPY if/when arm64 images
+# are built.
+COPY --from=libmagic-anchor /usr/lib/x86_64-linux-gnu/libmagic.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=libmagic-anchor /usr/lib/file/magic.mgc /usr/lib/file/magic.mgc
+COPY --from=libmagic-anchor /usr/share/misc/magic.mgc /usr/share/misc/magic.mgc
 
 # Install dockerize (optional)
 ARG TARGETARCH

--- a/indexer/src/index_core/magic_consensus.py
+++ b/indexer/src/index_core/magic_consensus.py
@@ -1,0 +1,108 @@
+"""
+Consensus-anchor assertion for libmagic.
+
+The txlist_hash depends on libmagic's MIME classification of stamp bytes
+(file_suffix → is_btc_stamp → ValidStamp dict → str(list) → sha256). The
+CHECKPOINTS in check.py were generated against libmagic 5.41. Drift to a
+newer libmagic silently flips is_btc_stamp on classification-borderline
+stamps (e.g. the 2023-byte ZIP-header stamp 7d6a382d… in block 783727 that
+5.41 calls application/zip and 5.46 calls application/octet-stream) and
+diverges every subsequent block's txlist_hash.
+
+This module verifies at startup that the loaded libmagic matches the
+consensus anchor and fails loud otherwise. The Dockerfile vendors the 5.41
+binaries from Ubuntu 22.04; on host (systemd) installs, operators must
+`apt-mark hold libmagic1 libmagic-mgc` on Ubuntu 22.04.
+"""
+
+import ctypes
+import ctypes.util
+import hashlib
+import logging
+import os
+
+import config
+
+logger = logging.getLogger(__name__)
+
+# libmagic.magic_version() returns the version as an integer: 5.41 → 541.
+CONSENSUS_LIBMAGIC_VERSION = 541
+
+# sha256 of the libmagic-mgc 1:5.41-3ubuntu0.1 magic database, as shipped by
+# Ubuntu 22.04. Verified identical on the host's /usr/lib/file/magic.mgc and
+# /usr/share/misc/magic.mgc (both are the same file from the same package),
+# and identical to the file copied out of an `ubuntu:22.04` Docker image.
+CONSENSUS_MAGIC_MGC_SHA256 = "5d82f8f7172ab254d0241a7a558fe3a7a9d88cbb4bc6c8828c6bd48fd80cd228"
+
+# libmagic searches these paths in order. We check both because some libmagic
+# builds default to /usr/share/misc and some to /usr/lib/file; if either one
+# drifts the wrong build could load the wrong file.
+_MGC_PATHS = ("/usr/lib/file/magic.mgc", "/usr/share/misc/magic.mgc")
+
+
+def _read_libmagic_runtime_version() -> int:
+    """Returns the integer version reported by the loaded libmagic.so (e.g. 541)."""
+    libname = ctypes.util.find_library("magic") or "libmagic.so.1"
+    lib = ctypes.CDLL(libname)
+    lib.magic_version.restype = ctypes.c_int
+    return int(lib.magic_version())
+
+
+def _sha256_file(path: str) -> str:
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def assert_consensus_libmagic() -> None:
+    """
+    Verify the runtime libmagic matches the consensus anchor.
+
+    Logs all observed values (loud audit trail) and raises ConsensusError if
+    anything drifts. Honors config.FORCE: with FORCE=True the mismatch is
+    downgraded to a WARNING for operators who knowingly want to run a
+    non-canonical build (e.g. a reparse-and-recheckpoint workflow).
+    """
+    runtime_version = _read_libmagic_runtime_version()
+    logger.info("libmagic runtime version: %d (consensus anchor: %d)",
+                runtime_version, CONSENSUS_LIBMAGIC_VERSION)
+
+    mgc_hashes = {}
+    for path in _MGC_PATHS:
+        if os.path.exists(path):
+            mgc_hashes[path] = _sha256_file(path)
+            logger.info("libmagic database sha256: %s = %s", path, mgc_hashes[path])
+        else:
+            logger.warning("libmagic database missing at expected path: %s", path)
+
+    problems = []
+    if runtime_version != CONSENSUS_LIBMAGIC_VERSION:
+        problems.append(
+            f"libmagic runtime version {runtime_version} != consensus anchor "
+            f"{CONSENSUS_LIBMAGIC_VERSION}"
+        )
+    for path, observed in mgc_hashes.items():
+        if observed != CONSENSUS_MAGIC_MGC_SHA256:
+            problems.append(
+                f"libmagic database sha256 mismatch at {path}: "
+                f"observed {observed}, expected {CONSENSUS_MAGIC_MGC_SHA256}"
+            )
+
+    if not problems:
+        return
+
+    detail = (
+        "libmagic consensus drift detected — txlist_hash will diverge from "
+        "CHECKPOINTS_MAINNET. Fix:\n"
+        "  Docker:  rebuild from the supplied Dockerfile (vendors libmagic "
+        "5.41 from ubuntu:22.04)\n"
+        "  Host:    `sudo apt install libmagic1=1:5.41-3ubuntu0.1 "
+        "libmagic-mgc=1:5.41-3ubuntu0.1 && sudo apt-mark hold libmagic1 "
+        "libmagic-mgc`  (Ubuntu 22.04 only)\n"
+        "Details:\n  - " + "\n  - ".join(problems)
+    )
+
+    if getattr(config, "FORCE", False):
+        logger.warning("FORCE mode: ignoring libmagic consensus drift. %s", detail)
+        return
+
+    raise RuntimeError(detail)

--- a/indexer/src/index_core/server.py
+++ b/indexer/src/index_core/server.py
@@ -168,6 +168,11 @@ def initialize_config(
         logger.error(f"SHA Hash Inconsistencies: {e}")
         raise e
 
+    # libmagic is consensus-critical: its MIME classification of stamp bytes
+    # feeds is_btc_stamp which feeds txlist_hash. Fail-loud on drift.
+    from index_core.magic_consensus import assert_consensus_libmagic
+    assert_consensus_libmagic()
+
     # Data directory
     data_dir = appdirs.user_data_dir(appauthor=config.STAMPS_NAME, appname=config.APP_NAME, roaming=True)
     if not os.path.isdir(data_dir):


### PR DESCRIPTION
## Summary

The indexer's `txlist_hash` transitively depends on the host's `libmagic` version. `CHECKPOINTS_MAINNET` in `check.py` was generated against libmagic **5.41** (Ubuntu 22.04). The Docker base `python:3.x-slim` (Debian trixie) ships libmagic **5.46**, which silently classifies some borderline content differently — flipping `is_btc_stamp` and diverging `txlist_hash` from **block 783727** onward. Empirically verified on stamp `7d6a382d…` (a 2023-byte ZIP-header file): 5.41 → `application/zip` (valid); 5.46 → `application/octet-stream` (in `INVALID_BTC_STAMP_SUFFIX`).

This PR locks libmagic at the consensus-anchor version (5.41) and adds a startup assertion that fails loud on any future drift.

## What changed

- **`indexer/Dockerfile`** — add `libmagic-anchor` stage (`ubuntu:22.04`, libmagic pinned to `1:5.41-3ubuntu0.1`); remove the apt install of `libmagic1` from the runtime stage; COPY the `libmagic.so*` and both `magic.mgc` paths from the anchor into the trixie-based runtime. The compiled `.mgc` binary format is not forward-compatible across libmagic majors, so both the `.so` and `.mgc` must move together.
- **`indexer/src/index_core/magic_consensus.py`** (new) — startup assertion that reads `libmagic.magic_version()` via ctypes, sha256s both system `magic.mgc` paths, and raises with explicit remediation steps if anything drifts. Honors `config.FORCE` to downgrade to WARNING (consistent with `consensus_hash()` semantics).
- **`indexer/src/index_core/server.py`** — call the assertion in `initialize_config()` alongside the existing sha256/sha3_256 consistency checks.

## How the divergence flows into the hash

```
enhanced_mime_detection.py:184/204     magic.from_buffer(content_bytes, mime=True)   ← version-sensitive
  ↓
models.py:424                          self.file_suffix = mime_type.split("/")[-1]
  ↓
models.py:706/724/732/736              is_btc_stamp ← file_suffix in INVALID_BTC_STAMP_SUFFIX
  ↓
stamp.py:105-114                       ValidStamp dict (8 fields, includes is_btc_stamp)
  ↓
block_validation.py:62                 txlist_content = str(sorted_valid_stamps)
  ↓
check.py:247 → util.py:103             sha256(sha256(bytes(str(...), "utf-8")))
```

Flipping one bool in one stamp's dict at block 783727 changes one character in `str(...)` → cascading hash divergence.

## Test plan

Empirical, on this branch:

- [x] Host (libmagic 5.41) — assertion PASS
- [x] Unpinned `python:3.12-slim` (libmagic 5.46) — assertion FAILs loud with full diagnostic + remediation
- [x] Vendored-5.41-in-trixie image (the exact runtime the patched Dockerfile produces) — assertion PASS
- [x] `libmagic-anchor` stage builds, ships `libmagic-mgc 1:5.41-3ubuntu0.1`, sha256 = `5d82f8f7172ab254d0241a7a558fe3a7a9d88cbb4bc6c8828c6bd48fd80cd228`
- [x] Stamp `7d6a382d…` (block 783727) under vendored binaries → `application/zip` (canonical 5.41 answer)
- [ ] **CI**: full Dockerfile end-to-end build (Rust + Poetry, ~30 min)
- [ ] **Pre-merge**: reparse from block 783727 on a scratch DB under the patched image, confirm hashes match `CHECKPOINTS_MAINNET` at 785000 / 790000 / 795000

## Operational note for host (systemd) operators

Already applied on the index host:

```sh
sudo apt-mark hold libmagic1 libmagic-mgc
```

And added to `/etc/apt/apt.conf.d/50unattended-upgrades` Package-Blacklist:

```
"libmagic1$";
"libmagic-mgc$";
```

The startup assertion catches drift either way (Docker or host).

## Side effects / non-effects

- **No checkpoint regeneration needed.** This PR *preserves* the current consensus behavior by locking the classifier to the libmagic the existing checkpoints were generated against. It is not a hard fork.
- **No indexed-data change.** Stamps, balances, owners, sends: unchanged.
- **Repo size: unchanged.** Binaries come from Ubuntu's apt repo at Docker build time; nothing vendored.
- **arm64 not yet covered.** The runtime-stage `COPY` uses `/usr/lib/x86_64-linux-gnu/`. If arm64 images are in the release matrix, add a parallel `COPY --from=libmagic-anchor /usr/lib/aarch64-linux-gnu/libmagic.so* /usr/lib/aarch64-linux-gnu/`. Flagged with a comment in the Dockerfile.
- **Ubuntu jammy retirement risk (April 2027).** When `5.41-3ubuntu0.1` is superseded or jammy drops out of standard support, the apt pin breaks the build. Mitigations later: switch to ESM repos or vendor the `.deb` directly. Not blocking.

## Out of scope (separate follow-up)

`block_validation.py:62-72` hashes `str(list_of_dicts)` directly. Locking libmagic closes the immediate consensus hole, but `str()` over dicts is a latent risk for other reasons (any Python `repr` change for bytes / floats / None could break consensus). Switching to a deterministic encoder is a hard fork (regenerate every checkpoint), so it should be planned as its own change with a block-height activation gate. No data-semantics change, hash columns only — but still a coordinated upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)