### PR TITLE
fix(pipeline): configurable block-fetch timeout, default 180s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ db
 .DS_Store
 .env
 .env.local
-db_data/
+db_data*/
 files/
 indexer/.env
 .idea/

--- a/indexer/.env.sample
+++ b/indexer/.env.sample
@@ -118,6 +118,11 @@ CP_FALLBACK_MODE=true
 # How many times a block must fail before triggering fallback mode (default: 3)
 CP_FALLBACK_FAILURE_THRESHOLD=3
 
+# Seconds before an in-flight block fetch is considered stalled and re-queued
+# (default: 180). Busy SRC-20 blocks need many paginated /v2/blocks/N/transactions
+# calls; under the 20 req/s rate limit a legitimate fetch can exceed 60s.
+PIPELINE_FETCH_TIMEOUT=180
+
 # How close to chain tip (in blocks) before allowing fallback mode (default: 100)
 # Prevents fallback during initial sync where it would be pointless
 CP_FALLBACK_TIP_THRESHOLD=100

--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -72,7 +72,11 @@ class CPBlocksPipeline:
         self.fetch_futures_lock = threading.Lock()  # Lock for fetch_futures dictionary
         self.fetch_futures = {}  # Track active fetch futures
         self.blocks_fetch_timestamps = {}  # Track when each block started being fetched
-        self.fetch_timeout = 60  # Timeout for block fetches in seconds
+        # Busy SRC-20 blocks need many paginated /v2/blocks/N/transactions calls;
+        # under the 20 req/s rate limit a legitimate fetch can exceed 60s and
+        # trip a timeout cascade that jams the retry queue. Configurable via
+        # PIPELINE_FETCH_TIMEOUT so operators can adjust without a code change.
+        self.fetch_timeout = int(os.environ.get("PIPELINE_FETCH_TIMEOUT", "180"))
         self.failed_fetch_blocks = {}  # Track blocks that failed to fetch with retry count
 
         # Fallback mode settings


### PR DESCRIPTION
## Summary

Closes priority 1 of #756. Makes `CPBlocksPipeline.fetch_timeout` configurable via `PIPELINE_FETCH_TIMEOUT` env var and raises the default from 60s → 180s.

## Why

Busy SRC-20 blocks (e.g. mint storms ~500 messages) require many serial paginated `/v2/blocks/N/transactions` calls. Under the default `CP_LOCAL_NODE_LIMIT=20` req/s rate limit, a legitimate fetch can exceed the previous hard-coded 60s timeout, tripping the retry queue and stalling the indexer during reindex. Surfaced repeatedly during the #753 stampsdev reindex; the env-var workaround has been running in the stampsdev docker image since 2026-06-20 with no adverse effects.

## Scope

This PR ONLY brings in the env-var workaround. The other #756 items (CP `limit=25→100` bump pending CP v11.1.0 verbose-pagination validation, Rust-parser pre-detection via #754, async pagination) remain open in #756 as separate work.

## Changes

- `indexer/src/index_core/pipeline_utils.py`: `self.fetch_timeout = int(os.environ.get("PIPELINE_FETCH_TIMEOUT", "180"))`
- `indexer/.env.sample`: document the new variable

## Test plan

- [ ] Unit tests pass (no behavior change for callers; only the default and source change)
- [ ] Stampsdev reindex from PR #753 already runs with `PIPELINE_FETCH_TIMEOUT=180` baked in — no stalls in the windows where the old 60s default would have tripped
- [ ] Operator sanity: `PIPELINE_FETCH_TIMEOUT=300 docker compose up` honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)