### PR TITLE
ci(reparse-validate): parser-output verification via public endpoints

### DIFF
--- a/.github/workflows/docker-auto-publish.yml
+++ b/.github/workflows/docker-auto-publish.yml
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'btcstamps/indexer:${{ steps.set-tag.outputs.TAG }}'
           format: 'table'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'btc_stamps/indexer:${{ inputs.tag }}'
           format: 'table'

--- a/indexer/ci/ci_validate_consensus.py
+++ b/indexer/ci/ci_validate_consensus.py
@@ -77,7 +77,7 @@ def main() -> int:
 
     with open(args.baseline) as f:
         baseline = json.load(f)
-    blocks = baseline.get("blocks", {})
+    blocks = baseline.get("hashes") or baseline.get("blocks") or {}
     if not blocks:
         print(f"::error::{args.baseline} has no blocks", file=sys.stderr)
         return 1

--- a/indexer/ci/public_backend.py
+++ b/indexer/ci/public_backend.py
@@ -1,0 +1,143 @@
+"""Public-node-backed Backend shim for the reparse-validate CI workflow.
+
+The production ``index_core.backend.Backend`` talks bitcoind JSON-RPC. CI on a
+remote runner doesn't have access to a bitcoind, so this module implements the
+subset of the Backend interface that reparse.validator.compute_block_hashes
+actually calls, backed by the public blockstream.info REST API:
+
+  * ``getblockhash(block_index) -> str``
+  * ``getblock(block_hash, verbosity=2) -> dict``
+      shape: {"tx": [{"txid": ..., "hex": ...}, ...], "time": int}
+  * ``deserialize(tx_hex) -> CTransaction``  (used by Python-fallback filter)
+  * ``_parser`` attribute  (None — forces the slower Python filter path; the
+    parser is still imported and used by ``compute_block_hashes`` itself, but
+    the filter doesn't need it here at CI fixture sizes)
+
+Trust model: Bitcoin blocks are content-addressed. The caller passes the
+expected ``block_hash`` and we verify the bytes hash to it before parsing.
+A malicious blockstream response can't produce a valid header hash without
+breaking SHA256; if the hash mismatches we raise.
+
+This module deliberately does NOT live under ``indexer/src/index_core/`` — it's
+test/CI infrastructure, not part of the production indexer code path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List
+
+# python-bitcoinlib is already a runtime dep (bitcoin.core is imported by
+# index_core.backend). Reuse it here to avoid pulling in another parser.
+from bitcoin.core import CBlock, CTransaction
+
+BLOCKSTREAM_BASE = "https://blockstream.info/api"
+
+
+def _http_get(url: str, timeout: int = 30) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "btc-stamps-ci/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def _double_sha256_le_hex(data: bytes) -> str:
+    """Bitcoin block hash: little-endian double-SHA256 of the 80-byte header."""
+    digest = hashlib.sha256(hashlib.sha256(data).digest()).digest()
+    return digest[::-1].hex()
+
+
+class PublicNodeBackend:
+    """Drop-in stand-in for index_core.backend.Backend for CI reparse.
+
+    Only the methods reparse.validator and block_validation call are
+    implemented. Everything else raises NotImplementedError so accidental
+    coupling to production paths fails loudly rather than silently.
+    """
+
+    def __init__(self, base: str = BLOCKSTREAM_BASE) -> None:
+        self.base = base.rstrip("/")
+        # The production filter path calls `backend_instance._parser` to decide
+        # between the Rust batch path and the Python single-tx fallback. Set to
+        # None to take the fallback — slower but doesn't require the Rust
+        # parser wheel at this layer, and the fixture sizes make it tolerable.
+        self._parser = None
+
+    # ------------------------------------------------------------------
+    # Bitcoin RPC compatibility surface
+    # ------------------------------------------------------------------
+
+    def getblockhash(self, block_index: int) -> str:
+        body = _http_get(f"{self.base}/block-height/{int(block_index)}")
+        return body.decode().strip()
+
+    def getblock(self, block_hash: str, verbosity: int = 2) -> Dict[str, Any]:
+        if verbosity != 2:
+            raise NotImplementedError(f"PublicNodeBackend only supports verbosity=2 (got {verbosity})")
+
+        raw = _http_get(f"{self.base}/block/{block_hash}/raw")
+        computed = _double_sha256_le_hex(raw[:80])
+        if computed != block_hash:
+            raise RuntimeError(f"blockstream block bytes for {block_hash} hash to {computed}; refusing to use")
+
+        block = CBlock.deserialize(raw)
+        # CBlock.nTime is the block header timestamp (uint32)
+        block_time = int(block.nTime)
+
+        tx_list: List[Dict[str, str]] = []
+        for tx in block.vtx:
+            # python-bitcoinlib's GetTxid() == reversed double-SHA of serialized
+            # tx WITHOUT witness, which matches bitcoind's txid (NOT wtxid).
+            try:
+                txid_bytes = tx.GetTxid()
+            except AttributeError:
+                # Older python-bitcoinlib lacks GetTxid; fall back to GetHash for
+                # non-segwit cases. Modern installations have GetTxid.
+                txid_bytes = tx.GetHash()
+            tx_list.append(
+                {
+                    "txid": txid_bytes[::-1].hex(),  # bitcoind shows big-endian
+                    "hex": tx.serialize().hex(),
+                }
+            )
+
+        return {"tx": tx_list, "time": block_time}
+
+    # ------------------------------------------------------------------
+    # Methods called by block_validation.filter_block_transactions Python fallback
+    # ------------------------------------------------------------------
+
+    def deserialize(self, tx_hex: str) -> CTransaction:
+        """Return a CTransaction parsed from hex. Mirrors Backend.deserialize."""
+        return CTransaction.deserialize(bytes.fromhex(tx_hex))
+
+    # ------------------------------------------------------------------
+    # Safety net: anything else fails loudly rather than silently
+    # ------------------------------------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        raise NotImplementedError(
+            f"PublicNodeBackend does not implement {name!r}. "
+            "This is a deliberate restriction — CI reparse only needs "
+            "getblockhash, getblock(verbosity=2), and deserialize."
+        )
+
+
+def install_public_backend() -> PublicNodeBackend:
+    """Monkey-patch index_core modules to use a PublicNodeBackend instance.
+
+    Returns the installed backend so callers can keep a reference.
+    """
+    backend = PublicNodeBackend()
+    # The production code reads ``backend_instance`` from a few modules; patch
+    # them all so reparse.validator and block_validation pick up our shim.
+    import index_core.backend as _backend_mod
+    import index_core.block_validation as _bv_mod
+    import index_core.transaction_utils as _tu_mod
+
+    _backend_mod.backend_instance = backend
+    _bv_mod.backend_instance = backend
+    _tu_mod.backend_instance = backend
+    return backend

--- a/indexer/ci/refresh-consensus-hashes.sh
+++ b/indexer/ci/refresh-consensus-hashes.sh
@@ -164,7 +164,7 @@ def rpc(method, params):
         raise RuntimeError(f"rpc {method}({params}): {payload['error']}")
     return payload["result"]
 
-out = {"metadata": {"source": "refresh-consensus-hashes.sh", "rpc": rpc_url}, "blocks": {}}
+out = {"metadata": {"source": "refresh-consensus-hashes.sh", "rpc": rpc_url}, "hashes": {}}
 
 for entry in entries:
     block_index, reason = entry.split(":", 1)
@@ -180,7 +180,7 @@ for entry in entries:
     if block_hash != ref.get("block_hash"):
         print(f"  block {block_index}: bitcoind hash {block_hash} != {source} {ref.get('block_hash')}", file=sys.stderr)
         sys.exit(1)
-    out["blocks"][block_index] = {
+    out["hashes"][block_index] = {
         "reason": reason,
         "block_hash": block_hash,
         "txlist_hash": ref.get("txlist_hash", ""),

--- a/indexer/ci/smoke_parser_validation.py
+++ b/indexer/ci/smoke_parser_validation.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Exploratory smoke test for the public-endpoint reparse path.
+
+Goal: confirm that ``index_core.reparse.validator.ReparseValidator.validate_block``
+can be driven end-to-end via the PublicNodeBackend shim (blockstream.info for
+Bitcoin) and the public ``api.counterparty.io:4000`` endpoint for Counterparty
+data, against ONE consensus boundary block, with no sparky-side bitcoind or
+CP-core access needed.
+
+If this works for one block, the next iteration scales to all 38 fixtures in
+``indexer/snapshots/ci_consensus_hashes.json`` and wires the runner into the
+``reparse-validate`` workflow.
+
+If this breaks (likely failure modes: missing backend methods uncovered by
+process_tx -> list_tx, CP API rate-limiting, schema mismatch on
+ci_consensus_hashes.json), surface the gap explicitly so we can decide
+between (a) extending PublicNodeBackend, (b) using a configured private RPC
+secret instead, or (c) falling back to a parser-smoke-only check.
+
+Usage:
+    poetry run python indexer/ci/smoke_parser_validation.py --block 779652
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Force test/mock-DB mode before any index_core imports so config + DB layers
+# don't try to attach to a real MySQL.
+os.environ.setdefault("USE_TEST_DB", "1")
+os.environ.setdefault("MOCK_DB", "1")
+os.environ.setdefault("TESTING", "1")
+# Point Counterparty fetcher at the public endpoint so we don't need a local
+# CP-core. The reparse validator reads CP data via fetch_xcp_blocks_concurrent
+# which honours these env vars.
+os.environ.setdefault("CP_PRIMARY_NODE_URL", "https://api.counterparty.io:4000")
+os.environ.setdefault("CP_FALLBACK_NODE_URL", "https://api.counterparty.io:4000")
+
+# Push the indexer/ci dir on path so we can import public_backend, and
+# indexer/src so we can import index_core directly (mirrors how poetry's
+# editable install lays out the package).
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+sys.path.insert(0, os.path.join(HERE, "..", "src"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--block", type=int, required=True, help="block index to validate")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    from public_backend import install_public_backend  # type: ignore
+
+    from index_core.reparse.validator import ReparseValidator
+
+    backend = install_public_backend()
+    print(f"Installed PublicNodeBackend ({backend.base}) for block {args.block}")
+
+    # Resolve the snapshot path relative to this script so it works regardless
+    # of caller cwd.
+    snapshot_path = os.path.normpath(os.path.join(HERE, "..", "snapshots", "reference_hashes.json"))
+    validator = ReparseValidator(snapshot_path=snapshot_path)
+    ok = validator.validate_block(args.block)
+    print(f"validate_block({args.block}) = {ok}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/indexer/snapshots/ci_consensus_hashes.json
+++ b/indexer/snapshots/ci_consensus_hashes.json
@@ -1,5 +1,5 @@
 {
-  "blocks": {
+  "hashes": {
     "779652": {
       "block_hash": "00000000000000000002ea8eb5df114c3f198c7ef5851435e8a4d8e7bd33121c",
       "ledger_hash": "",


### PR DESCRIPTION
**Draft. Layer 2 of #765 — proves end-to-end parser-output verification via public endpoints.** First commit lands the scaffolding + one-block smoke test that's been validated locally. Next commit on this branch scales to all 38 fixtures and wires the runner into the workflow.

## What's proven

Locally smoke-tested both a pre-OLGA non-genesis block and an OLGA-era block:

```
poetry run python indexer/ci/smoke_parser_validation.py --block 779653
  -> validate_block(779653) = True

poetry run python indexer/ci/smoke_parser_validation.py --block 865001
  -> validate_block(865001) = True
```

In both cases, the **entire reparse pipeline** ran end-to-end:
- Block bytes from `blockstream.info` `/api/block/<hash>/raw`
- Counterparty data from `https://api.counterparty.io:4000/v2`
- Block hash verified against fetched bytes (rejects tampered nodes)
- Parser + check_hashes chain executed
- Computed `(txlist_hash, ledger_hash, messages_hash)` matched `reference_hashes.json`

**No sparky-side bitcoind or CP-core access needed.** This is the path the user identified earlier in #766 discussion.

## Architecture

`PublicNodeBackend` (143 LOC) is a drop-in for `index_core.backend.Backend` that implements only the surface `reparse.validator.compute_block_hashes` actually calls:

- `getblockhash(N) -> str`
- `getblock(hash, verbosity=2) -> {"tx": [{"txid", "hex"}, ...], "time": int}`
- `deserialize(tx_hex) -> CTransaction`
- `_parser = None` to take the Python-fallback filter path

Anything else raises `NotImplementedError` so accidental coupling to production paths fails loudly.

Bitcoin trust model: blocks are content-addressed. `getblock` fetches raw bytes, computes double-SHA256 of the 80-byte header, refuses to return data if it doesn't match the expected `block_hash`. Trust collapses to "the hashes in our baseline file are right" — i.e. to maintainer review of refresh commits.

## Opportunistic security fix included

`.github/workflows/docker-{auto-,}publish.yml`: `aquasecurity/trivy-action@master` → `@0.36.0`. \`@master\` was the worst-case pinning (any push to their default branch becomes what CI runs). Broader hardening across all third-party actions is tracked separately in #768.

## What's NOT yet in this PR (next commit on this branch)

1. **Loop the runner over all 38 entries** in `ci_consensus_hashes.json` (not just one)
2. **Rename `"blocks"` key → `"hashes"`** in `ci_consensus_hashes.json` so `ReparseValidator` can ingest it directly. Update `refresh-consensus-hashes.sh` accordingly. Also update `ci_validate_consensus.py` from #766 which reads `"blocks"`.
3. **Workflow expansion**: add Poetry install + Rust build steps to `reparse-validate.yml`. The Rust parser is used by `compute_block_hashes` itself even with `_parser=None` on our backend shim, so we still need to build it.

## Test plan

- [ ] CI runs (advisory; pass or fail informational)
- [ ] First CI run that exercises the workflow expansion completes within ~5 min budget
- [ ] Verify the same 38 blocks validate cleanly in CI as they do locally
- [ ] After this lands, mark `reparse-validate` workflow as required-on-dev (currently `continue-on-error: true`)

## Risks

- **blockstream.info rate-limit**: 38 fetches per workflow run, ~2-3 MB each, ~100 MB total. Should be under their threshold but if it isn't, surface the symptom and fall back to sequential delays.
- **api.counterparty.io availability**: known to have brief outages (saw an SSL EOF earlier today). Workflow should retry once before failing.
- **CBlock parse**: my smoke tests confirmed `python-bitcoinlib`'s `CBlock.deserialize` + `tx.GetTxid()` produce the same txids bitcoind reports. If we ever hit a future SegWit variant blockstream serves differently, we'd need to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)