### PR TITLE
fix(#784): env-gate startup auto-rollback (default off)

### DIFF
--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -152,7 +152,11 @@ class CPBlocksPipeline:
         if self.state_manager and self.fallback_started_at:
             rollback_block = self.fallback_started_at
             if rollback_block:
-                auto_rollback_enabled = os.environ.get("STARTUP_AUTO_ROLLBACK_FALLBACK", "false").lower() in ("true", "1", "yes")
+                auto_rollback_enabled = os.environ.get("STARTUP_AUTO_ROLLBACK_FALLBACK", "false").lower() in (
+                    "true",
+                    "1",
+                    "yes",
+                )
                 if not auto_rollback_enabled:
                     logger.warning(
                         f"🛑 Startup auto-rollback SKIPPED for fallback state at block {rollback_block} "
@@ -162,7 +166,9 @@ class CPBlocksPipeline:
                         f"Proceeding without rollback (see issue #784)."
                     )
                 else:
-                    logger.warning(f"🔄 Performing startup rollback to block {rollback_block} (STARTUP_AUTO_ROLLBACK_FALLBACK=true)")
+                    logger.warning(
+                        f"🔄 Performing startup rollback to block {rollback_block} (STARTUP_AUTO_ROLLBACK_FALLBACK=true)"
+                    )
                     self._perform_startup_rollback(rollback_block)
                     # Clear the fallback state after successful rollback
                     self.state_manager.clear_fallback_state(rollback_block)

--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -140,27 +140,44 @@ class CPBlocksPipeline:
             logger.warning(f"Start block {start_block} is before CP genesis block {config.CP_STAMP_GENESIS_BLOCK}")
             start_block = config.CP_STAMP_GENESIS_BLOCK
 
-        # Check for fallback state and handle rollback if needed
+        # Check for fallback state and handle rollback if needed.
+        #
+        # Auto-rollback at startup is OPT-IN (issue #784): a prior bug allowed
+        # this branch to destructively wipe hundreds of already-indexed blocks
+        # on a routine restart. Operators must explicitly enable it via
+        # STARTUP_AUTO_ROLLBACK_FALLBACK=true after deciding the rollback is
+        # the right recovery action. Otherwise we log loudly and proceed; the
+        # persistent state is left in place so the operator can clear it
+        # deliberately with tools/clear_fallback_state.py.
         if self.state_manager and self.fallback_started_at:
-            # We have persistent fallback state from initialization
             rollback_block = self.fallback_started_at
             if rollback_block:
-                logger.warning(f"🔄 Performing startup rollback to block {rollback_block}")
-                self._perform_startup_rollback(rollback_block)
-                # Clear the fallback state after successful rollback
-                self.state_manager.clear_fallback_state(rollback_block)
-                # Also clear local state
-                self.failed_cp_blocks.clear()
-                self.fallback_started_at = None
+                auto_rollback_enabled = os.environ.get("STARTUP_AUTO_ROLLBACK_FALLBACK", "false").lower() in ("true", "1", "yes")
+                if not auto_rollback_enabled:
+                    logger.warning(
+                        f"🛑 Startup auto-rollback SKIPPED for fallback state at block {rollback_block} "
+                        f"({len(self.failed_cp_blocks)} blocks recorded). "
+                        f"Set STARTUP_AUTO_ROLLBACK_FALLBACK=true to enable, or run "
+                        f"tools/clear_fallback_state.py to discard the state without rollback. "
+                        f"Proceeding without rollback (see issue #784)."
+                    )
+                else:
+                    logger.warning(f"🔄 Performing startup rollback to block {rollback_block} (STARTUP_AUTO_ROLLBACK_FALLBACK=true)")
+                    self._perform_startup_rollback(rollback_block)
+                    # Clear the fallback state after successful rollback
+                    self.state_manager.clear_fallback_state(rollback_block)
+                    # Also clear local state
+                    self.failed_cp_blocks.clear()
+                    self.fallback_started_at = None
 
-                # Clear global fallback mode flag for fetch_utils
-                from index_core.fetch_utils import set_global_fallback_mode
+                    # Clear global fallback mode flag for fetch_utils
+                    from index_core.fetch_utils import set_global_fallback_mode
 
-                set_global_fallback_mode(False)
+                    set_global_fallback_mode(False)
 
-                logger.info("✅ Fallback state cleared - proceeding with normal operation")
-                # Update start_block to the rollback point
-                start_block = rollback_block
+                    logger.info("✅ Fallback state cleared - proceeding with normal operation")
+                    # Update start_block to the rollback point
+                    start_block = rollback_block
 
         self.current_block = start_block
         self.running = True

--- a/indexer/tests/test_pipeline_fallback_state_persistence.py
+++ b/indexer/tests/test_pipeline_fallback_state_persistence.py
@@ -210,6 +210,7 @@ def test_startup_auto_rollback_skipped_by_default(temp_db, mock_backend, mock_no
         mock_node_health[1].return_value = ["http://healthy-node:4000"]
 
         import logging
+
         with patch("src.config.CP_STAMP_GENESIS_BLOCK", 0), caplog.at_level(logging.WARNING):
             pipeline.start(12340)
 

--- a/indexer/tests/test_pipeline_fallback_state_persistence.py
+++ b/indexer/tests/test_pipeline_fallback_state_persistence.py
@@ -138,8 +138,11 @@ def test_fallback_state_save_on_enter_fallback_mode(temp_db, mock_backend, mock_
         assert loaded_state == {12350: True}  # New normalized structure preserves integer keys
 
 
-def test_fallback_state_clear_after_rollback(temp_db, mock_backend, mock_node_health):
-    """Test that fallback state is cleared after successful rollback."""
+def test_fallback_state_clear_after_rollback(temp_db, mock_backend, mock_node_health, monkeypatch):
+    """Test that fallback state is cleared after successful rollback (with opt-in env)."""
+
+    # Issue #784: startup auto-rollback is opt-in. Set the env to exercise the legacy path.
+    monkeypatch.setenv("STARTUP_AUTO_ROLLBACK_FALLBACK", "true")
 
     # Create initial fallback state
     with patch("src.index_core.config.REPROCESS_DB_PATH", temp_db):
@@ -178,6 +181,80 @@ def test_fallback_state_clear_after_rollback(temp_db, mock_backend, mock_node_he
         queue = ReprocessingQueue.get_instance()
         loaded_state = queue.load_fallback_state(12345)
         assert loaded_state is None
+
+
+@pytest.mark.parametrize("env_value", [None, "false", "False", "0", "no", "", "anything-else"])
+def test_startup_auto_rollback_skipped_by_default(temp_db, mock_backend, mock_node_health, monkeypatch, caplog, env_value):
+    """Issue #784: startup rollback must NOT fire unless STARTUP_AUTO_ROLLBACK_FALLBACK opts in."""
+
+    monkeypatch.delenv("STARTUP_AUTO_ROLLBACK_FALLBACK", raising=False)
+    if env_value is not None:
+        monkeypatch.setenv("STARTUP_AUTO_ROLLBACK_FALLBACK", env_value)
+
+    # Persist fallback state in the queue so detection triggers
+    with patch("src.index_core.config.REPROCESS_DB_PATH", temp_db):
+        queue = ReprocessingQueue.get_instance()
+        queue.save_fallback_state(12345, {12345: True, 12346: True})
+
+    ReprocessingQueue._instance = None
+
+    with patch("src.index_core.config.REPROCESS_DB_PATH", temp_db), patch.object(
+        CPBlocksPipeline, "_perform_startup_rollback"
+    ) as mock_rollback, patch.object(CPBlocksPipeline, "_fetch_blocks_worker"), patch.object(
+        CPBlocksPipeline, "wait_for_initial_blocks", return_value=True
+    ):
+
+        pipeline = CPBlocksPipeline(max_queue_size=10, target_queue_size=5, fallback_mode=True)
+        assert pipeline.fallback_started_at == 12345
+
+        mock_node_health[1].return_value = ["http://healthy-node:4000"]
+
+        import logging
+        with patch("src.config.CP_STAMP_GENESIS_BLOCK", 0), caplog.at_level(logging.WARNING):
+            pipeline.start(12340)
+
+        # The destructive rollback must not have run
+        mock_rollback.assert_not_called()
+
+        # Persistent state must still be present — operator decides when to clear it
+        queue = ReprocessingQueue.get_instance()
+        assert queue.load_fallback_state(12345) == {12345: True, 12346: True}
+
+        # Operator-facing warning must mention how to recover
+        warning_text = " ".join(r.message for r in caplog.records if r.levelno >= logging.WARNING)
+        assert "STARTUP_AUTO_ROLLBACK_FALLBACK" in warning_text
+        assert "12345" in warning_text
+
+
+@pytest.mark.parametrize("env_value", ["true", "True", "1", "yes", "YES"])
+def test_startup_auto_rollback_runs_when_env_enabled(temp_db, mock_backend, mock_node_health, monkeypatch, env_value):
+    """Issue #784: rollback fires when STARTUP_AUTO_ROLLBACK_FALLBACK is explicitly enabled."""
+
+    monkeypatch.setenv("STARTUP_AUTO_ROLLBACK_FALLBACK", env_value)
+
+    with patch("src.index_core.config.REPROCESS_DB_PATH", temp_db):
+        queue = ReprocessingQueue.get_instance()
+        queue.save_fallback_state(12345, {12345: True})
+
+    ReprocessingQueue._instance = None
+
+    with patch("src.index_core.config.REPROCESS_DB_PATH", temp_db), patch.object(
+        CPBlocksPipeline, "_perform_startup_rollback"
+    ) as mock_rollback, patch.object(CPBlocksPipeline, "_fetch_blocks_worker"), patch.object(
+        CPBlocksPipeline, "wait_for_initial_blocks", return_value=True
+    ):
+
+        pipeline = CPBlocksPipeline(max_queue_size=10, target_queue_size=5, fallback_mode=True)
+        assert pipeline.fallback_started_at == 12345
+
+        mock_node_health[1].return_value = ["http://healthy-node:4000"]
+
+        with patch("src.config.CP_STAMP_GENESIS_BLOCK", 0):
+            pipeline.start(12340)
+
+        mock_rollback.assert_called_once_with(12345)
+        queue = ReprocessingQueue.get_instance()
+        assert queue.load_fallback_state(12345) is None
 
 
 def test_fallback_state_no_persistence_when_no_state_manager(mock_backend, mock_node_health):

--- a/indexer/tools/clear_fallback_state.py
+++ b/indexer/tools/clear_fallback_state.py
@@ -34,15 +34,13 @@ def _list_sessions(queue: ReprocessingQueue) -> list[tuple[int, int]]:
     """Return [(start_block_index, failed_block_count), ...] for every session."""
     with queue.lock:
         cur = queue.conn.cursor()
-        cur.execute(
-            """
+        cur.execute("""
             SELECT s.start_block_index, COUNT(f.block_index)
             FROM fallback_sessions s
             LEFT JOIN failed_blocks f ON f.session_id = s.id
             GROUP BY s.start_block_index
             ORDER BY s.start_block_index
-            """
-        )
+            """)
         return cur.fetchall()
 
 

--- a/indexer/tools/clear_fallback_state.py
+++ b/indexer/tools/clear_fallback_state.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Clear persistent fallback state from the reprocess queue (issue #784).
+
+Default invocation lists current state without modifying anything. Pass
+``--clear`` to drop all fallback sessions, or ``--clear-block N`` to drop a
+specific session. Destructive actions require interactive confirmation unless
+``--yes`` is given.
+
+The script uses the same ``ReprocessingQueue`` singleton the indexer uses, so
+it resolves the SQLite DB path identically (typically
+``~/.local/share/btc_stamps/reprocess_queue.db``).
+
+Typical operator flow after the indexer logs a startup fallback warning:
+
+    poetry run python indexer/tools/clear_fallback_state.py            # inspect
+    poetry run python indexer/tools/clear_fallback_state.py --clear    # confirm + clear
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running directly from a checkout without installing the package.
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from index_core.reprocessing_queue import ReprocessingQueue  # noqa: E402
+
+
+def _list_sessions(queue: ReprocessingQueue) -> list[tuple[int, int]]:
+    """Return [(start_block_index, failed_block_count), ...] for every session."""
+    with queue.lock:
+        cur = queue.conn.cursor()
+        cur.execute(
+            """
+            SELECT s.start_block_index, COUNT(f.block_index)
+            FROM fallback_sessions s
+            LEFT JOIN failed_blocks f ON f.session_id = s.id
+            GROUP BY s.start_block_index
+            ORDER BY s.start_block_index
+            """
+        )
+        return cur.fetchall()
+
+
+def _confirm(prompt: str) -> bool:
+    if not sys.stdin.isatty():
+        print("Refusing to act non-interactively without --yes", file=sys.stderr)
+        return False
+    return input(prompt).strip().lower() in ("yes", "y")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--clear", action="store_true", help="Drop ALL fallback sessions")
+    parser.add_argument("--clear-block", type=int, metavar="N", help="Drop only the session starting at block N")
+    parser.add_argument("--yes", action="store_true", help="Skip the interactive confirmation prompt")
+    args = parser.parse_args()
+
+    if args.clear and args.clear_block is not None:
+        parser.error("--clear and --clear-block are mutually exclusive")
+
+    queue = ReprocessingQueue.get_instance()
+    print(f"Fallback DB: {queue.db_path}")
+
+    sessions = _list_sessions(queue)
+    if not sessions:
+        print("No fallback sessions recorded — nothing to clear.")
+        return 0
+
+    print(f"Found {len(sessions)} fallback session(s):")
+    for start_block, failed_count in sessions:
+        print(f"  start_block={start_block}  failed_blocks={failed_count}")
+
+    if not (args.clear or args.clear_block is not None):
+        print("\n(read-only) Re-run with --clear or --clear-block N to modify.")
+        return 0
+
+    if args.clear_block is not None:
+        target_blocks = [args.clear_block]
+        if args.clear_block not in {row[0] for row in sessions}:
+            print(f"\nNo session at start_block={args.clear_block}; nothing to do.")
+            return 0
+        action_desc = f"clear session starting at block {args.clear_block}"
+    else:
+        target_blocks = [row[0] for row in sessions]
+        action_desc = f"clear ALL {len(target_blocks)} session(s)"
+
+    if not args.yes and not _confirm(f"\nProceed to {action_desc}? Type 'yes': "):
+        print("Aborted.")
+        return 1
+
+    for start_block in target_blocks:
+        queue.clear_fallback_state(start_block)
+        print(f"  cleared start_block={start_block}")
+
+    print(f"\nDone. {len(target_blocks)} session(s) cleared.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the destructive-startup-rollback half of #784.

Persistent fallback state in the reprocess queue used to trigger an unconditional `perform_complete_rollback` during `CPBlocksPipeline.start()` — wiping every block the indexer had processed in fallback mode. On 2026-06-23 a routine restart purged ~700 prod blocks before the service was manually stopped.

This PR makes the startup rollback **opt-in** via a new env var. Default behavior is now non-destructive: the indexer detects the fallback state, logs an actionable warning, and proceeds without rewriting the DB.

## Changes

- `pipeline_utils.py:CPBlocksPipeline.start()` — wrap the existing rollback block in a `STARTUP_AUTO_ROLLBACK_FALLBACK` gate. When unset/false: log a WARNING naming the env var and the recovery tool, skip the rollback, leave persistent state in place. When true: existing behavior, unchanged.
- `tools/clear_fallback_state.py` — new operator helper. Lists current fallback sessions (read-only by default); `--clear` or `--clear-block N` drops state with interactive confirmation (or `--yes`). Uses the indexer's own `ReprocessingQueue` singleton so it always finds the right SQLite DB regardless of XDG path.
- `tests/test_pipeline_fallback_state_persistence.py` — existing rollback test now sets `STARTUP_AUTO_ROLLBACK_FALLBACK=true` (the path it exercises is now opt-in). Two new parametrized tests cover default-off and explicit-on across truthy/falsy env values, and assert the warning mentions both the env var name and the affected block.

The detection and `set_global_fallback_mode(True)` calls (loaded from SQLite on construction) are untouched, so runtime fallback-mode recovery still behaves identically.

## Scope

Companion fix for the second bug in #784 (stale `util.CURRENT_BLOCK_INDEX` after rollback, which drives `is_prev_block_parsed` into an iterative purge cascade) ships in a separate PR. That fix is broader — it audits every `perform_complete_rollback` caller — and warrants independent review.

## Test plan

- [x] Existing tests pass (19/19 in `test_pipeline_fallback_state_persistence.py`)
- [x] Tool smoke-tested via `--help`
- [ ] End-to-end dev-stack verification: induce fallback state via SQLite insert, restart dev indexer, confirm WARNING + no rollback. (Will run before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)