### PR TITLE
fix(ci): correct trivy-action tag to v0.36.0 (was missing 'v' prefix)

### DIFF
--- a/.github/workflows/docker-auto-publish.yml
+++ b/.github/workflows/docker-auto-publish.yml
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'btcstamps/indexer:${{ steps.set-tag.outputs.TAG }}'
           format: 'table'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'btc_stamps/indexer:${{ inputs.tag }}'
           format: 'table'


### PR DESCRIPTION
## What

Add the missing \`v\` prefix to the \`aquasecurity/trivy-action\` tag pin from #769. The published upstream tag is \`v0.36.0\`; I pinned to \`0.36.0\` which doesn't resolve:

\`\`\`
Error: Unable to resolve action 'aquasecurity/trivy-action@0.36.0', unable to find version '0.36.0'
\`\`\`

Affects \`docker-publish.yml\` and \`docker-auto-publish.yml\`.

## Verified

\`\`\`
$ curl -s 'https://api.github.com/repos/aquasecurity/trivy-action/releases?per_page=5' | jq -r '.[].tag_name'
v0.36.0
v0.35.0
0.35.0
v0.34.0
v0.33.1
\`\`\`

Both \`v0.36.0\` and \`0.35.0\` exist as upstream tags. \`0.36.0\` (no \`v\`) does not.

## Risk

Zero — single character per workflow, restores the action resolution. Without this, every push to a branch that triggers docker workflows fails.