### PR TITLE
perf(#756): bump CP verbose-pagination limit 25→100 via env knob

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -55,6 +55,18 @@ MAX_BATCH_MEMORY = int(os.environ.get("MAX_BATCH_MEMORY", "250"))  # Conservativ
 # Bug details: https://github.com/CounterpartyXCP/counterparty-core/issues (see counterparty_api_error.md)
 CP_API_USE_VERBOSE_WORKAROUND = os.environ.get("CP_API_USE_VERBOSE_WORKAROUND", "true").lower() == "true"
 
+# Per-page limit for the verbose=true safe-pagination path
+# (`_fetch_block_transactions_verbose_safe_pagination`). The legacy default
+# was 25 to dodge the v11.0.1 verbose=true bug that triggered at limit>=26;
+# the bug is fixed in v11.1.0+ which prod runs. Bumping to 100 cuts the
+# per-block round-trip count ~4x for typical blocks while staying well
+# below the limit ceiling and preserving the existing fallback chain
+# (verbose-safe → 2-step workaround) on any per-page failure. Issue #756.
+try:
+    CP_VERBOSE_PAGINATION_LIMIT = int(os.environ.get("CP_VERBOSE_PAGINATION_LIMIT", "100"))
+except ValueError:
+    CP_VERBOSE_PAGINATION_LIMIT = 100
+
 # Production-optimized batch sizes for database operations
 # Larger batches reduce network round-trips to RDS - optimized defaults for production
 DB_TRANSACTION_BATCH_SIZE = int(os.environ.get("DB_TRANSACTION_BATCH_SIZE", "15000"))  # Optimized for RDS

--- a/indexer/src/index_core/fetch_utils.py
+++ b/indexer/src/index_core/fetch_utils.py
@@ -1315,18 +1315,28 @@ async def _fetch_block_transactions_verbose_safe_pagination(
     This workaround addresses the Counterparty API bug where verbose=true fails
     with limit >= 26, while preserving the complete event data structure.
     """
-    logger.debug(f"Fetching block {block_index} transactions with verbose=true safe pagination (limit=25)")
+    # Per-page limit is env-overridable via CP_VERBOSE_PAGINATION_LIMIT (#756 item 2).
+    # Legacy default was 25 to dodge a CP v11.0.1 verbose=true bug that triggered
+    # at limit>=26; v11.1.0+ fixes it, so the default is now 100 to cut per-block
+    # round-trips ~4x. On any per-page failure the existing fallback to the
+    # 2-step workaround is still in effect — so the bump is safe even if
+    # upstream regresses for a specific block.
+    page_limit = config.CP_VERBOSE_PAGINATION_LIMIT
+    logger.debug(f"Fetching block {block_index} transactions with verbose=true safe pagination (limit={page_limit})")
 
     all_transactions: List[Dict[str, Any]] = []
     next_cursor = None
     page_count = 0
-    max_pages = 1000  # Increased safety limit (25 txs/page * 1000 pages = 25,000 max txs per block)
+    # Safety cap: limit * max_pages must stay well above any plausible per-block tx count.
+    # At limit=100 (default), max_pages=1000 ⇒ 100,000 max txs per block (vs Bitcoin's
+    # typical 2-3k); at limit=25 (legacy), 25,000. Scale the page cap inversely so the
+    # absolute cap stays roughly stable across limit choices.
+    max_pages = max(250, 25000 // max(page_limit, 1))
 
     while page_count < max_pages:
         page_count += 1
 
-        # Use limit=25 (safe limit for verbose=true)
-        params = {"verbose": "true", "limit": "25", "show_unconfirmed": "false"}  # Safe limit that works with verbose=true
+        params = {"verbose": "true", "limit": str(page_limit), "show_unconfirmed": "false"}
 
         if next_cursor:
             params["cursor"] = next_cursor

--- a/indexer/tests/test_cp_pagination_limit.py
+++ b/indexer/tests/test_cp_pagination_limit.py
@@ -1,0 +1,105 @@
+"""Tests for #756 item 2 — env-driven CP verbose-pagination limit.
+
+The legacy ``limit=25`` workaround for CP v11.0.1's verbose=true bug is now
+``CP_VERBOSE_PAGINATION_LIMIT`` (default 100). These tests cover the env
+default + override behavior and that the limit reaches the API call params.
+"""
+
+import importlib
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ["TESTING"] = "1"
+os.environ["USE_TEST_DB"] = "1"
+os.environ["MOCK_DB"] = "1"
+os.environ["RPC_USER"] = "rpc"
+os.environ["RPC_PASSWORD"] = "rpc"
+os.environ["RPC_IP"] = "127.0.0.1"
+os.environ["RPC_PORT"] = "8332"
+
+
+def test_default_limit_is_100():
+    """Without env override, CP_VERBOSE_PAGINATION_LIMIT defaults to 100."""
+    import config
+
+    importlib.reload(config)
+    assert config.CP_VERBOSE_PAGINATION_LIMIT == 100
+
+
+def test_env_override():
+    """Env var overrides the default."""
+    import config
+
+    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "50"}):
+        importlib.reload(config)
+        assert config.CP_VERBOSE_PAGINATION_LIMIT == 50
+    # Reload back to default for test isolation
+    importlib.reload(config)
+
+
+def test_invalid_env_falls_back_to_default():
+    """Garbage env value falls back to 100, no crash."""
+    import config
+
+    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "not-an-int"}):
+        importlib.reload(config)
+        assert config.CP_VERBOSE_PAGINATION_LIMIT == 100
+    importlib.reload(config)
+
+
+@pytest.mark.asyncio
+async def test_pagination_uses_configured_limit():
+    """The verbose-safe pagination function must pass the configured limit
+    to every CP API call — guards against a regression that re-hardcodes 25."""
+    import config
+
+    # Override before importing the function so it reads the configured value
+    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "100"}):
+        importlib.reload(config)
+        from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
+
+        # Single-page response (no next_cursor) so we stop after one fetch.
+        mock_response = {
+            "result": [
+                {"tx_hash": "txA", "transaction_type": "send", "block_hash": "block_h"},
+            ],
+            "next_cursor": None,
+        }
+        with patch("index_core.fetch_utils.fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
+            result = await _fetch_block_transactions_verbose_safe_pagination(900000)
+            assert result is not None
+            # First positional arg is the endpoint; second is the params dict.
+            call_args = mock_fetch.call_args
+            params = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("params")
+            # Allow either positional or kwarg form; locate params dict robustly.
+            if params is None:
+                # Fall back: scan args/kwargs for a dict containing "limit"
+                for candidate in list(call_args.args) + list(call_args.kwargs.values()):
+                    if isinstance(candidate, dict) and "limit" in candidate:
+                        params = candidate
+                        break
+            assert params is not None and params.get("limit") == "100"
+            assert params.get("verbose") == "true"
+
+    importlib.reload(config)
+
+
+@pytest.mark.asyncio
+async def test_pagination_passes_lower_limit_when_overridden():
+    """If an operator dials limit down (e.g. for a misbehaving upstream),
+    the lower value reaches the API call."""
+    import config
+
+    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "25"}):
+        importlib.reload(config)
+        from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
+
+        mock_response = {"result": [], "next_cursor": None}
+        with patch("index_core.fetch_utils.fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
+            await _fetch_block_transactions_verbose_safe_pagination(900000)
+            params = mock_fetch.call_args.args[1]
+            assert params["limit"] == "25"
+
+    importlib.reload(config)

--- a/indexer/tests/test_cp_pagination_limit.py
+++ b/indexer/tests/test_cp_pagination_limit.py
@@ -1,12 +1,23 @@
 """Tests for #756 item 2 — env-driven CP verbose-pagination limit.
 
 The legacy ``limit=25`` workaround for CP v11.0.1's verbose=true bug is now
-``CP_VERBOSE_PAGINATION_LIMIT`` (default 100). These tests cover the env
-default + override behavior and that the limit reaches the API call params.
+``CP_VERBOSE_PAGINATION_LIMIT`` (default 100). These tests cover:
+
+- the default value
+- env-driven init (run in a subprocess so the running test session's
+  already-loaded ``config`` module isn't disturbed — importlib.reload is
+  fragile under pytest-xdist parallel workers, manifests as flaky CI)
+- the configured value reaches the API call's params dict (regression
+  guard against any future re-hardcoding of the limit)
+
+The function-level tests directly patch ``config.CP_VERBOSE_PAGINATION_LIMIT``
+instead of reloading the module, which is both safer and stricter (the
+function MUST read the live module attribute, not a stale import).
 """
 
-import importlib
 import os
+import subprocess
+import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -24,82 +35,74 @@ def test_default_limit_is_100():
     """Without env override, CP_VERBOSE_PAGINATION_LIMIT defaults to 100."""
     import config
 
-    importlib.reload(config)
+    # In an unconfigured session this is the live value. We don't reload —
+    # if some sibling test mutated it, that's a separate concern that
+    # subprocess tests below cover authoritatively.
     assert config.CP_VERBOSE_PAGINATION_LIMIT == 100
+
+
+def _read_config_in_subprocess(env_overrides: dict) -> int:
+    """Spawn a child interpreter with the given env overrides applied, import
+    ``config``, return the resolved CP_VERBOSE_PAGINATION_LIMIT. Subprocess
+    isolation guarantees no cross-test module-state pollution."""
+    child_env = os.environ.copy()
+    child_env.update(env_overrides)
+    code = "import sys; sys.path.insert(0, 'src'); " "import config; " "print(config.CP_VERBOSE_PAGINATION_LIMIT)"
+    indexer_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=child_env,
+        cwd=indexer_dir,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, f"child failed: stderr={result.stderr}"
+    return int(result.stdout.strip().splitlines()[-1])
 
 
 def test_env_override():
     """Env var overrides the default."""
-    import config
-
-    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "50"}):
-        importlib.reload(config)
-        assert config.CP_VERBOSE_PAGINATION_LIMIT == 50
-    # Reload back to default for test isolation
-    importlib.reload(config)
+    assert _read_config_in_subprocess({"CP_VERBOSE_PAGINATION_LIMIT": "50"}) == 50
 
 
 def test_invalid_env_falls_back_to_default():
     """Garbage env value falls back to 100, no crash."""
-    import config
-
-    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "not-an-int"}):
-        importlib.reload(config)
-        assert config.CP_VERBOSE_PAGINATION_LIMIT == 100
-    importlib.reload(config)
+    assert _read_config_in_subprocess({"CP_VERBOSE_PAGINATION_LIMIT": "not-an-int"}) == 100
 
 
 @pytest.mark.asyncio
-async def test_pagination_uses_configured_limit():
-    """The verbose-safe pagination function must pass the configured limit
-    to every CP API call — guards against a regression that re-hardcodes 25."""
+async def test_pagination_uses_configured_limit_100():
+    """The verbose-safe pagination function must pass the live
+    ``config.CP_VERBOSE_PAGINATION_LIMIT`` to every CP API call — guards
+    against a regression that re-hardcodes 25."""
     import config
+    from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
 
-    # Override before importing the function so it reads the configured value
-    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "100"}):
-        importlib.reload(config)
-        from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
+    mock_response = {"result": [], "next_cursor": None}
 
-        # Single-page response (no next_cursor) so we stop after one fetch.
-        mock_response = {
-            "result": [
-                {"tx_hash": "txA", "transaction_type": "send", "block_hash": "block_h"},
-            ],
-            "next_cursor": None,
-        }
+    with patch.object(config, "CP_VERBOSE_PAGINATION_LIMIT", 100):
         with patch("index_core.fetch_utils.fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
-            result = await _fetch_block_transactions_verbose_safe_pagination(900000)
-            assert result is not None
-            # First positional arg is the endpoint; second is the params dict.
-            call_args = mock_fetch.call_args
-            params = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("params")
-            # Allow either positional or kwarg form; locate params dict robustly.
-            if params is None:
-                # Fall back: scan args/kwargs for a dict containing "limit"
-                for candidate in list(call_args.args) + list(call_args.kwargs.values()):
-                    if isinstance(candidate, dict) and "limit" in candidate:
-                        params = candidate
-                        break
-            assert params is not None and params.get("limit") == "100"
-            assert params.get("verbose") == "true"
+            await _fetch_block_transactions_verbose_safe_pagination(900000)
 
-    importlib.reload(config)
+    params = mock_fetch.call_args.args[1]
+    assert params["limit"] == "100"
+    assert params["verbose"] == "true"
 
 
 @pytest.mark.asyncio
 async def test_pagination_passes_lower_limit_when_overridden():
     """If an operator dials limit down (e.g. for a misbehaving upstream),
-    the lower value reaches the API call."""
+    the lower value reaches the API call. Uses direct attribute patch
+    rather than env+reload to be robust under pytest-xdist parallelism."""
     import config
+    from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
 
-    with patch.dict(os.environ, {"CP_VERBOSE_PAGINATION_LIMIT": "25"}):
-        importlib.reload(config)
-        from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
+    mock_response = {"result": [], "next_cursor": None}
 
-        mock_response = {"result": [], "next_cursor": None}
+    with patch.object(config, "CP_VERBOSE_PAGINATION_LIMIT", 25):
         with patch("index_core.fetch_utils.fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
             await _fetch_block_transactions_verbose_safe_pagination(900000)
-            params = mock_fetch.call_args.args[1]
-            assert params["limit"] == "25"
 
-    importlib.reload(config)
+    params = mock_fetch.call_args.args[1]
+    assert params["limit"] == "25"

--- a/indexer/tests/test_cp_pagination_limit.py
+++ b/indexer/tests/test_cp_pagination_limit.py
@@ -75,15 +75,20 @@ def test_invalid_env_falls_back_to_default():
 async def test_pagination_uses_configured_limit_100():
     """The verbose-safe pagination function must pass the live
     ``config.CP_VERBOSE_PAGINATION_LIMIT`` to every CP API call — guards
-    against a regression that re-hardcodes 25."""
-    import config
-    from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
+    against a regression that re-hardcodes 25.
+
+    Patches via ``fetch_utils.config`` (the exact module object the
+    function reads from) rather than the test's separate ``import config``,
+    in case any sys.path quirk in CI causes those to resolve to distinct
+    module objects.
+    """
+    from index_core import fetch_utils
 
     mock_response = {"result": [], "next_cursor": None}
 
-    with patch.object(config, "CP_VERBOSE_PAGINATION_LIMIT", 100):
-        with patch("index_core.fetch_utils.fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
-            await _fetch_block_transactions_verbose_safe_pagination(900000)
+    with patch.object(fetch_utils.config, "CP_VERBOSE_PAGINATION_LIMIT", 100):
+        with patch.object(fetch_utils, "fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
+            await fetch_utils._fetch_block_transactions_verbose_safe_pagination(900000)
 
     params = mock_fetch.call_args.args[1]
     assert params["limit"] == "100"
@@ -93,16 +98,15 @@ async def test_pagination_uses_configured_limit_100():
 @pytest.mark.asyncio
 async def test_pagination_passes_lower_limit_when_overridden():
     """If an operator dials limit down (e.g. for a misbehaving upstream),
-    the lower value reaches the API call. Uses direct attribute patch
-    rather than env+reload to be robust under pytest-xdist parallelism."""
-    import config
-    from index_core.fetch_utils import _fetch_block_transactions_verbose_safe_pagination
+    the lower value reaches the API call. Patches via ``fetch_utils.config``
+    for the same module-identity reasons as the test above."""
+    from index_core import fetch_utils
 
     mock_response = {"result": [], "next_cursor": None}
 
-    with patch.object(config, "CP_VERBOSE_PAGINATION_LIMIT", 25):
-        with patch("index_core.fetch_utils.fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
-            await _fetch_block_transactions_verbose_safe_pagination(900000)
+    with patch.object(fetch_utils.config, "CP_VERBOSE_PAGINATION_LIMIT", 25):
+        with patch.object(fetch_utils, "fetch_xcp_async", new=AsyncMock(return_value=mock_response)) as mock_fetch:
+            await fetch_utils._fetch_block_transactions_verbose_safe_pagination(900000)
 
     params = mock_fetch.call_args.args[1]
     assert params["limit"] == "25"


### PR DESCRIPTION
## Summary

Issue #756 item 2. The verbose-safe pagination path in \`fetch_utils._fetch_block_transactions_verbose_safe_pagination\` hardcoded \`limit=25\` as a workaround for the Counterparty v11.0.1 verbose=true pagination bug. That bug is fixed in v11.1.0+ (which prod runs), so bumping the default to 100 cuts per-block round-trips ~4x for typical blocks.

## Safety properties

- **Fallback chain unchanged**: any per-page failure still drops to \`_fetch_block_transactions_workaround\` (2-step \`verbose=false\` @ limit=2000). Even if CP regresses for a specific block at limit=100, the indexer still makes forward progress.
- **Env-tunable**: \`CP_VERBOSE_PAGINATION_LIMIT\` (default 100). Operators can dial back to 25 or any value without a code change. Invalid value falls back to 100.
- **Safety cap scales**: max-pages cap inversely scales with limit so absolute max txs/block stays stable (~25k either way).

## Scope (issue #756 status update)

| Item | Status |
|---|---|
| Item 1 — PIPELINE_FETCH_TIMEOUT env knob | **Already done** at \`pipeline_utils.py:79\` — issue was stale |
| **Item 2 — bump limit 25→100** | **This PR** |
| Item 3 — skip CP on no-stamp blocks | **Blocked by #754** (consensus risk — false-negative gives missed stamp, irreversible numbering drift) |
| Item 4 — parallelize pagination | **Deferred** — cursor-based pagination is inherently sequential; true parallel needs API offset support not yet verified upstream. With limit=100, most blocks are 1-2 pages so the gain is small |

## Test plan

- [x] 5 new tests in \`test_cp_pagination_limit.py\`:
  - default value (100)
  - env override (verifies operator can dial in any value)
  - invalid env value falls back to default
  - configured limit reaches the API call params (regression guard against re-hardcoding)
  - lower-limit override also reaches API params
- [x] No regressions in \`test_counterparty_api_methods.py\` / \`test_async_concurrency_simple.py\` (22 tests pass)
- [x] black + flake8 clean
- [ ] After merge: dev-stack confirms blocks fetch ~4x faster on multi-page blocks; prod soak shows reduced fetch latency in logs

Refs #756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)