### PR TITLE
fix(#782) part 2: run SRC-20 background validator in a daemon thread

### DIFF
--- a/indexer/src/index_core/server.py
+++ b/indexer/src/index_core/server.py
@@ -375,16 +375,52 @@ def start_all(db: Connection) -> None:
         else:
             logger.info("Async holder count updater is disabled via ENABLE_ASYNC_HOLDER_UPDATES=false")
 
-        # Start the SRC-20 validation background service
+        # Start the SRC-20 validation background service.
+        #
+        # The legacy `asyncio.run(validator.start())` did not work: start()
+        # only schedules `_validation_loop` as a task on the new loop and
+        # returns immediately, after which asyncio.run() tears the loop
+        # down and cancels the task. The queue accepted writes but its
+        # consumer never ran — `Block X validated successfully` /
+        # `VALIDATION MISMATCH` log lines were absent for the entire
+        # service uptime.
+        #
+        # Run the validator in its own daemon thread with its own event
+        # loop, mirroring the existing daemon-thread pattern used by
+        # ops_alerter.ProgressWatchdog / async_upload / async_holder_updater.
+        # Daemon=True so the thread doesn't block process shutdown — the
+        # finally block below sets is_running=False to ask the loop to
+        # exit cleanly first.
         if config.ENABLE_SRC20_BACKGROUND_VALIDATION:
             try:
                 import asyncio
+                import threading
 
                 from index_core.background_validator import get_background_validator
 
                 validator = get_background_validator()
-                logger.info("Starting SRC-20 background validator...")
-                asyncio.run(validator.start())
+
+                def _run_validator_loop():
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
+                    try:
+                        loop.run_until_complete(validator._validation_loop())
+                    except Exception as loop_err:
+                        logger.error(f"SRC-20 background validator loop crashed: {loop_err}")
+                    finally:
+                        try:
+                            loop.close()
+                        except Exception:
+                            pass
+
+                validator.is_running = True
+                validator_thread = threading.Thread(
+                    target=_run_validator_loop,
+                    name="src20-bg-validator",
+                    daemon=True,
+                )
+                validator_thread.start()
+                logger.info("Background validator started (daemon thread)")
             except Exception as e:
                 logger.error(f"Failed to start background validator: {e}")
                 # Continue without background validation
@@ -398,13 +434,18 @@ def start_all(db: Connection) -> None:
             shutdown_flag.set()
         logger.info("Server shutdown initiated.")
 
-        # Stop the background validator if it's running
+        # Stop the background validator if it's running. The thread is a
+        # daemon, so process exit will kill it regardless — this path just
+        # asks the loop to exit cleanly on its next check_interval tick.
         if validator and config.ENABLE_SRC20_BACKGROUND_VALIDATION:
             try:
                 logger.info("Stopping SRC-20 background validator...")
-                import asyncio
-
-                asyncio.run(validator.stop())
+                validator.is_running = False
+                # Best-effort shutdown of the internal ThreadPoolExecutor too.
+                try:
+                    validator.executor.shutdown(wait=False)
+                except Exception:
+                    pass
             except Exception as e:
                 logger.error(f"Error stopping background validator: {e}")
 

--- a/indexer/tests/test_validation_queue.py
+++ b/indexer/tests/test_validation_queue.py
@@ -412,5 +412,59 @@ class TestSrc20Integration:
         assert mock_sleep.call_count == 0
 
 
+class TestValidatorThreadLifecycle:
+    """Regression cover for #782 part 2 — validator must survive in its own
+    daemon thread with its own asyncio loop, not be cancelled by an
+    asyncio.run() teardown the way the legacy `asyncio.run(validator.start())`
+    pattern silently did."""
+
+    def test_validation_loop_runs_in_daemon_thread(self):
+        """Spawn `_validation_loop` in the same pattern server.py uses and
+        verify it actually executes (processes the mocked queue) before
+        being asked to stop."""
+        import asyncio
+        import threading
+        import time
+
+        # Independent ValidationQueueManager isolation
+        ValidationQueueManager._instance = None
+
+        mock_queue_manager = Mock(spec=ValidationQueueManager)
+        mock_queue_manager.get_pending_validations = Mock(return_value=[])
+        mock_queue_manager.get_validation_stats = Mock(return_value={})
+
+        with patch.object(ValidationQueueManager, "get_instance", return_value=mock_queue_manager):
+            validator = BackgroundValidator(check_interval=1)
+
+        def _run():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(validator._validation_loop())
+            finally:
+                loop.close()
+
+        validator.is_running = True
+        thread = threading.Thread(target=_run, name="test-validator", daemon=True)
+        thread.start()
+
+        # Give the loop one tick to call get_pending_validations.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if mock_queue_manager.get_pending_validations.called:
+                break
+            time.sleep(0.05)
+
+        # Ask the loop to exit
+        validator.is_running = False
+        thread.join(timeout=3.0)
+
+        # The legacy pattern (asyncio.run + start()) cancelled the task
+        # before it ever ran; under the fix the loop must have ticked at
+        # least once and the thread must have exited cleanly.
+        assert mock_queue_manager.get_pending_validations.called
+        assert not thread.is_alive()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes the second half of #782. The legacy `asyncio.run(validator.start())` at `server.py:387` never worked — `start()` schedules `_validation_loop` as a task on the new loop and returns immediately, after which `asyncio.run()` tears the loop down and cancels the task. The validation queue accepted enqueues from the main loop but its consumer never ran (zero `Block X validated successfully` log entries across 5+ days of journalctl on prod).

Runs the validator in a daemon thread that owns its own asyncio event loop, mirroring the existing daemon-thread pattern used by `ops_alerter.ProgressWatchdog`, `async_upload`, and `async_holder_updater`.

## Depends on #788 (already merged)

Now consumes the `LedgerFetchResult` namedtuple from #788. Rebased onto dev.

## Changes

- `server.py:378-417` — replace `asyncio.run(validator.start())` with `threading.Thread(target=_run_validator_loop, daemon=True)` that creates its own event loop and `run_until_complete(_validation_loop())`. Wraps in try/except so crashes log but don't bubble; daemon=True so process exit isn't blocked.
- `server.py:402-415` (shutdown) — drop the broken `asyncio.run(validator.stop())` symmetry; just flip `is_running=False` and best-effort `executor.shutdown(wait=False)`.
- `tests/test_validation_queue.py:TestValidatorThreadLifecycle::test_validation_loop_runs_in_daemon_thread` — new regression test that spawns `_validation_loop` in the exact pattern `server.py` uses and asserts `get_pending_validations` was actually called before shutdown.

## Test plan

- [x] New `test_validation_loop_runs_in_daemon_thread` passes
- [x] All 24 tests in `test_validation_queue.py` pass
- [x] black + flake8 clean
- [ ] After merge: prod restart confirms `Background validator started (daemon thread)` appears; `Block X validated successfully` log entries appear once the queue gets any entries
- [ ] 24h prod `FORCE=false` soak: queue drains; real mismatches (if any) surface via ops_alerter SNS

Refs #782 part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)