### PR TITLE
ci: bump actions to Node 24-targeting major versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
       status: ${{ steps.test.outputs.test_status }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Create Python module structure
         run: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -37,7 +37,7 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -78,7 +78,7 @@ jobs:
 
       - name: Set up Python
         if: env.SKIP == 'false'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -172,7 +172,7 @@ jobs:
       - name: Create Release
         if: env.SKIP == 'false' && env.NEW_VERSION && github.ref == 'refs/heads/main'
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -215,12 +215,12 @@ jobs:
       NEW_VERSION: ''
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       
@@ -257,7 +257,7 @@ jobs:
       - name: Create Release
         if: env.NEW_VERSION
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Use default behavior - Claude action handles PR context internally
           fetch-depth: 0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,12 +26,12 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,10 +23,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'  # Use single version for coverage (same as integration tests)
           

--- a/.github/workflows/docker-auto-publish.yml
+++ b/.github/workflows/docker-auto-publish.yml
@@ -19,10 +19,10 @@ jobs:
     
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Extract version from pyproject.toml
         id: get-version
@@ -99,7 +99,7 @@ jobs:
           fi
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./indexer
           push: true
@@ -120,7 +120,7 @@ jobs:
           skip-files: 'app/bootstrap/srcbackground.csv,/usr/src/app/files/**'
 
       - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         if: github.ref == 'refs/heads/main'
         with:
           username: btcstamps

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,10 +29,10 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -50,7 +50,7 @@ jobs:
             type=sha,prefix=,suffix=,format=short
       
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./indexer
           push: true

--- a/.github/workflows/freeze-drift.yml
+++ b/.github/workflows/freeze-drift.yml
@@ -34,13 +34,13 @@ jobs:
     name: Freeze Drift Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build production-mode indexer image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: indexer
           file: indexer/Dockerfile

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -16,9 +16,9 @@ jobs:
       USE_TEST_DB: '1'
       MOCK_DB: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Set up Rust toolchain
@@ -52,9 +52,9 @@ jobs:
       USE_TEST_DB: '1'
       MOCK_DB: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Rust toolchain
@@ -101,9 +101,9 @@ jobs:
       USE_TEST_DB: '1'
       MOCK_DB: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Set up Rust toolchain

--- a/.github/workflows/reparse-validate.yml
+++ b/.github/workflows/reparse-validate.yml
@@ -45,10 +45,10 @@ jobs:
     # Advisory on first land — promote to required after one bake cycle.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -14,10 +14,10 @@ jobs:
       cache-hit: ${{ steps.cache-poetry.outputs.cache-hit }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache Poetry
         id: cache-poetry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pypoetry
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate version format
         run: |


### PR DESCRIPTION
## Summary

Quiet the Node 20 deprecation warning that's been showing up on every CI run since GitHub started [phasing out Node 20 on runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Bumps action majors to versions that target Node 24.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-python` | v5 | **v6** |
| `actions/cache` | v4 | **v5** |
| `docker/build-push-action` | v5 / v6 | **v7** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `softprops/action-gh-release` | v1 | **v2** |
| `peter-evans/dockerhub-description` | v3 | **v4** |

12 workflow files, 34 line changes, mechanical version bumps only.

### Untouched (already Node 24 in their latest version, or pinned to a non-version ref)

- `actions-rust-lang/setup-rust-toolchain@v1`
- `Swatinem/rust-cache@v2`
- `aquasecurity/trivy-action@master`

## Risk

Each bumped action has a major-version boundary, so behavior can shift on inputs we use. Spot-check of the action changelogs vs how we invoke them:

- **checkout v5**: drops Node 16 support, no input-shape changes affecting us. Safe.
- **setup-python v6**: same — Node-engine bump only. Safe.
- **cache v5**: same. Safe.
- **build-push-action v7**: minor API: deprecated some inputs but the ones we use (`context`, `file`, `target`, `build-args`, `tags`, `load`, `cache-from`, `cache-to`) are unchanged. Safe.
- **setup-buildx-action v4**: drops a deprecated `endpoint` input; we don't use it. Safe.
- **action-gh-release v2**: changes \`token\` defaults but we either pass \`GITHUB_TOKEN\` explicitly or rely on default. Worth eyeballing the next release run.
- **dockerhub-description v4**: input shape unchanged.

If any of these turns out to break, revert is trivial — single grep+sed undo.

## Test plan

- [ ] CI passes on this PR (the trivial test — most workflows touch most of these actions)
- [ ] The "Node 20 is being deprecated" warning disappears from the run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)