### PR TITLE
fix(fetch_utils): probe expected count before accepting empty block

### DIFF
--- a/indexer/src/index_core/fetch_utils.py
+++ b/indexer/src/index_core/fetch_utils.py
@@ -1020,8 +1020,33 @@ async def _validate_block_data_completeness(block_index: int, block_data: Dict[s
         # Check for suspiciously low transaction count
         tx_count = len(transactions)
         if tx_count == 0:
-            logger.debug(f"Block {block_index}: No transactions found - empty block")
-            # Empty blocks are possible, so we don't fail validation
+            # Empty CP blocks are normal — Bitcoin blocks often have no CP-relevant
+            # transactions. But "0 transactions" can also mean CP returned a partial
+            # response during a hiccup. Cross-check against result_count before
+            # accepting. Without this guard, a transient empty response silently
+            # drops every issuance/transfer in the block (see incident with
+            # A15716034302284605000 at block 954140).
+            try:
+                probe = await fetch_xcp_async(
+                    f"/blocks/{block_index}/transactions",
+                    {"verbose": "false", "limit": "1"},
+                    timeout=30,
+                )
+                expected = probe.get("result_count") if probe else None
+            except Exception as e:
+                logger.warning(
+                    f"Block {block_index}: count probe failed ({e}); " f"accepting 0-tx as empty block (cannot verify)"
+                )
+                return True
+
+            if expected is not None and expected > 0:
+                logger.error(
+                    f"Block {block_index}: CP says {expected} transactions exist "
+                    f"but fetcher returned 0 — refusing to index incomplete data"
+                )
+                return False
+
+            logger.debug(f"Block {block_index}: No transactions found - empty block (verified)")
             return True
 
         # Check if we hit pagination limits

--- a/indexer/tests/test_fetch_utils_validate_block.py
+++ b/indexer/tests/test_fetch_utils_validate_block.py
@@ -1,0 +1,73 @@
+"""Tests for _validate_block_data_completeness empty-block guard.
+
+Covers the regression where a transient 0-transactions response from CP was
+accepted as a legitimate empty block, silently dropping any issuances/transfers
+in that block (see incident with A15716034302284605000 in block 954140).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from index_core.fetch_utils import _validate_block_data_completeness
+
+
+@pytest.mark.asyncio
+async def test_empty_block_accepted_when_probe_confirms_zero():
+    """Block truly empty (CP says 0 too) — accept."""
+    block_data = {"transactions": []}
+    with patch(
+        "index_core.fetch_utils.fetch_xcp_async",
+        new=AsyncMock(return_value={"result": [], "result_count": 0}),
+    ):
+        assert await _validate_block_data_completeness(900000, block_data) is True
+
+
+@pytest.mark.asyncio
+async def test_empty_block_rejected_when_probe_says_nonzero():
+    """Fetcher returned 0 but CP says there are transactions — reject so caller retries."""
+    block_data = {"transactions": []}
+    with patch(
+        "index_core.fetch_utils.fetch_xcp_async",
+        new=AsyncMock(return_value={"result": [], "result_count": 7}),
+    ):
+        assert await _validate_block_data_completeness(900000, block_data) is False
+
+
+@pytest.mark.asyncio
+async def test_empty_block_accepted_when_probe_fails():
+    """Probe network failure — fall back to current behavior (accept) so the
+    validator isn't a new outage vector."""
+    block_data = {"transactions": []}
+    with patch(
+        "index_core.fetch_utils.fetch_xcp_async",
+        new=AsyncMock(side_effect=Exception("simulated network failure")),
+    ):
+        assert await _validate_block_data_completeness(900000, block_data) is True
+
+
+@pytest.mark.asyncio
+async def test_empty_block_accepted_when_probe_has_no_count_field():
+    """Probe succeeds but response is malformed (no result_count) — accept."""
+    block_data = {"transactions": []}
+    with patch(
+        "index_core.fetch_utils.fetch_xcp_async",
+        new=AsyncMock(return_value={"result": []}),
+    ):
+        assert await _validate_block_data_completeness(900000, block_data) is True
+
+
+@pytest.mark.asyncio
+async def test_nonempty_block_skips_probe():
+    """When the fetcher returned transactions, the count probe is never reached."""
+    block_data = {"transactions": [{"tx_hash": "deadbeef" * 8}]}
+    mock_fetch = AsyncMock()
+    with patch("index_core.fetch_utils.fetch_xcp_async", new=mock_fetch):
+        assert await _validate_block_data_completeness(900000, block_data) is True
+    mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_transactions_field_rejected():
+    """Pre-existing behavior preserved: missing key fails fast."""
+    assert await _validate_block_data_completeness(900000, {}) is False


### PR DESCRIPTION
## Summary

Counterparty-relevant transactions are silently dropped when CP returns 0 transactions for a block under stress. The block-data validator accepted every \`0 transactions\` response as a legitimate empty block, with no cross-check against CP's own count.

## Reproduction (today)

Stamp asset \`A15716034302284605000\` was issued in Bitcoin block **954140**. Counterparty (both local and public nodes) has the issuance fully recorded — \`transaction_type=issuance\`, \`status=valid\`, \`description=stamp:\`, complete events including \`ASSET_ISSUANCE\`. Yet the indexer's tables (\`transactions\`, \`StampTableV4\`) had zero hits.

Timeline:
- **20:18** \`OPS_ALERT [critical] Indexer progress watchdog tripped\` (1847s of no progress, block 954135)
- **21:12:34** \`Directly fetching block 954139 from XCP API\` — pipeline fallback engaged
- **21:13:11** block 954140 indexed: **\`S:0 SRC20:0 SRC101:0\`**, 36.24s vs ~1s average

CP was clearly stressed across this window. Our fetcher came back with 0 transactions for 954140, and \`_validate_block_data_completeness\` happily accepted it.

## Root cause

\`indexer/src/index_core/fetch_utils.py:1022-1025\` (pre-fix):

```python
if tx_count == 0:
    logger.debug(f\"Block {block_index}: No transactions found - empty block\")
    # Empty blocks are possible, so we don't fail validation
    return True
```

No probe of CP's \`result_count\`. Most Bitcoin blocks legitimately have zero CP-relevant transactions, so the existing branch is fine for those — but it gives the same answer to a transient CP hiccup that drops every issuance/transfer in a block.

PR #750's events-count guard does exist but only in \`_fetch_block_transactions_workaround\`, which is the *fallback* fetcher. The production path is \`_verbose_safe_pagination\` (selected by \`fetch_block_transactions_with_pagination\` based on \`CP_API_USE_VERBOSE_WORKAROUND\`). Adding the check at the validator covers both fetcher implementations.

## Fix

Cross-check \`tx_count == 0\` against a cheap count probe (\`?verbose=false&limit=1\` → \`result_count\`):

| Probe outcome | Result |
|---|---|
| \`expected == 0\` | Accept (verified empty) |
| \`expected > 0\` | **Reject** → caller retries this block |
| Probe raises | Accept (preserves current behavior so the guard isn't a new outage vector) |
| Probe response lacks \`result_count\` | Accept (cannot verify) |
| \`tx_count > 0\` | Existing path; probe not called |

## Tests

New file \`tests/test_fetch_utils_validate_block.py\` covers all six cases (the four above + nonempty-skips-probe + missing-key path unchanged). All pass.

Full unit suite: **1723 passed, 26 skipped** (+6 from this PR). black + isort + flake8 clean.

## Recovery for the live miss

The indexer is currently catching up from a rollback I ran before opening this PR (target 953149, covers 954140 with buffer). CP is healthy now, so the reprocess re-fetches block 954140 normally and indexes the missing stamp — independent of this fix landing.

## Related

- PR #750 (\`fix(fetch_utils): detect silently-truncated CP events pagination\`) — sibling guard on the events endpoint, scoped to the fallback fetcher. This PR completes the coverage for the primary path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)