### PR TITLE
fix(#784): refresh util.CURRENT_BLOCK_INDEX after rollback

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -926,6 +926,32 @@ def follow(
                 fallback_mode=config.CP_FALLBACK_MODE,
             )
             cp_pipeline_instance.start(block_index)
+            # Issue #784: CPBlocksPipeline.start() may run perform_complete_rollback
+            # (startup auto-rollback when STARTUP_AUTO_ROLLBACK_FALLBACK is set). That
+            # rollback executes via a *separate* DB connection and purges blocks
+            # beyond the rollback target. Two things follow that break the
+            # processing loop unless we reset:
+            #   1. follow()'s `db` connection holds a REPEATABLE-READ snapshot
+            #      from before the rollback — last_db_index(db) and
+            #      is_prev_block_parsed(db, ...) would still report the
+            #      pre-rollback tip. Commit to end the snapshot and force a
+            #      fresh read on the next query.
+            #   2. The local `block_index` was derived from the pre-rollback
+            #      tip and would drive is_prev_block_parsed() into a
+            #      destructive iterative cascade. Recompute from
+            #      util.CURRENT_BLOCK_INDEX (a Python int — no MySQL isolation;
+            #      refreshed inside perform_complete_rollback).
+            try:
+                db.commit()
+            except Exception as commit_err:
+                logger.debug(f"Post-pipeline commit (snapshot reset) failed harmlessly: {commit_err}")
+            new_block_index = config.BLOCK_FIRST if util.CURRENT_BLOCK_INDEX == 0 else util.CURRENT_BLOCK_INDEX + 1
+            if new_block_index != block_index:
+                logger.warning(
+                    f"Pipeline init reset block_index: {block_index} → {new_block_index} "
+                    f"(util.CURRENT_BLOCK_INDEX now {util.CURRENT_BLOCK_INDEX} — rollback fired during pipeline init)"
+                )
+                block_index = new_block_index
             stamp_issuances_list = {}  # Initialize empty dict, will be populated by pipeline
 
             # Log fallback mode status

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -46,6 +46,7 @@ from index_core.database import (  # update_src20_token_stats,  # Now handled by
     insert_into_stamp_table,
     insert_transactions,
     is_prev_block_parsed,
+    last_db_index,
     log_reorg_event,
     next_tx_index,
     purge_block_db,
@@ -873,7 +874,14 @@ def follow(
 
         progress_watchdog.start()
 
-        # Get index of last block and current tip
+        # Get index of last block and current tip.
+        # Safety belt for issue #784: refresh the in-process tip from the DB
+        # before deriving block_index. perform_complete_rollback() already
+        # refreshes this global; this is defense in depth so a future caller
+        # that purges blocks without going through that function cannot strand
+        # follow() with a stale value (the prior incident drove
+        # is_prev_block_parsed into an iterative destructive purge cascade).
+        util.CURRENT_BLOCK_INDEX = last_db_index(db)
         block_tip = backend_instance.getblockcount()
         if util.CURRENT_BLOCK_INDEX == 0:
             logger.warning("New database.")

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -1283,6 +1283,16 @@ def perform_complete_rollback(block_index: int, force: bool = False) -> None:
 
         logger.info(f"✅ Complete rollback finished to block {block_index}")
 
+        # Refresh the in-process tip cache (issue #784). Without this, callers
+        # such as blocks.follow() and the runtime fallback-rollback path read a
+        # pre-rollback util.CURRENT_BLOCK_INDEX and drive is_prev_block_parsed()
+        # into a destructive iterative purge cascade. Mirrors the pattern used
+        # by initialize_database(). Safe in the CLI rollback case too — the
+        # process exits shortly after.
+        refreshed_tip = last_db_index(db)
+        util.CURRENT_BLOCK_INDEX = refreshed_tip
+        logger.info(f"🔁 Refreshed util.CURRENT_BLOCK_INDEX to {refreshed_tip} after rollback")
+
         # Check if we should clear fallback state.
         # Query the fallback session directly via ReprocessingQueue rather than
         # load_failed_blocks(), which depends on util.CURRENT_BLOCK_INDEX and silently

--- a/indexer/tests/test_rollback_functionality.py
+++ b/indexer/tests/test_rollback_functionality.py
@@ -101,6 +101,7 @@ def test_indexer_rollback_method_integration(temp_db, clean_singleton):
                 patch("src.index_core.database.clear_all_caches") as mock_clear_caches,
                 patch("src.index_core.database.rebuild_balances") as mock_rebuild_balances,
                 patch("src.index_core.database.rebuild_owners") as mock_rebuild_owners,
+                patch("src.index_core.database.last_db_index", return_value=12000),
                 patch("src.index_core.backend.Backend"),
             ):
 
@@ -133,6 +134,7 @@ def test_bitcoin_block_rollback_not_affected():
             patch("src.index_core.database.clear_all_caches") as mock_clear_caches,
             patch("src.index_core.database.rebuild_balances") as mock_rebuild_balances,
             patch("src.index_core.database.rebuild_owners") as mock_rebuild_owners,
+            patch("src.index_core.database.last_db_index", return_value=12000),
             patch("src.index_core.backend.Backend"),
         ):
 
@@ -259,6 +261,7 @@ def test_fallback_state_integration_with_rollback(temp_db, clean_singleton):
                 patch("src.index_core.database.clear_all_caches"),
                 patch("src.index_core.database.rebuild_balances"),
                 patch("src.index_core.database.rebuild_owners"),
+                patch("src.index_core.database.last_db_index", return_value=12000),
                 patch("src.index_core.backend.Backend"),
             ):
                 # Perform rollback to block before fallback started
@@ -266,3 +269,42 @@ def test_fallback_state_integration_with_rollback(temp_db, clean_singleton):
 
                 # The rollback operation should complete successfully
                 # Fallback state handling is managed by the main indexer code
+
+
+def test_rollback_refreshes_current_block_index(clean_singleton):
+    """Issue #784 (sub-bug 2): perform_complete_rollback must refresh
+    util.CURRENT_BLOCK_INDEX so callers (e.g. blocks.follow()) don't read a
+    stale pre-rollback value and drive is_prev_block_parsed() into a
+    destructive iterative purge cascade."""
+    # Reach the global via the SAME module identity database.py uses
+    # (``import index_core.util as util``). Importing via ``src.index_core``
+    # gives a different sys.modules entry and the assertion would miss the write.
+    import src.index_core.database as database_module
+
+    util = database_module.util
+
+    # Pre-seed the global to a stale (pre-rollback) value, as it would be
+    # after initialize_database() ran but before a rollback is triggered.
+    util.CURRENT_BLOCK_INDEX = 955065
+
+    with patch("src.index_core.database.DatabaseManager") as mock_db_manager_class, patch(
+        "src.index_core.database.last_db_index", return_value=12000
+    ) as mock_last_db_index:
+        mock_db_manager = Mock()
+        mock_conn = Mock()
+        mock_db_manager.connect.return_value = mock_conn
+        mock_db_manager_class.return_value = mock_db_manager
+
+        with (
+            patch("src.index_core.database.purge_block_db"),
+            patch("src.index_core.database.clear_all_caches"),
+            patch("src.index_core.database.rebuild_balances"),
+            patch("src.index_core.database.rebuild_owners"),
+            patch("src.index_core.backend.Backend"),
+        ):
+            perform_complete_rollback(12000)
+
+        # Global must now reflect the post-rollback DB tip, not the stale 955065.
+        assert util.CURRENT_BLOCK_INDEX == 12000
+        # last_db_index was consulted against the same connection used for the purge.
+        mock_last_db_index.assert_called_with(mock_conn)

--- a/indexer/tests/test_rollback_functionality.py
+++ b/indexer/tests/test_rollback_functionality.py
@@ -287,9 +287,10 @@ def test_rollback_refreshes_current_block_index(clean_singleton):
     # after initialize_database() ran but before a rollback is triggered.
     util.CURRENT_BLOCK_INDEX = 955065
 
-    with patch("src.index_core.database.DatabaseManager") as mock_db_manager_class, patch(
-        "src.index_core.database.last_db_index", return_value=12000
-    ) as mock_last_db_index:
+    with (
+        patch("src.index_core.database.DatabaseManager") as mock_db_manager_class,
+        patch("src.index_core.database.last_db_index", return_value=12000) as mock_last_db_index,
+    ):
         mock_db_manager = Mock()
         mock_conn = Mock()
         mock_db_manager.connect.return_value = mock_conn


### PR DESCRIPTION
## Summary

Closes the second half of #784 — the stale-tip cascade that compounded the 2026-06-23 prod incident.

After ``perform_complete_rollback()`` purges blocks, ``util.CURRENT_BLOCK_INDEX`` remained at its pre-rollback value. The next caller into ``blocks.follow()`` read that stale value, computed ``block_index = stale_tip + 1``, called ``is_prev_block_parsed()`` against a block that had just been purged, returned False, and iteratively walked backwards purging more blocks one at a time.

## Changes

- **``database.py:perform_complete_rollback``** — refresh ``util.CURRENT_BLOCK_INDEX = last_db_index(db)`` immediately after the purge succeeds. Mirrors the existing pattern at ``database.py:3244`` (``initialize_database``). Covers every in-process caller of the rollback primitive.
- **``blocks.py:follow``** — defensive re-read of ``last_db_index(db)`` into the global before computing ``block_index``. Belt-and-suspenders: a future purge that bypasses ``perform_complete_rollback`` cannot strand the loop with a stale value.
- **``tests/test_rollback_functionality.py``** — new ``test_rollback_refreshes_current_block_index`` asserts the global is updated when the rollback completes. Existing tests updated to patch ``last_db_index`` (called once per rollback now).

Both production-code changes are no-ops outside the rollback path: in steady state the refresh just re-assigns the value already present.

## Caller audit (per fork audit attached to #784)

In-process callers of ``perform_complete_rollback``:
- ``pipeline_utils.py:858`` — runtime fallback-mode rollback (worked today only by coincidence: ``blocks.py:1545`` updates the global mid-loop just before the rollback fires)
- ``pipeline_utils.py:958`` — startup auto-rollback (the path that caused the prod incident; also covered by PR #786)

Out-of-process: ``tools/rollback_db.py`` runs in a separate process where ``CURRENT_BLOCK_INDEX`` is ``None`` and the indexer is restarted afterward; the refresh is a no-op there but harmless.

## Relation to PR #786

PR #786 makes the startup auto-rollback opt-in (operator decides whether to roll back). This PR fixes the cascade that fires *after* a rollback runs — so it matters whether or not #786 lands. The two are independent; merge order doesn't matter.

## Test plan

- [x] Existing rollback/fallback tests pass (18/18 in ``test_rollback_functionality.py`` + ``test_pipeline_fallback_state_persistence.py`` + ``test_fallback_state.py``)
- [ ] End-to-end dev-stack verification: force a rollback, assert ``follow()`` doesn't enter the iterative ``is_prev_block_parsed`` cascade. (Will run before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)