### PR TITLE
chore(deps): pin pynacl and pybase64 to exact versions

### DIFF
--- a/indexer/poetry.lock
+++ b/indexer/poetry.lock
@@ -5418,4 +5418,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "9b01fd55ba8f502cc6e4022374a4de716c28f0a40c054c46b49d9d27653fb79a"
+content-hash = "ff8697478484705d1389e78f3c6fcaf89823e276d99e47cef9930032defaafb6"

--- a/indexer/pyproject.toml
+++ b/indexer/pyproject.toml
@@ -37,7 +37,7 @@ regex = "2026.2.28"
 requests = "2.32.5"
 pymysql = "1.1.1"
 cryptography = "^46.0.5"
-pybase64 = "^1.4.1"
+pybase64 = "1.4.3"
 python-magic = "0.4.27"
 boto3 = "^1.39.12"
 msgpack = "1.1.2"
@@ -54,7 +54,7 @@ redis = "^6.2.0"
 
 [tool.poetry.group.arweave.dependencies]
 arweave-python-client = "1.0.19"
-pynacl = ">=1.6.2"
+pynacl = "1.6.2"
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.13.0"


### PR DESCRIPTION
## Summary

Closes part 1 of #759. Pins two consensus-critical packages to exact versions in `pyproject.toml`. Zero behavior change — the existing lock already resolved to these versions; constraints are tightened around the current resolution.

## Why

Both packages touch consensus code paths:
- `pybase64` backs `decode_base64` (the tier-3 path we just hardened in #753)
- `pynacl` backs signature / key handling

Previous constraints (`pybase64 = "^1.4.1"`, `pynacl = ">=1.6.2"`) left silent-bump risk on any `poetry update` — exactly the regex/PyNaCl version drift HANDOFF flagged.

## Baseline rationale

Pinned to the versions empirically validated in production:
- `pybase64 == 1.4.3` — matches stampsdev container (validating reindex against prod RDS, currently through block ~874k) AND prod systemd venv (live mainnet at tip)
- `pynacl == 1.6.2` — same: container == prod

**No drift between container and prod systemd venv on these packages.** The only stale-venv drift is `/home/ubuntu/stampsdev/btc_stamps/indexer/.venv` (regex 2024.11.6, PyNaCl 1.5.0) — tracked separately in #757 (host venv rebuild).

**Why not bump to latest?** Bumping = unknown validation work. Each of these packages has potential consensus impact. The whole point of pinning is to make any version change a deliberate, separately-validated PR.

## Out of scope

- `regex` — already pinned to exact `"2026.2.28"` in pyproject; no change needed
- `python-magic` — being removed by #753; pinning would be churn
- `btc_stamps_parser` (Rust wheel) — locally built per env; wheel distribution is a separate design discussion (still on #759)
- CI job to verify host venv pip freeze == container pip freeze — separate, larger task (still on #759)

## Changes

```diff
-pybase64 = "^1.4.1"
+pybase64 = "1.4.3"
-pynacl = ">=1.6.2"
+pynacl = "1.6.2"
```

`poetry lock` (without `--regenerate`) updated only the manifest content-hash — verified the lockfile diff is a single line and zero transitive package versions moved.

## Test plan

- [ ] CI green (unit + integration + Rust)
- [ ] `poetry check --lock` passes
- [ ] Stampsdev reindex (running on PR #753) continues clean — uses the same resolved versions, so no impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)