### PR TITLE
feat(#779): startup chain-integrity check vs bitcoind

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -454,6 +454,17 @@ try:
 except ValueError:
     STAMPSCAN_REQUEST_TIMEOUT = 15
 
+# Depth of the startup chain-integrity check (issue #779). On every indexer
+# start, the last N stored block_hash values are compared against bitcoind's
+# canonical chain. If any mismatch is found the indexer rolls back to the
+# divergence point - 1 and resumes from there. Set to 0 to disable (not
+# recommended in production — this is defense in depth against post-crash
+# stale-row scenarios like the 945,189 incident from 2026-04-15).
+try:
+    STARTUP_CHAIN_INTEGRITY_DEPTH = int(os.environ.get("STARTUP_CHAIN_INTEGRITY_DEPTH", "100"))
+except ValueError:
+    STARTUP_CHAIN_INTEGRITY_DEPTH = 100
+
 # Enable background validation of SRC-20 blocks processed with FORCE=True
 ENABLE_SRC20_BACKGROUND_VALIDATION = bool(os.environ.get("ENABLE_SRC20_BACKGROUND_VALIDATION", "true").lower() == "true")
 

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -16,7 +16,7 @@ import threading
 import time
 import urllib.parse
 from collections import namedtuple
-from typing import List
+from typing import List, Optional
 
 import pymysql as mysql
 import requests
@@ -729,6 +729,76 @@ def rollback_and_clear_caches(db: Connection, error_type: str = "general") -> No
         # Continue anyway - rollback is more important than cache clearing
 
 
+def verify_recent_chain_integrity(db: Connection, depth: int) -> Optional[int]:
+    """Compare the last ``depth`` stored ``block_hash`` values against bitcoind's
+    canonical chain. Defense in depth for the post-#728 scenario (issue #779):
+    if the indexer ever crashes mid-reorg and restarts after the tip has
+    advanced beyond the orphan-check window, stale-row drift would otherwise
+    persist indefinitely (as happened at block 945,189 on 2026-04-15).
+
+    Returns:
+        ``None`` if the last ``depth`` blocks match bitcoind exactly.
+        Otherwise the OLDEST mismatching ``block_index`` — caller should
+        rollback to ``divergence - 1`` so the divergent block (and everything
+        after it) gets re-fetched and re-processed.
+
+    Logs at WARNING when a divergence is found, INFO on clean pass.
+    Never raises — any backend / DB error is logged and treated as
+    inconclusive (returns None) so a transient bitcoind hiccup at startup
+    cannot block the indexer from coming up.
+    """
+    if depth <= 0:
+        return None
+
+    try:
+        with db.cursor() as cursor:
+            cursor.execute(
+                "SELECT block_index, block_hash FROM blocks ORDER BY block_index DESC LIMIT %s",
+                (depth,),
+            )
+            rows = cursor.fetchall()
+    except Exception as e:
+        logger.warning(f"Startup chain-integrity check skipped (DB read failed): {e}")
+        return None
+
+    if not rows:
+        logger.debug("Startup chain-integrity check skipped (no stored blocks)")
+        return None
+
+    # Iterate oldest → newest so the first mismatch we find is the divergence
+    # point. Returning the OLDEST diverging block (rather than the newest) is
+    # important: if a reorg replaced blocks N..N+k, every one of N..N+k will
+    # mismatch — we need to roll back to N - 1 so all of them get re-fetched.
+    rows_sorted = sorted(rows, key=lambda r: r[0])
+    divergence: Optional[int] = None
+    checked = 0
+    for block_index, stored_hash in rows_sorted:
+        try:
+            canonical_hash = backend_instance.getblockhash(block_index)
+        except Exception as e:
+            logger.warning(
+                f"Startup chain-integrity check inconclusive at block {block_index} "
+                f"(bitcoind getblockhash failed: {e}); skipping remaining checks"
+            )
+            return divergence  # may be None — accept best-effort findings so far
+        checked += 1
+        if canonical_hash != stored_hash:
+            divergence = block_index
+            break
+
+    if divergence is None:
+        logger.info(f"Startup chain-integrity check: last {checked} blocks match bitcoind ✓")
+        return None
+
+    newest_in_window = rows_sorted[-1][0]
+    logger.warning(
+        f"Startup chain-integrity check: divergence detected at block {divergence} "
+        f"(checked range {rows_sorted[0][0]}..{newest_in_window}); "
+        f"will roll back to {divergence - 1} and re-process"
+    )
+    return divergence
+
+
 def rollback_to_block(db: Connection, block_index: int, reason: str) -> int:
     """Roll back the database to a specific block index with full cleanup."""
     # Calculate rollback depth based on error type
@@ -898,6 +968,25 @@ def follow(
         # follow() with a stale value (the prior incident drove
         # is_prev_block_parsed into an iterative destructive purge cascade).
         util.CURRENT_BLOCK_INDEX = last_db_index(db)
+
+        # Issue #779: startup chain-integrity check. Catches stale-row drift
+        # from any post-#728 crash-during-reorg-then-restart-after-tip-moved
+        # scenario (same failure mode as the 945,189 incident from 2026-04-15).
+        # Runs once per startup; on divergence triggers a normal rollback,
+        # then re-reads the tip so the main loop resumes from the correct
+        # block_index. Gated by STARTUP_CHAIN_INTEGRITY_DEPTH (default 100;
+        # set to 0 to disable).
+        try:
+            divergence_block = verify_recent_chain_integrity(db, config.STARTUP_CHAIN_INTEGRITY_DEPTH)
+        except Exception as chain_check_err:
+            # Belt-and-suspenders — function already swallows its own errors,
+            # but a totally unexpected failure must not block startup.
+            logger.warning(f"Startup chain-integrity check raised unexpectedly: {chain_check_err}")
+            divergence_block = None
+        if divergence_block is not None:
+            rollback_to_block(db, divergence_block - 1, f"Startup chain-integrity divergence at {divergence_block}")
+            util.CURRENT_BLOCK_INDEX = last_db_index(db)
+
         block_tip = backend_instance.getblockcount()
         if util.CURRENT_BLOCK_INDEX == 0:
             logger.warning("New database.")

--- a/indexer/tests/test_chain_integrity.py
+++ b/indexer/tests/test_chain_integrity.py
@@ -1,0 +1,154 @@
+"""Tests for the startup chain-integrity check (issue #779).
+
+The function under test is ``index_core.blocks.verify_recent_chain_integrity``.
+It reads the last N stored blocks from the DB and compares each ``block_hash``
+against ``backend_instance.getblockhash(block_index)``. The OLDEST diverging
+block is returned (so the caller can roll back from divergence-1 and re-process
+everything after); ``None`` means clean / inconclusive.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+os.environ["TESTING"] = "1"
+os.environ["USE_TEST_DB"] = "1"
+os.environ["MOCK_DB"] = "1"
+os.environ["RPC_USER"] = "rpc"
+os.environ["RPC_PASSWORD"] = "rpc"
+os.environ["RPC_IP"] = "127.0.0.1"
+os.environ["RPC_PORT"] = "8332"
+
+
+def _make_db(rows):
+    """Return a mock pymysql connection whose cursor.fetchall() yields ``rows``.
+
+    Rows are returned in the DESC order the SQL query uses.
+    """
+    db = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = list(rows)
+    db.cursor.return_value.__enter__.return_value = cursor
+    db.cursor.return_value.__exit__.return_value = None
+    return db
+
+
+def test_clean_chain_returns_none():
+    """Every stored block matches bitcoind → return None."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    rows = [(102, "hash102"), (101, "hash101"), (100, "hash100")]  # DESC
+    db = _make_db(rows)
+
+    with patch("index_core.blocks.backend_instance") as backend:
+        backend.getblockhash.side_effect = lambda i: f"hash{i}"
+        assert verify_recent_chain_integrity(db, depth=3) is None
+
+    # All three blocks were checked, in ascending order.
+    assert [call.args[0] for call in backend.getblockhash.call_args_list] == [100, 101, 102]
+
+
+def test_oldest_divergence_is_returned():
+    """When blocks 100..102 all diverge, the OLDEST (100) must be returned.
+
+    Rolling back to divergence-1 from the newest mismatch would miss the
+    older stale rows; rolling back to divergence-1 from the oldest catches
+    everything.
+    """
+    from index_core.blocks import verify_recent_chain_integrity
+
+    rows = [(102, "stale102"), (101, "stale101"), (100, "stale100")]
+    db = _make_db(rows)
+
+    with patch("index_core.blocks.backend_instance") as backend:
+        backend.getblockhash.side_effect = lambda i: f"canonical{i}"
+        assert verify_recent_chain_integrity(db, depth=3) == 100
+
+    # We stop on the first mismatch — only one canonical lookup happens.
+    assert backend.getblockhash.call_count == 1
+
+
+def test_single_block_diverges_in_middle():
+    """Mid-window divergence: 100 matches, 101 diverges, 102 doesn't matter."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    rows = [(102, "hash102"), (101, "stale101"), (100, "hash100")]
+    db = _make_db(rows)
+
+    with patch("index_core.blocks.backend_instance") as backend:
+        backend.getblockhash.side_effect = lambda i: f"hash{i}"
+        assert verify_recent_chain_integrity(db, depth=3) == 101
+
+    # 100 (ok) then 101 (diverges, stop).
+    assert backend.getblockhash.call_count == 2
+
+
+def test_depth_zero_is_no_op():
+    """depth=0 disables the check entirely — no DB or backend calls."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    db = MagicMock()
+    with patch("index_core.blocks.backend_instance") as backend:
+        assert verify_recent_chain_integrity(db, depth=0) is None
+    assert not db.cursor.called
+    assert not backend.getblockhash.called
+
+
+def test_empty_blocks_table_returns_none():
+    """Fresh DB with no stored blocks → None, never calls backend."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    db = _make_db([])
+    with patch("index_core.blocks.backend_instance") as backend:
+        assert verify_recent_chain_integrity(db, depth=10) is None
+    assert not backend.getblockhash.called
+
+
+def test_db_read_failure_returns_none_safely():
+    """A DB read error must not raise — startup should not be blocked."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    db = MagicMock()
+    db.cursor.side_effect = RuntimeError("DB went away")
+    with patch("index_core.blocks.backend_instance") as backend:
+        assert verify_recent_chain_integrity(db, depth=10) is None
+    assert not backend.getblockhash.called
+
+
+def test_backend_failure_returns_best_effort():
+    """If bitcoind getblockhash fails mid-check, return any divergence found
+    so far (None if none yet). Never raises."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    rows = [(102, "hash102"), (101, "hash101"), (100, "hash100")]
+    db = _make_db(rows)
+
+    with patch("index_core.blocks.backend_instance") as backend:
+        # 100 ok, then 101 raises → result is None (no divergence found yet)
+        def fake_getblockhash(i):
+            if i == 100:
+                return "hash100"
+            raise ConnectionError("bitcoind unreachable")
+
+        backend.getblockhash.side_effect = fake_getblockhash
+        assert verify_recent_chain_integrity(db, depth=3) is None
+
+
+def test_945189_scenario():
+    """Regression: the original 945,189 stale-row incident. The stored
+    block_hash for one historical block diverges from bitcoind; the check
+    must surface it so the caller rolls back to 945,188 and reprocesses
+    945,189 onward."""
+    from index_core.blocks import verify_recent_chain_integrity
+
+    # Tip is 945,288. Stored 945,189 is the orphaned hash; everything else
+    # matches. depth=100 covers the affected window.
+    canonical = {i: f"hash{i}" for i in range(945_188, 945_289)}
+    rows = []
+    for i in range(945_288, 945_188, -1):  # DESC
+        stored = canonical[i] if i != 945_189 else "orphaned_945189_hash"
+        rows.append((i, stored))
+    db = _make_db(rows)
+
+    with patch("index_core.blocks.backend_instance") as backend:
+        backend.getblockhash.side_effect = lambda i: canonical[i]
+        assert verify_recent_chain_integrity(db, depth=100) == 945_189


### PR DESCRIPTION
## Summary

Defense in depth for the post-#728 fix. Closes #779.

If the indexer ever crashes mid-reorg and restarts after the chain tip has advanced beyond the orphan-check window — the failure mode that caused the 945,189 stale-row incident on 2026-04-15 — the next startup now retroactively detects the drift instead of letting it persist indefinitely.

## How it works

On every startup, after `util.CURRENT_BLOCK_INDEX = last_db_index(db)` but before the main `follow()` loop:

1. Read the last N stored `(block_index, block_hash)` rows from the `blocks` table (N = `STARTUP_CHAIN_INTEGRITY_DEPTH`, default 100)
2. Iterate oldest → newest, calling `backend_instance.getblockhash(block_index)` for each
3. **Return the OLDEST diverging block** — returning the newest would miss older stale rows in a multi-block reorg
4. If divergence found: `rollback_to_block(db, divergence - 1, ...)` then re-read tip

## Safety properties

- **Never raises**: DB read errors / bitcoind RPC errors are logged at WARNING and treated as inconclusive. A transient bitcoind hiccup at startup cannot block the indexer from coming up.
- **Best-effort on backend failure**: returns any divergence found before the failure (or None) — partial check is better than no check.
- **No-op fast path** when clean: ~100 RPC calls to local bitcoind takes <1s.
- **Gate-able**: set `STARTUP_CHAIN_INTEGRITY_DEPTH=0` to disable entirely.

## New env knob

| Var | Default | Notes |
|---|---|---|
| `STARTUP_CHAIN_INTEGRITY_DEPTH` | `100` | 0 disables. Higher = catches longer-downtime drift but more startup latency. |

## Test plan

- [x] 8 new unit tests in `test_chain_integrity.py` covering:
  - clean chain → None
  - oldest-divergence priority (multi-block stale window)
  - mid-window divergence
  - depth=0 no-op (no DB or backend calls)
  - empty blocks table
  - DB read failure (returns None, never raises)
  - backend failure mid-check (best-effort)
  - direct regression for the 945,189 scenario
- [x] No regressions in existing `test_block_rollback.py` / `test_blocks_simple.py` / `test_blocks_coverage.py` / `test_rollback_functionality.py` (24 tests pass)
- [x] black + flake8 clean
- [ ] After merge: prod restart confirms `Startup chain-integrity check: last 100 blocks match bitcoind ✓` log line appears (current prod chain is known clean per the 2026-06-23 manual sweep)

Refs #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)