### PR TITLE
fix(#782) part 1: explicit stampscan fetch contract + ops_alerter on real mismatch

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -448,6 +448,12 @@ SRC_VALIDATION_API2 = (
 )
 SRC_VALIDATION_SECRET_API2: Optional[str] = os.environ.get("SRC_VALIDATION_SECRET_API2", None)
 
+# HTTP timeout (seconds) for each stampscan request inside fetch_api_ledger_data.
+try:
+    STAMPSCAN_REQUEST_TIMEOUT = int(os.environ.get("STAMPSCAN_REQUEST_TIMEOUT", "15"))
+except ValueError:
+    STAMPSCAN_REQUEST_TIMEOUT = 15
+
 # Enable background validation of SRC-20 blocks processed with FORCE=True
 ENABLE_SRC20_BACKGROUND_VALIDATION = bool(os.environ.get("ENABLE_SRC20_BACKGROUND_VALIDATION", "true").lower() == "true")
 

--- a/indexer/src/index_core/background_validator.py
+++ b/indexer/src/index_core/background_validator.py
@@ -3,8 +3,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
-import config
-from index_core.src20 import fetch_api_ledger_data
+from index_core.src20 import LedgerFetchStatus, fetch_api_ledger_data
 from index_core.validation_queue import ValidationQueueManager
 
 logger = logging.getLogger(__name__)
@@ -75,53 +74,67 @@ class BackgroundValidator:
                 await asyncio.sleep(self.check_interval)
 
     def _should_run_validation(self) -> bool:
-        """Check if we should attempt validation (e.g., not during active indexing)."""
-        # Don't run validation if FORCE is currently True (API is down)
-        if config.FORCE:
-            return False
+        """Check if we should attempt validation.
 
-        # Could add additional checks here, like:
-        # - Is the indexer actively processing blocks?
-        # - Is system load too high?
-        # - Is it within allowed time window?
-
+        Stampscan availability is now determined per-request via the
+        ``LedgerFetchStatus`` returned by ``fetch_api_ledger_data``; the
+        legacy ``config.FORCE``-as-API-state signal has been removed.
+        Validation is always permitted at the queue level — individual
+        fetches deferred when stampscan can't authoritatively answer.
+        """
         return True
 
     def _process_validations(self, pending_validations):
-        """Process a batch of pending validations."""
+        """Process a batch of pending validations.
+
+        Consumes the new ``LedgerFetchResult`` from ``fetch_api_ledger_data``.
+        Only marks a block validated when stampscan returned data for the
+        exact requested block (status OK). For deferral statuses (tip-lag /
+        not_indexed / API error) the row is left in the queue for the next
+        cycle. Mismatches surface via ``ops_alerter`` so they reach SNS /
+        log alerting infrastructure.
+        """
         successful = 0
         failed = 0
 
         for block_index, local_hash, valid_src20_str in pending_validations:
             try:
-                # Temporarily store current FORCE state
-                original_force = config.FORCE
-                config.FORCE = False
+                result = fetch_api_ledger_data(block_index)
 
-                # Attempt to fetch API data
-                api_hash, api_validation = fetch_api_ledger_data(block_index)
-
-                # Restore FORCE state
-                config.FORCE = original_force
-
-                if api_hash is None:
-                    # API is still unavailable
-                    self.queue_manager.mark_api_error(block_index, "API unavailable during background validation")
+                if result.status != LedgerFetchStatus.OK:
+                    # Stampscan still can't authoritatively confirm — leave
+                    # in queue; mark the latest attempt for observability.
+                    self.queue_manager.mark_api_error(
+                        block_index,
+                        f"deferred during background validation: status={result.status.value}",
+                    )
                     failed += 1
                     continue
 
-                # Compare hashes
-                is_valid = api_hash == local_hash
-
-                # Update validation status
-                self.queue_manager.mark_validated(block_index, api_hash, is_valid)
+                is_valid = result.hash == local_hash
+                self.queue_manager.mark_validated(block_index, result.hash, is_valid)
 
                 if is_valid:
                     logger.info(f"✅ Block {block_index} validated successfully")
                     successful += 1
                 else:
-                    logger.error(f"❌ VALIDATION MISMATCH for block {block_index}! " f"Local: {local_hash}, API: {api_hash}")
-                    # Here you could trigger alerts, notifications, etc.
+                    logger.error(f"❌ VALIDATION MISMATCH for block {block_index}! Local: {local_hash}, API: {result.hash}")
+                    # Surface as a real consensus alert through ops_alerter.
+                    try:
+                        from index_core.ops_alerter import notify as ops_notify
+
+                        ops_notify(
+                            "critical",
+                            f"SRC-20 ledger mismatch at block {block_index} (background)",
+                            (
+                                f"Background validator detected SRC-20 ledger_hash divergence at block {block_index}. "
+                                f"Local: {local_hash} Stampscan: {result.hash}. "
+                                f"Investigate immediately."
+                            ),
+                            dedup_key=f"src20-mismatch-bg-{block_index}",
+                        )
+                    except Exception as alert_err:
+                        logger.error(f"ops_alerter notify failed for block {block_index}: {alert_err}")
 
             except Exception as e:
                 logger.error(f"Error validating block {block_index}: {e}")
@@ -129,7 +142,7 @@ class BackgroundValidator:
                 failed += 1
 
         if successful > 0 or failed > 0:
-            logger.info(f"Validation batch complete: {successful} successful, {failed} failed")
+            logger.info(f"Validation batch complete: {successful} successful, {failed} failed/deferred")
 
     def get_status(self) -> dict:
         """Get the current status of the background validator."""

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -327,11 +327,27 @@ class BlockProcessor:
         # Only validate ledger hash if both valid_src20_str and new_ledger_hash are non-empty
         if valid_src20_str and new_ledger_hash:
             if not validate_src20_ledger_hash(block_index, new_ledger_hash, valid_src20_str):
-                # Only raise LedgerMismatchError if FORCE is not enabled
-                if not config.FORCE:
-                    raise LedgerMismatchError(block_index)
-                else:
-                    logger.warning(f"Ledger hash mismatch at block {block_index}. Continuing due to FORCE=True...")
+                # Real consensus divergence (stampscan returned the exact requested
+                # block with a different hash). Surface as a high-signal alert and
+                # keep indexing — crashing here would block recovery and the
+                # background validator can re-check once stampscan is consistent.
+                # Alert failure must NOT crash the main loop, so wrap the import+notify.
+                try:
+                    from index_core.ops_alerter import notify as ops_notify
+
+                    ops_notify(
+                        "critical",
+                        f"SRC-20 ledger mismatch at block {block_index}",
+                        (
+                            f"Local SRC-20 ledger_hash differs from stampscan for block {block_index}. "
+                            f"This indicates a real consensus divergence in SRC-20 processing. "
+                            f"Indexer is continuing; investigate the affected block immediately."
+                        ),
+                        dedup_key=f"src20-mismatch-{block_index}",
+                    )
+                except Exception as alert_err:
+                    logger.error(f"ops_alerter notify failed for block {block_index}: {alert_err}")
+                logger.error(f"SRC-20 LEDGER MISMATCH at block {block_index} — alert sent; continuing")
 
         stamps_in_block = len(self.valid_stamps_in_block)
         src20_in_block = len(self.processed_src20_in_block)

--- a/indexer/src/index_core/src20.py
+++ b/indexer/src/index_core/src20.py
@@ -7,6 +7,7 @@ import time
 from collections import defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from decimal import ROUND_DOWN, Decimal, InvalidOperation
+from enum import Enum
 from typing import List, Optional, TypedDict, Union
 
 import requests
@@ -1248,7 +1249,30 @@ def clear_zero_balances(db):
     return
 
 
-def fetch_api_ledger_data(block_index: int):
+class LedgerFetchStatus(Enum):
+    # Stampscan returned data for the exact requested block.
+    OK = "ok"
+    # Stampscan returned data for an earlier block (M < requested) — its
+    # "shadow" behavior for blocks not yet indexed, or blocks with no SRC-20
+    # activity. From the indexer's POV this is a deferral, not a divergence.
+    BLOCK_INDEX_MISMATCH = "block_index_mismatch"
+    # Stampscan explicitly reports it has not indexed the block yet.
+    NOT_INDEXED = "not_indexed"
+    # Any HTTP / JSON / timeout / empty-validation failure.
+    API_ERROR = "api_error"
+
+
+# Named tuple so callers can still unpack three fields naturally.
+LedgerFetchResult = namedtuple("LedgerFetchResult", ["status", "hash", "validation"])
+
+
+def fetch_api_ledger_data(block_index: int) -> "LedgerFetchResult":
+    """Fetch the canonical SRC-20 ledger hash for ``block_index`` from stampscan.
+
+    Returns a ``LedgerFetchResult`` whose ``status`` distinguishes the four
+    possible outcomes (see ``LedgerFetchStatus``). Never mutates
+    ``config.FORCE`` — control flow is purely via the returned status.
+    """
     urls = []
     # if SRC_VALIDATION_API1:
     #     urls.append(SRC_VALIDATION_API1 + str(block_index))  # OKX diverges on hashes at 856444 due to their sci notation in strings
@@ -1256,135 +1280,111 @@ def fetch_api_ledger_data(block_index: int):
         urls.append(SRC_VALIDATION_API2.format(block_index=block_index, secret=SRC_VALIDATION_SECRET_API2))
 
     if not urls:
-        return None, None
+        return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
 
     max_retries = 5
     backoff_time = 3
-    retry_count = 0
 
     def fetch_url(url):
         try:
-            response = requests.get(url, timeout=15)
-            logger.debug(f"Fetching URL: {url}")
-            logger.debug(f"Response status code: {response.status_code}")
-            logger.debug(f"Response headers: {response.headers}")
-            logger.debug(f"Raw response text: {response.text}")
+            response = requests.get(url, timeout=config.STAMPSCAN_REQUEST_TIMEOUT)
+            logger.debug(f"Fetching URL: {url} → status {response.status_code}")
 
-            if response.status_code == 200:
-                try:
-                    data = response.json()
-                    logger.debug(f"Parsed JSON data: {data}")
-
-                    if "data" in data:
-                        data = data["data"]
-                        logger.debug(f"Data field: {data}")
-
-                        api_ledger_hash = data.get("hash")
-                        api_ledger_validation = data.get("balance_data")
-
-                        logger.debug(f"api_ledger_hash: {api_ledger_hash}")
-                        logger.debug(f"api_ledger_validation: {api_ledger_validation}")
-
-                        if not api_ledger_validation:
-                            logger.error("api_ledger_validation is empty")
-                            return None, None
-
-                        if retry_count > 0:
-                            logger.debug(f"Successfully fetched ledger data after {retry_count} retries")
-
-                        return api_ledger_hash, api_ledger_validation
-                    else:
-                        logger.error("No 'data' key in response JSON")
-                        return None, None
-                except JSONDecodeError as e:
-                    logger.error(f"JSONDecodeError: {e}")
-                    logger.debug(f"Response content: {response.content}")
-                    return None, None
-                except Exception as e:
-                    logger.error(f"Unexpected error parsing JSON: {e}")
-                    return None, None
-            else:
-                # Log 404 specifically at debug level during retries
+            if response.status_code != 200:
                 if response.status_code == 404:
                     logger.debug(f"Non-200 response code: {response.status_code} from URL: {url} (Will retry)")
                 else:
                     logger.warning(f"Non-200 response code: {response.status_code} from URL: {url}")
-                return None, None
+                return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
+
+            try:
+                payload = response.json()
+            except JSONDecodeError as e:
+                logger.error(f"JSONDecodeError: {e}; raw={response.content!r}")
+                return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
+            except Exception as e:
+                logger.error(f"Unexpected error parsing JSON: {e}")
+                return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
+
+            # Explicit "not_indexed" sentinel (no `data` key in this case).
+            if payload.get("msg") == "not_indexed":
+                logger.debug(f"Stampscan reports block {block_index} not_indexed")
+                return LedgerFetchResult(LedgerFetchStatus.NOT_INDEXED, None, None)
+
+            inner = payload.get("data")
+            if not isinstance(inner, dict):
+                logger.error(f"No usable 'data' field in response JSON: {payload}")
+                return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
+
+            api_hash = inner.get("hash")
+            api_validation = inner.get("balance_data")
+            api_block_index_raw = inner.get("block_index")
+
+            if not api_validation:
+                logger.warning(f"Stampscan returned empty balance_data for block {block_index}")
+                return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
+
+            # Stampscan returns the nearest preceding block when ours isn't
+            # yet indexed (or had no SRC-20 activity). Detect that explicitly
+            # via the embedded block_index — it is NOT a consensus mismatch.
+            try:
+                api_block_index = int(api_block_index_raw)
+            except (TypeError, ValueError):
+                logger.error(f"Stampscan response missing/invalid block_index: {api_block_index_raw!r}")
+                return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
+
+            if api_block_index != block_index:
+                logger.debug(
+                    f"Stampscan returned shadow for block {block_index}: "
+                    f"got block_index={api_block_index} (defer to background)"
+                )
+                return LedgerFetchResult(LedgerFetchStatus.BLOCK_INDEX_MISMATCH, api_hash, api_validation)
+
+            return LedgerFetchResult(LedgerFetchStatus.OK, api_hash, api_validation)
+
         except requests.exceptions.RequestException as e:
             logger.error(f"Request failed for URL {url}: {e}")
-            return None, None
+            return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
 
-    for attempt in range(max_retries):
-        retry_count = attempt
+    # Retry only on API_ERROR. OK / NOT_INDEXED / BLOCK_INDEX_MISMATCH are
+    # definitive answers from stampscan; retrying them just adds latency.
+    for _ in range(max_retries):
         with ThreadPoolExecutor() as executor:
             future_to_url = {executor.submit(fetch_url, url): url for url in urls}
             for future in as_completed(future_to_url):
                 result = future.result()
-                if result != (None, None):
+                if result.status != LedgerFetchStatus.API_ERROR:
                     return result
 
         time.sleep(backoff_time)
         backoff_time *= 2
 
-    # Set FORCE to True when API retrieval fails after max retries
-    config.FORCE = True
-    logger.warning(f"Failed to retrieve from the API after {max_retries} retries. Setting FORCE=True to continue processing.")
-    return None, None
+    logger.warning(f"Failed to retrieve from stampscan after {max_retries} retries for block {block_index}")
+    return LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
 
 
-def validate_src20_ledger_hash(block_index: int, ledger_hash: str, valid_src20_str: str):
-    # Reset FORCE to False at the beginning of each validation
-    was_force_enabled = config.FORCE
-    config.FORCE = False
-
+def _enqueue_for_background_validation(block_index: int, ledger_hash: str, valid_src20_str: str, reason: str) -> None:
+    """Enqueue this block for later validation when stampscan can't authoritatively
+    confirm it right now (tip-lag, not-indexed, API error, or unexpected exception).
+    Queue failures are logged but never raised — the main indexer loop must keep moving.
+    """
     try:
-        logger.debug(f"\n{'=' * 50}")
-        logger.debug(f"Validating ledger hash for block {block_index}")
-        logger.debug(f"Local ledger hash: {ledger_hash}")
+        from index_core.validation_queue import ValidationQueueManager
 
-        api_ledger_hash, api_ledger_validation = fetch_api_ledger_data(block_index)
+        ValidationQueueManager.get_instance().add_to_queue(block_index, ledger_hash, valid_src20_str)
+        logger.info(f"Added block {block_index} to validation queue for later checking ({reason})")
+    except Exception as e:
+        logger.error(f"Failed to add block {block_index} to validation queue: {e}")
 
-        # If fetch_api_ledger_data failed and set FORCE to True, we should return True
-        # to allow processing to continue
-        if config.FORCE and not was_force_enabled:
-            logger.warning(
-                f"FORCE was enabled due to API retrieval failure for block {block_index}. Continuing with processing."
-            )
 
-            # Add to validation queue for later checking
-            try:
-                from index_core.validation_queue import ValidationQueueManager
-
-                queue_manager = ValidationQueueManager.get_instance()
-                queue_manager.add_to_queue(block_index, ledger_hash, valid_src20_str)
-                logger.info(f"Added block {block_index} to validation queue for later checking")
-            except Exception as e:
-                logger.error(f"Failed to add block {block_index} to validation queue: {e}")
-
-            return True
-
-        config.FORCE = was_force_enabled
-
-        if api_ledger_validation is None:
-            logger.error(f"API ledger validation data is None. Local ledger_hash: {ledger_hash}")
-            raise ValueError(f"API ledger validation data is None. Local ledger_hash: {ledger_hash}")
-
-        logger.debug(f"API ledger hash: {api_ledger_hash}")
-
-        # Quick comparison of hashes - if they match, we can return immediately
-        if api_ledger_hash == ledger_hash:
-            logger.debug(f"Ledger hashes match for block {block_index}. Skipping detailed comparison.")
-            logger.debug(f"{'=' * 50}\n")
-            return True
-
-        # If we get here, hashes don't match - perform detailed comparison for debugging
-        logger.debug(f"Ledger hashes DON'T match for block {block_index}. Performing detailed comparison.")
-        logger.debug(f"Local ledger string: {valid_src20_str}")
-        logger.debug(f"API ledger string: {api_ledger_validation}")
-
-        # Parse and compare balances
-        local_balances = parse_balances(valid_src20_str)
-        api_balances = parse_balances(api_ledger_validation)
+def _log_balance_diff(local_str: Optional[str], api_str: Optional[str]) -> None:
+    """Pretty-print SRC-20 balance differences at DEBUG level. Diagnostic aid
+    for real-mismatch investigation; never raises."""
+    if not local_str or not api_str:
+        return
+    try:
+        local_balances = parse_balances(local_str)
+        api_balances = parse_balances(api_str)
 
         logger.debug("Local balances:")
         for tick, addresses in local_balances.items():
@@ -1398,26 +1398,57 @@ def validate_src20_ledger_hash(block_index: int, ledger_hash: str, valid_src20_s
             for addr, bal in addresses.items():
                 logger.debug(f"    {addr}: {bal}")
 
-        # Compare string formats
-        local_entries = set(valid_src20_str.split(";"))
-        api_entries = set(api_ledger_validation.split(";"))
-
-        logger.debug("String format comparison:")
-        logger.debug(f"  Local entries count: {len(local_entries)}")
-        logger.debug(f"  API entries count: {len(api_entries)}")
-
+        local_entries = set(local_str.split(";"))
+        api_entries = set(api_str.split(";"))
+        logger.debug(f"String entries: local={len(local_entries)} api={len(api_entries)}")
         differences = local_entries.symmetric_difference(api_entries)
         if differences:
-            logger.debug("Found differences in entries:")
+            logger.debug("Differences:")
             for diff in differences:
                 logger.debug(f"  {diff}")
+    except Exception as e:
+        logger.debug(f"Balance-diff helper failed (non-fatal): {e}")
 
-        logger.debug(f"{'=' * 50}\n")
-        return False  # Return False as hashes don't match
+
+def validate_src20_ledger_hash(block_index: int, ledger_hash: str, valid_src20_str: str) -> bool:
+    """Validate this block's SRC-20 ledger hash against stampscan.
+
+    Returns:
+        ``True`` when validation passed OR was deferred (stampscan tip-lag,
+        not_indexed, API error, unexpected exception). The caller treats True
+        as "keep indexing".
+        ``False`` ONLY when stampscan returned data for the exact requested
+        block AND the hashes differ — a real consensus divergence. The caller
+        is expected to alert (ops_alerter) and continue indexing (no crash).
+    """
+    try:
+        logger.debug(f"\n{'=' * 50}")
+        logger.debug(f"Validating ledger hash for block {block_index}")
+        logger.debug(f"Local ledger hash: {ledger_hash}")
+
+        result = fetch_api_ledger_data(block_index)
+
+        if result.status == LedgerFetchStatus.OK:
+            if result.hash == ledger_hash:
+                logger.debug(f"Ledger hashes match for block {block_index}.")
+                logger.debug(f"{'=' * 50}\n")
+                return True
+
+            # Real divergence. Log diagnostic detail; caller alerts.
+            logger.error(f"SRC-20 ledger hash MISMATCH at block {block_index}: local={ledger_hash} stampscan={result.hash}")
+            _log_balance_diff(valid_src20_str, result.validation)
+            logger.debug(f"{'=' * 50}\n")
+            return False
+
+        # Any non-OK status is a deferral — enqueue for background validator.
+        _enqueue_for_background_validation(block_index, ledger_hash, valid_src20_str, result.status.value)
+        return True
 
     except Exception as e:
-        logger.error(f"Error validating ledger hash: {e}")
-        return False
+        # Last-resort safety net. Defer to background; never crash the indexer.
+        logger.error(f"Unexpected error validating ledger hash for block {block_index}: {e}")
+        _enqueue_for_background_validation(block_index, ledger_hash, valid_src20_str, "exception")
+        return True
 
 
 def parse_balances(balance_str):

--- a/indexer/tests/test_high_risk_src20.py
+++ b/indexer/tests/test_high_risk_src20.py
@@ -655,13 +655,11 @@ class TestLedgerValidationSecurity(unittest.TestCase):
 
     @patch("index_core.src20.fetch_api_ledger_data")
     def test_ledger_hash_validation_mismatch(self, mock_fetch):
-        """Test ledger hash validation detects mismatches."""
-        # Mock API response
-        mock_fetch.return_value = {"ledger_hash": "different_hash", "balances_str": "api_balances"}
+        """OK status + different hashes = real consensus mismatch → returns False."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus
 
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.OK, "different_hash", "api_balances")
         result = validate_src20_ledger_hash(block_index=800000, ledger_hash="local_hash", valid_src20_str="local_balances")
-
-        # Should detect mismatch
         self.assertFalse(result)
 
     @patch("index_core.src20.SRC_VALIDATION_API2", "https://test-api.com/{block_index}/{secret}")
@@ -669,27 +667,26 @@ class TestLedgerValidationSecurity(unittest.TestCase):
     @patch("index_core.src20.time.sleep")  # Mock sleep to speed up test
     @patch("index_core.src20.requests.get")
     def test_api_timeout_handling(self, mock_get, mock_sleep):
-        """Test API timeout handling in ledger validation."""
+        """Timeouts on every retry must return API_ERROR via the new enum
+        (never touch ``config.FORCE``)."""
         from requests.exceptions import Timeout
+
+        from index_core.src20 import LedgerFetchStatus, fetch_api_ledger_data
 
         mock_get.side_effect = Timeout("Request timed out")
         mock_sleep.return_value = None  # Skip actual sleep delays
 
-        # Should handle timeout gracefully
-        from index_core.src20 import fetch_api_ledger_data
-
         result = fetch_api_ledger_data(800000)
 
-        # Function returns tuple (ledger_hash, balances_str), both should be None on timeout
-        self.assertEqual(result, (None, None))
+        self.assertEqual(result.status, LedgerFetchStatus.API_ERROR)
+        self.assertIsNone(result.hash)
+        self.assertIsNone(result.validation)
 
         # Verify it attempted retries (max_retries=5, each submits 1 request via ThreadPoolExecutor).
         # Use assertGreaterEqual because ThreadPoolExecutor thread scheduling can
         # occasionally cause an extra call when thread teardown overlaps with the
         # next iteration's submission.
         self.assertGreaterEqual(mock_get.call_count, 5)
-
-        # Verify sleep was called for backoff between retries
         self.assertGreaterEqual(mock_sleep.call_count, 5)
 
 

--- a/indexer/tests/test_src20_edge_cases.py
+++ b/indexer/tests/test_src20_edge_cases.py
@@ -239,34 +239,35 @@ class TestSrc20EdgeCases(unittest.TestCase):
 
     @patch("index_core.src20.requests.get")
     def test_ledger_validation_edge_cases(self, mock_get):
-        """Test edge cases in ledger validation."""
-        # Test API timeout
+        """Test edge cases in ledger validation.
+
+        Under the #782 algorithm, any stampscan response the indexer can't
+        authoritatively confirm — connection error, malformed payload,
+        missing/wrong block_index — is a *deferral* (returns True, enqueued
+        for the background validator), not a hard failure.
+        """
+        # API timeout / connection error → API_ERROR → deferred (True)
         mock_get.side_effect = Exception("Connection timeout")
+        assert validate_src20_ledger_hash(1000, "expected_hash", "valid_str") is True
 
-        result = validate_src20_ledger_hash(1000, "expected_hash", "valid_str")
-        assert result is False
-
-        # Test malformed API response
+        # Malformed payload (no `data`, no `msg`) → API_ERROR → deferred (True)
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {"malformed": "response"}
         mock_response.raise_for_status = Mock()
+        mock_get.side_effect = None
         mock_get.return_value = mock_response
+        assert validate_src20_ledger_hash(1000, "expected_hash", "valid_str") is True
 
-        result = validate_src20_ledger_hash(1000, "expected_hash", "valid_str")
-        assert result is False
-
-        # Test Unicode in tick names
+        # Schema we don't recognize → API_ERROR → deferred (True)
         mock_response.json.return_value = {"ledger": [{"address": "addr1", "balance": "100"}], "tick": "TEST🚀"}
         mock_get.return_value = mock_response
+        assert validate_src20_ledger_hash(1000, "hash", "valid_str") is True
 
-        # Should handle unicode in API responses
-        result = validate_src20_ledger_hash(1000, "hash", "valid_str")
-
-        # Test empty ledger
+        # Empty ledger / unknown schema → API_ERROR → deferred (True)
         mock_response.json.return_value = {"ledger": [], "tick": "TEST"}
         mock_get.return_value = mock_response
-
-        result = validate_src20_ledger_hash(1000, "hash", "valid_str")
+        assert validate_src20_ledger_hash(1000, "hash", "valid_str") is True
 
     @patch("index_core.src20.update_balance_table")
     def test_database_transaction_atomicity(self, mock_update_balance):

--- a/indexer/tests/test_src20_edge_cases_migrated.py
+++ b/indexer/tests/test_src20_edge_cases_migrated.py
@@ -266,34 +266,35 @@ class TestSrc20EdgeCases:
 
     @patch("index_core.src20.requests.get")
     def test_ledger_validation_edge_cases(self, mock_get):
-        """Test edge cases in ledger validation."""
-        # Test API timeout
+        """Test edge cases in ledger validation.
+
+        Under the #782 algorithm, any stampscan response the indexer can't
+        authoritatively confirm — connection error, malformed payload,
+        missing/wrong block_index — is a *deferral* (returns True, enqueued
+        for the background validator), not a hard failure.
+        """
+        # API timeout / connection error → API_ERROR → deferred (True)
         mock_get.side_effect = Exception("Connection timeout")
+        assert validate_src20_ledger_hash(1000, "expected_hash", "valid_str") is True
 
-        result = validate_src20_ledger_hash(1000, "expected_hash", "valid_str")
-        assert result is False
-
-        # Test malformed API response
+        # Malformed payload (no `data`, no `msg`) → API_ERROR → deferred (True)
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {"malformed": "response"}
         mock_response.raise_for_status = Mock()
+        mock_get.side_effect = None
         mock_get.return_value = mock_response
+        assert validate_src20_ledger_hash(1000, "expected_hash", "valid_str") is True
 
-        result = validate_src20_ledger_hash(1000, "expected_hash", "valid_str")
-        assert result is False
-
-        # Test Unicode in tick names
+        # Schema we don't recognize → API_ERROR → deferred (True)
         mock_response.json.return_value = {"ledger": [{"address": "addr1", "balance": "100"}], "tick": "TEST🚀"}
         mock_get.return_value = mock_response
+        assert validate_src20_ledger_hash(1000, "hash", "valid_str") is True
 
-        # Should handle unicode in API responses
-        result = validate_src20_ledger_hash(1000, "hash", "valid_str")
-
-        # Test empty ledger
+        # Empty ledger / unknown schema → API_ERROR → deferred (True)
         mock_response.json.return_value = {"ledger": [], "tick": "TEST"}
         mock_get.return_value = mock_response
-
-        result = validate_src20_ledger_hash(1000, "hash", "valid_str")
+        assert validate_src20_ledger_hash(1000, "hash", "valid_str") is True
 
     @patch("index_core.src20.update_balance_table")
     def test_database_transaction_atomicity(self, mock_update_balance, mock_db_manager):

--- a/indexer/tests/test_src20_ledger_validation.py
+++ b/indexer/tests/test_src20_ledger_validation.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from index_core.src20 import (
+    LedgerFetchStatus,
     compare_balances,
     fetch_api_ledger_data,
     parse_balances,
@@ -33,48 +34,60 @@ class TestSrc20LedgerValidation(unittest.TestCase):
     @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
     @patch("index_core.src20.requests.get")
     def test_fetch_api_ledger_data_success(self, mock_get):
-        """Test successful API ledger data fetch."""
+        """Successful fetch returns LedgerFetchResult(status=OK, hash, validation).
+
+        Stampscan response must include `block_index` matching the requested
+        block — otherwise it's a BLOCK_INDEX_MISMATCH (shadow / tip-lag).
+        """
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"data": {"hash": "test_hash", "balance_data": "TEST,addr1,100.5;TEST,addr2,200.25"}}
+        mock_response.json.return_value = {
+            "data": {
+                "block_index": 1000,
+                "hash": "test_hash",
+                "balance_data": "TEST,addr1,100.5;TEST,addr2,200.25",
+            }
+        }
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         result = fetch_api_ledger_data(1000)
 
-        # fetch_api_ledger_data returns a tuple (hash, validation_data)
-        assert result[0] == "test_hash"  # hash
-        assert result[1] == "TEST,addr1,100.5;TEST,addr2,200.25"  # validation_data
+        assert result.status == LedgerFetchStatus.OK
+        assert result.hash == "test_hash"
+        assert result.validation == "TEST,addr1,100.5;TEST,addr2,200.25"
         mock_get.assert_called()
 
-    @patch("index_core.src20.config.FORCE", False)
     def test_fetch_api_ledger_data_retry_logic(self):
-        """Test retry logic in API fetch."""
-        # When APIs are not configured, it returns (None, None)
-        # The actual retry logic is internal to the function and hard to test directly
-        # Let's test that it handles the no-API case correctly
+        """With no API URLs configured, returns API_ERROR immediately."""
         with patch("index_core.src20.SRC_VALIDATION_API2", None):
             with patch("index_core.src20.SRC_VALIDATION_SECRET_API2", None):
                 result = fetch_api_ledger_data(1000)
-                assert result == (None, None)
+                assert result.status == LedgerFetchStatus.API_ERROR
+                assert result.hash is None
+                assert result.validation is None
 
-    @patch("index_core.src20.config.FORCE", False)
     def test_fetch_api_ledger_data_max_retries_exceeded(self):
-        """Test behavior when max retries exceeded."""
-        # Test the no-API configured case
-        with patch("index_core.src20.SRC_VALIDATION_API2", None):
-            with patch("index_core.src20.SRC_VALIDATION_SECRET_API2", None):
-                result = fetch_api_ledger_data(1000)
-                # When no APIs configured, returns (None, None)
-                assert result == (None, None)
+        """No API configured → API_ERROR; never mutates config.FORCE."""
+        import config as global_config
+
+        original_force = global_config.FORCE
+        try:
+            global_config.FORCE = False
+            with patch("index_core.src20.SRC_VALIDATION_API2", None):
+                with patch("index_core.src20.SRC_VALIDATION_SECRET_API2", None):
+                    result = fetch_api_ledger_data(1000)
+                    assert result.status == LedgerFetchStatus.API_ERROR
+                    assert global_config.FORCE is False
+        finally:
+            global_config.FORCE = original_force
 
     @patch("index_core.src20.SRC_VALIDATION_API2", "http://test-api.com/{block_index}?secret={secret}")
     @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
     @patch("index_core.src20.time.sleep")  # Mock sleep to speed up test
     @patch("index_core.src20.requests.get")
     def test_fetch_api_ledger_data_malformed_response(self, mock_get, mock_sleep):
-        """Test handling of malformed API responses."""
-        # Test one malformed response - missing data field
+        """Missing `data` field → API_ERROR after retries (deferred)."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"tick": "TEST"}  # Missing 'data' field
@@ -82,8 +95,9 @@ class TestSrc20LedgerValidation(unittest.TestCase):
         mock_get.return_value = mock_response
 
         result = fetch_api_ledger_data(1000)
-        # Should handle gracefully without crashing - returns (None, None) for malformed responses
-        assert result == (None, None)
+        assert result.status == LedgerFetchStatus.API_ERROR
+        assert result.hash is None
+        assert result.validation is None
 
     def test_parse_balances(self):
         """Test parsing balance strings."""
@@ -211,20 +225,24 @@ class TestSrc20LedgerValidation(unittest.TestCase):
     @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
     @patch("index_core.src20.requests.get")
     def test_api_ledger_special_characters_handling(self, mock_get):
-        """Test API response with special characters in addresses."""
+        """Special characters in balance_data are preserved on OK status."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "data": {"hash": "test_hash", "balance_data": "TEST,addr with spaces,100;TEST,addr\\nwith\\nnewlines,200"}
+            "data": {
+                "block_index": 1000,
+                "hash": "test_hash",
+                "balance_data": "TEST,addr with spaces,100;TEST,addr\\nwith\\nnewlines,200",
+            }
         }
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         result = fetch_api_ledger_data(1000)
 
-        # fetch_api_ledger_data returns a tuple
-        assert result[0] == "test_hash"
-        assert "addr with spaces" in result[1]
+        assert result.status == LedgerFetchStatus.OK
+        assert result.hash == "test_hash"
+        assert "addr with spaces" in result.validation
 
     def test_ledger_validation_performance_with_large_datasets(self):
         """Test ledger validation performance with large balance sets."""

--- a/indexer/tests/test_src20_ledger_validation_migrated.py
+++ b/indexer/tests/test_src20_ledger_validation_migrated.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from index_core.src20 import (
+    LedgerFetchStatus,
     compare_balances,
     fetch_api_ledger_data,
     parse_balances,
@@ -42,48 +43,60 @@ class TestSrc20LedgerValidation:
     @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
     @patch("index_core.src20.requests.get")
     def test_fetch_api_ledger_data_success(self, mock_get):
-        """Test successful API ledger data fetch."""
+        """Successful fetch returns LedgerFetchResult(status=OK, hash, validation).
+
+        Stampscan response must include `block_index` matching the requested
+        block — otherwise it's a BLOCK_INDEX_MISMATCH (shadow / tip-lag).
+        """
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"data": {"hash": "test_hash", "balance_data": "TEST,addr1,100.5;TEST,addr2,200.25"}}
+        mock_response.json.return_value = {
+            "data": {
+                "block_index": 1000,
+                "hash": "test_hash",
+                "balance_data": "TEST,addr1,100.5;TEST,addr2,200.25",
+            }
+        }
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         result = fetch_api_ledger_data(1000)
 
-        # fetch_api_ledger_data returns a tuple (hash, validation_data)
-        assert result[0] == "test_hash"  # hash
-        assert result[1] == "TEST,addr1,100.5;TEST,addr2,200.25"  # validation_data
+        assert result.status == LedgerFetchStatus.OK
+        assert result.hash == "test_hash"
+        assert result.validation == "TEST,addr1,100.5;TEST,addr2,200.25"
         mock_get.assert_called()
 
-    @patch("index_core.src20.config.FORCE", False)
     def test_fetch_api_ledger_data_retry_logic(self):
-        """Test retry logic in API fetch."""
-        # When APIs are not configured, it returns (None, None)
-        # The actual retry logic is internal to the function and hard to test directly
-        # Let's test that it handles the no-API case correctly
+        """With no API URLs configured, returns API_ERROR immediately."""
         with patch("index_core.src20.SRC_VALIDATION_API2", None):
             with patch("index_core.src20.SRC_VALIDATION_SECRET_API2", None):
                 result = fetch_api_ledger_data(1000)
-                assert result == (None, None)
+                assert result.status == LedgerFetchStatus.API_ERROR
+                assert result.hash is None
+                assert result.validation is None
 
-    @patch("index_core.src20.config.FORCE", False)
     def test_fetch_api_ledger_data_max_retries_exceeded(self):
-        """Test behavior when max retries exceeded."""
-        # Test the no-API configured case
-        with patch("index_core.src20.SRC_VALIDATION_API2", None):
-            with patch("index_core.src20.SRC_VALIDATION_SECRET_API2", None):
-                result = fetch_api_ledger_data(1000)
-                # When no APIs configured, returns (None, None)
-                assert result == (None, None)
+        """No API configured → API_ERROR; never mutates config.FORCE."""
+        import config as global_config
+
+        original_force = global_config.FORCE
+        try:
+            global_config.FORCE = False
+            with patch("index_core.src20.SRC_VALIDATION_API2", None):
+                with patch("index_core.src20.SRC_VALIDATION_SECRET_API2", None):
+                    result = fetch_api_ledger_data(1000)
+                    assert result.status == LedgerFetchStatus.API_ERROR
+                    assert global_config.FORCE is False
+        finally:
+            global_config.FORCE = original_force
 
     @patch("index_core.src20.SRC_VALIDATION_API2", "http://test-api.com/{block_index}?secret={secret}")
     @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
     @patch("index_core.src20.time.sleep")  # Mock sleep to speed up test
     @patch("index_core.src20.requests.get")
     def test_fetch_api_ledger_data_malformed_response(self, mock_get, mock_sleep):
-        """Test handling of malformed API responses."""
-        # Test one malformed response - missing data field
+        """Missing `data` field → API_ERROR after retries (deferred)."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"tick": "TEST"}  # Missing 'data' field
@@ -91,8 +104,9 @@ class TestSrc20LedgerValidation:
         mock_get.return_value = mock_response
 
         result = fetch_api_ledger_data(1000)
-        # Should handle gracefully without crashing - returns (None, None) for malformed responses
-        assert result == (None, None)
+        assert result.status == LedgerFetchStatus.API_ERROR
+        assert result.hash is None
+        assert result.validation is None
 
     def test_parse_balances(self):
         """Test parsing balance strings."""
@@ -220,20 +234,24 @@ class TestSrc20LedgerValidation:
     @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
     @patch("index_core.src20.requests.get")
     def test_api_ledger_special_characters_handling(self, mock_get):
-        """Test API response with special characters in addresses."""
+        """Special characters in balance_data are preserved on OK status."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "data": {"hash": "test_hash", "balance_data": "TEST,addr with spaces,100;TEST,addr\\nwith\\nnewlines,200"}
+            "data": {
+                "block_index": 1000,
+                "hash": "test_hash",
+                "balance_data": "TEST,addr with spaces,100;TEST,addr\\nwith\\nnewlines,200",
+            }
         }
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         result = fetch_api_ledger_data(1000)
 
-        # fetch_api_ledger_data returns a tuple
-        assert result[0] == "test_hash"
-        assert "addr with spaces" in result[1]
+        assert result.status == LedgerFetchStatus.OK
+        assert result.hash == "test_hash"
+        assert "addr with spaces" in result.validation
 
     def test_ledger_validation_performance_with_large_datasets(self):
         """Test ledger validation performance with large balance sets."""

--- a/indexer/tests/test_validation_queue.py
+++ b/indexer/tests/test_validation_queue.py
@@ -1,8 +1,7 @@
 import asyncio
 import os
 import tempfile
-from datetime import datetime, timedelta
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -214,25 +213,28 @@ class TestBackgroundValidator:
         validator.queue_manager.get_pending_validations.assert_called()
 
     def test_should_run_validation(self, validator):
-        """Test validation run conditions."""
-        # Should not run when FORCE is True
-        with patch("index_core.background_validator.config.FORCE", True):
-            assert not validator._should_run_validation()
+        """Validation is always permitted at the queue level under #782.
 
-        # Should run when FORCE is False
-        with patch("index_core.background_validator.config.FORCE", False):
-            assert validator._should_run_validation()
+        Stampscan availability is now determined per-request via
+        ``LedgerFetchStatus``; the legacy ``config.FORCE`` gate has been
+        removed from ``_should_run_validation``.
+        """
+        assert validator._should_run_validation() is True
 
     @patch("index_core.background_validator.fetch_api_ledger_data")
     def test_process_validations_success(self, mock_fetch, validator):
         """Test processing validations successfully."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus
+
         pending = [(906394, "hash1", "src20_data1"), (906395, "hash2", "src20_data2")]
 
-        # Mock API returns matching hashes
-        mock_fetch.side_effect = [("hash1", {"some": "data"}), ("hash2", {"some": "data"})]
+        # Mock API returns matching hashes (status OK = block_index matches)
+        mock_fetch.side_effect = [
+            LedgerFetchResult(LedgerFetchStatus.OK, "hash1", "balance_data_1"),
+            LedgerFetchResult(LedgerFetchStatus.OK, "hash2", "balance_data_2"),
+        ]
 
-        with patch("index_core.background_validator.config.FORCE", False):
-            validator._process_validations(pending)
+        validator._process_validations(pending)
 
         # Should mark both as validated
         assert validator.queue_manager.mark_validated.call_count == 2
@@ -241,35 +243,36 @@ class TestBackgroundValidator:
 
     @patch("index_core.background_validator.fetch_api_ledger_data")
     def test_process_validations_mismatch(self, mock_fetch, validator):
-        """Test processing validations with mismatch."""
+        """Real consensus mismatch — status OK + hashes differ — must alert and mark invalid."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus
+
         pending = [(906394, "local_hash", "src20_data")]
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.OK, "api_hash", "balance_data")
 
-        # Mock API returns different hash
-        mock_fetch.return_value = ("api_hash", {"some": "data"})
+        with patch("index_core.background_validator.logger") as mock_logger:
+            validator._process_validations(pending)
 
-        with patch("index_core.background_validator.config.FORCE", False):
-            with patch("index_core.background_validator.logger") as mock_logger:
-                validator._process_validations(pending)
-
-                # Should log error for mismatch
-                mock_logger.error.assert_called()
-                assert "VALIDATION MISMATCH" in mock_logger.error.call_args[0][0]
+            # Should log error for mismatch
+            mock_logger.error.assert_called()
+            assert any("VALIDATION MISMATCH" in call.args[0] for call in mock_logger.error.call_args_list)
 
         validator.queue_manager.mark_validated.assert_called_with(906394, "api_hash", False)
 
     @patch("index_core.background_validator.fetch_api_ledger_data")
     def test_process_validations_api_error(self, mock_fetch, validator):
-        """Test processing validations when API is unavailable."""
+        """Non-OK status — block stays in queue, marked with the deferral reason."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus
+
         pending = [(906394, "hash1", "src20_data")]
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
 
-        # Mock API returns None (unavailable)
-        mock_fetch.return_value = (None, None)
+        validator._process_validations(pending)
 
-        with patch("index_core.background_validator.config.FORCE", False):
-            validator._process_validations(pending)
-
-        # Should mark as API error
-        validator.queue_manager.mark_api_error.assert_called_with(906394, "API unavailable during background validation")
+        validator.queue_manager.mark_api_error.assert_called_once()
+        call_args = validator.queue_manager.mark_api_error.call_args
+        assert call_args.args[0] == 906394
+        assert "deferred" in call_args.args[1]
+        assert "api_error" in call_args.args[1]
 
     def test_get_status(self, validator):
         """Test getting validator status."""
@@ -289,42 +292,124 @@ class TestSrc20Integration:
 
     @patch("index_core.validation_queue.ValidationQueueManager")
     @patch("index_core.src20.fetch_api_ledger_data")
-    @patch("index_core.src20.config")
-    def test_validate_with_force_adds_to_queue(self, mock_config, mock_fetch, mock_queue_class):
-        """Test that blocks processed with FORCE are added to validation queue."""
-        from index_core.src20 import validate_src20_ledger_hash
+    def test_validate_api_error_enqueues_and_continues(self, mock_fetch, mock_queue_class):
+        """API_ERROR / NOT_INDEXED / BLOCK_INDEX_MISMATCH paths all enqueue
+        the block for the background validator and return True so indexing
+        continues. ``config.FORCE`` is no longer touched by this path."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus, validate_src20_ledger_hash
 
-        # Setup mocks
-        # Initial state: FORCE is False
-        mock_config.FORCE = False
-        mock_config.ENABLE_SRC20_BACKGROUND_VALIDATION = True  # Enable background validation
-
-        # Mock fetch_api_ledger_data to simulate API failure that sets FORCE=True
-        def mock_fetch_side_effect(*args):
-            # Simulate API failure that enables FORCE
-            mock_config.FORCE = True
-            return (None, None)
-
-        mock_fetch.side_effect = mock_fetch_side_effect
-
-        # Mock the ValidationQueueManager singleton
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.API_ERROR, None, None)
         mock_queue_instance = Mock()
         mock_queue_instance.add_to_queue = Mock()
         mock_queue_class.get_instance.return_value = mock_queue_instance
 
-        # Run validation
         block_index = 906394
         ledger_hash = "test_hash"
         valid_src20_str = "test_data"
 
-        result = validate_src20_ledger_hash(block_index, ledger_hash, valid_src20_str)
+        assert validate_src20_ledger_hash(block_index, ledger_hash, valid_src20_str) is True
 
-        # Should return True to continue processing when FORCE gets enabled
-        assert result is True
-
-        # Should get singleton instance and add to queue
         mock_queue_class.get_instance.assert_called_once()
         mock_queue_instance.add_to_queue.assert_called_once_with(block_index, ledger_hash, valid_src20_str)
+
+    @patch("index_core.validation_queue.ValidationQueueManager")
+    @patch("index_core.src20.fetch_api_ledger_data")
+    def test_validate_block_index_mismatch_enqueues(self, mock_fetch, mock_queue_class):
+        """Stampscan shadow response (block_index < requested) also defers."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus, validate_src20_ledger_hash
+
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.BLOCK_INDEX_MISMATCH, "shadow_hash", "shadow_data")
+        mock_queue_instance = Mock()
+        mock_queue_class.get_instance.return_value = mock_queue_instance
+
+        assert validate_src20_ledger_hash(906394, "test_hash", "test_data") is True
+        mock_queue_instance.add_to_queue.assert_called_once_with(906394, "test_hash", "test_data")
+
+    @patch("index_core.src20.fetch_api_ledger_data")
+    def test_validate_real_mismatch_returns_false(self, mock_fetch):
+        """OK status + hashes differ = real consensus divergence → False.
+        The caller (blocks.py) is expected to emit an ops_alerter notification."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus, validate_src20_ledger_hash
+
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.OK, "stampscan_hash", "balance_data")
+        assert validate_src20_ledger_hash(906394, "local_hash", "src20_data") is False
+
+    @patch("index_core.src20.fetch_api_ledger_data")
+    def test_validate_ok_matching_hashes(self, mock_fetch):
+        """OK status + matching hashes = success path."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus, validate_src20_ledger_hash
+
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.OK, "same_hash", "balance_data")
+        assert validate_src20_ledger_hash(906394, "same_hash", "src20_data") is True
+
+    @patch("index_core.src20.requests.get")
+    def test_fetch_api_does_not_mutate_force(self, mock_get):
+        """Even after max retries on API errors, fetch_api_ledger_data
+        must NOT mutate ``config.FORCE``. Control flow is via the
+        returned ``LedgerFetchStatus`` only."""
+        import config as global_config
+        from index_core.src20 import LedgerFetchStatus, fetch_api_ledger_data
+
+        original_force = global_config.FORCE
+        try:
+            global_config.FORCE = False
+            mock_get.side_effect = Exception("boom")
+            result = fetch_api_ledger_data(123456)
+            assert result.status == LedgerFetchStatus.API_ERROR
+            assert global_config.FORCE is False
+        finally:
+            global_config.FORCE = original_force
+
+    @patch("index_core.validation_queue.ValidationQueueManager")
+    @patch("index_core.src20.fetch_api_ledger_data")
+    def test_validate_not_indexed_enqueues(self, mock_fetch, mock_queue_class):
+        """NOT_INDEXED status defers to background validator without raising."""
+        from index_core.src20 import LedgerFetchResult, LedgerFetchStatus, validate_src20_ledger_hash
+
+        mock_fetch.return_value = LedgerFetchResult(LedgerFetchStatus.NOT_INDEXED, None, None)
+        mock_queue_instance = Mock()
+        mock_queue_class.get_instance.return_value = mock_queue_instance
+
+        assert validate_src20_ledger_hash(906394, "local_hash", "test_data") is True
+        mock_queue_instance.add_to_queue.assert_called_once_with(906394, "local_hash", "test_data")
+
+    @patch("index_core.src20.SRC_VALIDATION_API2", "https://test-api.com/{block_index}/{secret}")
+    @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
+    @patch("index_core.src20.time.sleep")
+    @patch("index_core.src20.requests.get")
+    def test_fetch_api_not_indexed_short_circuits_retries(self, mock_get, mock_sleep):
+        """NOT_INDEXED is a definitive answer — must NOT retry. Guards against
+        a future refactor reintroducing the legacy retry-on-any-failure loop."""
+        from index_core.src20 import LedgerFetchStatus, fetch_api_ledger_data
+
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"msg": "not_indexed"}
+        mock_get.return_value = response
+
+        result = fetch_api_ledger_data(800000)
+        assert result.status == LedgerFetchStatus.NOT_INDEXED
+        assert mock_get.call_count == 1
+        assert mock_sleep.call_count == 0
+
+    @patch("index_core.src20.SRC_VALIDATION_API2", "https://test-api.com/{block_index}/{secret}")
+    @patch("index_core.src20.SRC_VALIDATION_SECRET_API2", "test-secret")
+    @patch("index_core.src20.time.sleep")
+    @patch("index_core.src20.requests.get")
+    def test_fetch_api_block_index_mismatch_short_circuits_retries(self, mock_get, mock_sleep):
+        """BLOCK_INDEX_MISMATCH (stampscan shadow) is also definitive."""
+        from index_core.src20 import LedgerFetchStatus, fetch_api_ledger_data
+
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"data": {"hash": "shadow_hash", "balance_data": "shadow_data", "block_index": "799995"}}
+        mock_get.return_value = response
+
+        result = fetch_api_ledger_data(800000)
+        assert result.status == LedgerFetchStatus.BLOCK_INDEX_MISMATCH
+        assert result.hash == "shadow_hash"
+        assert mock_get.call_count == 1
+        assert mock_sleep.call_count == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the first half of #782. Replaces stampscan validation's brittle "any failure → silent (None, None)" contract with an explicit four-state enum, and routes real consensus divergences to `ops_alerter` instead of `FORCE=true` masking.

## The bug

Stampscan deliberately returns the **nearest preceding SRC-20-touching block** when asked about a block with no new SRC-20 activity (or one it hasn't yet indexed). The previous `fetch_url` read `data.hash` without verifying `data.block_index == requested`, so every shadow response looked like a "ledger hash mismatch" — and only `FORCE=true` in prod's `.env` kept the indexer from crashing at chain tip every minute.

The 2026-06-23 dev reindex was the first time `FORCE=false` was attempted at tip in months. Every shadow response crashed the indexer. The team filed #782 and reverted to `FORCE=true` to unblock.

## The fix

### `fetch_api_ledger_data` — new return contract
```python
class LedgerFetchStatus(Enum):
    OK = "ok"                       # data.block_index == requested
    BLOCK_INDEX_MISMATCH = "..."    # stampscan shadow (M < requested)
    NOT_INDEXED = "not_indexed"     # explicit "msg": "not_indexed"
    API_ERROR = "api_error"         # HTTP/JSON/timeout/empty
```
Returns `LedgerFetchResult(status, hash, validation)` namedtuple. Retries are gated on `API_ERROR` only — `NOT_INDEXED` and `BLOCK_INDEX_MISMATCH` are definitive answers, returning immediately.

### `validate_src20_ledger_hash` — clean control flow
- `OK + hashes match` → return True
- `OK + hashes differ` → return False (caller alerts; **real consensus divergence**)
- Any other status → enqueue for background validator + return True (defer)
- Unexpected exception → enqueue + return True (last-resort safety net)

### `blocks.py` call site — alert + continue, no more crash
On real mismatch (validate returns False), emit `ops_alerter.notify("critical", ...)` and continue indexing. Wrapped in try/except so an alerter failure can't crash the main loop. The `FORCE` check on the SRC-20 path is removed — `ops_alerter` IS the new "loud failure" mechanism, and the indexer should never crash on stampscan disagreement.

### `background_validator._process_validations` — enum-aware + alerts on mismatch
- Consumes the new `LedgerFetchResult`
- Only marks `validated` on status `OK`; non-OK rows stay in the queue with a deferral reason
- On `OK + mismatch`, emits its own `ops_alerter` notification with a distinct `dedup_key` (`src20-mismatch-bg-{block}`) so background and main-loop alerts don't dedupe each other

### `config.FORCE` mutation eliminated
- `fetch_api_ledger_data` no longer sets `config.FORCE = True` after max retries (latent footgun)
- `validate_src20_ledger_hash` no longer save/clear/restores it
- `background_validator._process_validations` no longer save/clear/restores it
- Removes a latent race once PR-2 wakes the validator thread

### New env knob
- `STAMPSCAN_REQUEST_TIMEOUT` (default 15s) — replaces hardcoded timeout

## What's NOT in this PR (PR-2)

The dead `asyncio.run(validator.start())` at `server.py:387` is fixed in a follow-up. PR-1's changes are still net-positive on their own: the validation queue continues to accept entries; once PR-2 lands the consumer side wakes up and drains them.

## Test plan

- [x] All ~1850 existing unit tests pass
- [x] 132 tests in the SRC-20 / validation-queue suites pass after the contract change
- [x] New tests added:
  - `test_validate_block_index_mismatch_enqueues` — shadow response defers, no alert
  - `test_validate_real_mismatch_returns_false` — OK + hash diff = False
  - `test_validate_ok_matching_hashes` — success path
  - `test_validate_api_error_enqueues_and_continues`
  - `test_validate_not_indexed_enqueues`
  - `test_fetch_api_does_not_mutate_force` — explicit `config.FORCE` invariant
  - `test_fetch_api_not_indexed_short_circuits_retries` — guards against legacy retry loop reintroduction
  - `test_fetch_api_block_index_mismatch_short_circuits_retries` — same
- [x] `black` + `flake8` clean on all changed files
- [ ] Dev-stack soak with `FORCE=false` at chain tip for 1h: confirm no crash on shadow responses; verify validation queue accepts/defers
- [ ] After PR-2 lands: 24h `FORCE=false` soak; queue drains; verify `Block X validated successfully` log entries appear

Refs #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)