### PR TITLE
ci: respect pinned Rust toolchain (1.85.1) in all workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./indexer
 
       - name: Setup Rust and build parser
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build Rust parser
         working-directory: ./indexer

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,14 +31,14 @@ jobs:
           python-version: '3.11'  # Use single version for coverage (same as integration tests)
           
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-          
+
       - name: Cache Rust dependencies (Restore Only)
         uses: Swatinem/rust-cache@v2
         with:
-          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
           save-if: ${{ false }}  # Don't save cache, only restore from main CI
           
       - name: Install Poetry

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -58,13 +58,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
       - name: Cache Rust dependencies (Restore Only)
         uses: Swatinem/rust-cache@v2
         with:
-          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
           save-if: ${{ false }}
       - name: Install Poetry
         run: |
@@ -107,13 +107,13 @@ jobs:
         with:
           python-version: '3.11'
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
       - name: Cache Rust dependencies (Restore Only)
         uses: Swatinem/rust-cache@v2
         with:
-          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
+          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
           save-if: ${{ false }}
       - name: Install Poetry
         run: |

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./indexer
 
       - name: Setup Rust and build parser
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build Rust parser
         working-directory: ./indexer


### PR DESCRIPTION
## Summary

Closes the Rust-toolchain-pin half of #759. The repo already pins channel `1.85.1` in `indexer/src/rust_parser/rust-toolchain.toml`, but five CI Rust-setup steps were using `dtolnay/rust-toolchain@stable` which installs whatever the **latest stable** rustc is at CI time — silently defeating the pin and risking compiler-version drift on the `btc_stamps_parser` wheel.

Since the parser drives `stamp:` / SRC-20 / CP detection, that wheel is on the consensus surface. Two rustc minors with different codegen could (in principle) produce different parse outputs on edge-case bytes. This PR makes CI compile with the same `rustc 1.85.1` the docker image and host venv use.

## Changes

**5 Rust toolchain installs swapped** `dtolnay/rust-toolchain@stable` → `actions-rust-lang/setup-rust-toolchain@v1` (the action that respects `rust-toolchain.toml`):
- `coverage.yml`
- `setup-python.yml`
- `claude.yml`
- `python-check.yml` (two blocks)

**3 cache-key bugs fixed** in `Swatinem/rust-cache@v2` `key:` lines: `rust-toolchain` → `rust-toolchain.toml`. The bare filename does not exist; `hashFiles()` returned empty string → cache key silently missing a component → invalidation broken on toolchain changes.
- `coverage.yml:41`
- `python-check.yml:67, :116`

## Why the smaller solution and not a full Rust wheel distribution

#759 lists two outstanding items: this pin + a wheel distribution. Distributing pre-built wheels needs a build matrix and pyproject install-source logic — a real piece of work. Pinning the toolchain so every \`maturin develop\` run produces the same bytes is a 9-line fix that addresses the same root cause (compiler drift) and unblocks the harder question. We can come back to wheel distribution as a separate PR once we've validated the pin works in CI.

## Test plan

- [ ] All CI workflows green; \`Rust Checks\` job confirms it builds at 1.85.1
- [ ] Inspect a CI run log to confirm rustc version line reads \`1.85.1\` (not whatever \`@stable\` resolves to today)
- [ ] No cache misses or rebuilds caused by the cache-key correction (transient on first run is OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)