### PR TITLE
perf(#793): pre-warm Backend.deserialize cache via Rust batch_parse

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -84,6 +84,12 @@ DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 DEBUG_SKIP_REBUILD_BALANCES = os.getenv("DEBUG_SKIP_REBUILD_BALANCES", "false").lower() == "true"
 DEBUG_PROFILING = os.getenv("DEBUG_PROFILING", "false").lower() == "true"
 DISABLE_RUST_PARSER = os.environ.get("DISABLE_RUST_PARSER", "False").lower() == "true"
+# OPP-3 (#793): pre-warm Backend.deserialize cache via the Rust parser's
+# rayon-parallel batch_parse_transactions during get_tx_list. Cuts per-tx
+# wall-clock by ~2-4x on multi-core hosts for stamp-bearing blocks. Pure-
+# additive — any failure in the pre-warm path falls back to the existing
+# per-tx lazy deserialize. Set to false to disable.
+PREWARM_DESERIALIZE_CACHE = os.environ.get("PREWARM_DESERIALIZE_CACHE", "true").lower() == "true"
 DEBUG_VALIDATION = os.getenv("DEBUG_VALIDATION", "false").lower() == "true"
 
 # Consensus error handling

--- a/indexer/src/index_core/backend.py
+++ b/indexer/src/index_core/backend.py
@@ -452,6 +452,42 @@ class Backend:
     def serialize(self, ctx):
         return CTransaction.serialize(ctx)
 
+    def _prewarm_deserialize_cache(self, raw_transactions):
+        """Pre-warm the per-tx ``deserialize`` cache for this block by calling
+        the Rust parser's ``batch_parse_transactions`` (rayon-parallel under
+        the hood). Subsequent ``deserialize(tx_hex)`` calls for stamp-candidate
+        txs in this block then hit the cache instead of re-doing the per-tx
+        Rust call serially.
+
+        Implementation notes (#793, the OPP-3 wiring):
+        - ``batch_parse_transactions`` returns only the ``should_include``
+          subset, but it processes EVERY input tx through the same per-tx
+          pipeline first — so the parallel work happens for all txs; the
+          cache simply gets populated for the stamp candidates. Non-candidates
+          fall through to the existing lazy per-tx path on demand (status quo).
+        - Pure-additive: any exception is logged at DEBUG and swallowed.
+          The block keeps being processed with the same correctness as
+          before — only the perf benefit is forfeited.
+        """
+        if self._parser is None or not raw_transactions:
+            return
+        try:
+            tx_hex_list = list(raw_transactions.values())
+            # txid → tx_hex lookup so we can key the cache by tx_hex
+            # (matching ``deserialize``'s cache key), not by txid.
+            txid_to_tx_hex = dict(raw_transactions.items())
+            tx_infos = self._parser.batch_parse_transactions(tx_hex_list)
+            cached = 0
+            for info in tx_infos:
+                tx_hex = txid_to_tx_hex.get(info.txid)
+                if tx_hex is not None:
+                    self.deserialized_tx_cache.set(tx_hex, info)
+                    cached += 1
+            logger.debug(f"Pre-warmed deserialize cache with {cached} stamp-candidate txs of {len(tx_hex_list)} in block")
+        except Exception as e:
+            # Non-fatal — the per-tx lazy path stays as the fallback.
+            logger.debug(f"batch deserialize pre-warm failed (continuing with per-tx fallback): {e}")
+
     def get_tx_list(self, block_hash):
         """Get transaction list from block using Rust parser if available."""
         if self._parser is not None:
@@ -459,6 +495,14 @@ class Backend:
                 block_data = self.rpc("getblock", [block_hash, 0])  # Get raw block hex
                 # The Rust parser now returns a tuple directly
                 tx_hash_list, raw_transactions, timestamp, prev_block_hash, bits = self._parser.parse_block(block_data)
+                # OPP-3 (#793): batch-parse the per-tx data in parallel and
+                # pre-populate the deserialize cache. Subsequent per-tx
+                # deserialize calls from transaction_utils / block_validation
+                # then hit the cache instead of re-doing the per-tx Rust call
+                # serially. Gated by config.PREWARM_DESERIALIZE_CACHE so
+                # operators can disable if it ever regresses.
+                if getattr(config, "PREWARM_DESERIALIZE_CACHE", True):
+                    self._prewarm_deserialize_cache(raw_transactions)
                 return (
                     tx_hash_list,
                     raw_transactions,

--- a/indexer/tests/test_prewarm_deserialize_cache.py
+++ b/indexer/tests/test_prewarm_deserialize_cache.py
@@ -3,13 +3,19 @@ Rust parser's parallel ``batch_parse_transactions`` during ``get_tx_list``.
 
 Key invariants:
 - Pre-warmed entries match what ``deserialize`` would have produced per-tx
-  (cache key = tx_hex, cache value = TransactionInfo).
+  (cache key = tx_hex, cache value = TransactionInfo / CTransaction).
 - Non-included txs are NOT cached (Rust filters those out) — subsequent
   ``deserialize`` calls fall through to the per-tx lazy path (status quo).
 - Any failure in ``_prewarm_deserialize_cache`` is swallowed and indexing
   continues with the existing per-tx fallback — this method is pure
   performance, must never break correctness.
 - ``config.PREWARM_DESERIALIZE_CACHE`` gates the call (default true).
+
+Backend is a process-global singleton (``__new__`` returns the same
+instance). These tests MUST NOT mutate ``backend._parser`` /
+``backend.deserialized_tx_cache`` directly or they leak into other tests
+in the same xdist worker (e.g. test_special_txs_*). All mutations go
+through ``patch.object`` so they auto-revert on context exit.
 """
 
 import os
@@ -24,23 +30,6 @@ os.environ["RPC_IP"] = "127.0.0.1"
 os.environ["RPC_PORT"] = "8332"
 
 
-def _make_backend_with_parser(parser_result):
-    """Build a Backend instance with a mocked Rust parser whose
-    ``batch_parse_transactions`` returns ``parser_result``."""
-    from index_core.backend import Backend
-
-    backend = Backend()
-    parser = MagicMock()
-    parser.batch_parse_transactions = MagicMock(return_value=parser_result)
-    backend._parser = parser
-    # Replace the cache with a real instance so .set/.get behaves like prod.
-    cache = MagicMock()
-    cache.set = MagicMock()
-    cache.get = MagicMock(return_value=None)
-    backend.deserialized_tx_cache = cache
-    return backend, parser, cache
-
-
 def _tx_info(txid):
     info = MagicMock()
     info.txid = txid
@@ -50,30 +39,44 @@ def _tx_info(txid):
 def test_prewarm_caches_included_subset():
     """The Rust batch returns the should_include subset; cache must be
     keyed by tx_hex (not txid) so per-tx ``deserialize(tx_hex)`` hits."""
+    from index_core.backend import Backend
+
     info_a = _tx_info("txid_A")
     info_c = _tx_info("txid_C")
-    # Block has 3 txs; only A and C are stamp candidates per Rust filter.
     raw_transactions = {"txid_A": "hex_A", "txid_B": "hex_B", "txid_C": "hex_C"}
 
-    backend, parser, cache = _make_backend_with_parser([info_a, info_c])
-    backend._prewarm_deserialize_cache(raw_transactions)
+    backend = Backend()
+    mock_parser = MagicMock()
+    mock_parser.batch_parse_transactions = MagicMock(return_value=[info_a, info_c])
+    mock_cache = MagicMock()
+    mock_cache.set = MagicMock()
 
-    parser.batch_parse_transactions.assert_called_once()
-    # Cache set called twice (A and C), NOT three times.
-    assert cache.set.call_count == 2
-    cache.set.assert_any_call("hex_A", info_a)
-    cache.set.assert_any_call("hex_C", info_c)
-    # B was filtered out by Rust — must NOT be cached.
-    cached_hexes = {call.args[0] for call in cache.set.call_args_list}
+    with patch.object(backend, "_parser", mock_parser), patch.object(backend, "deserialized_tx_cache", mock_cache):
+        backend._prewarm_deserialize_cache(raw_transactions)
+
+    mock_parser.batch_parse_transactions.assert_called_once()
+    assert mock_cache.set.call_count == 2
+    mock_cache.set.assert_any_call("hex_A", info_a)
+    mock_cache.set.assert_any_call("hex_C", info_c)
+    cached_hexes = {call.args[0] for call in mock_cache.set.call_args_list}
     assert "hex_B" not in cached_hexes
 
 
 def test_prewarm_no_op_when_empty():
     """Empty raw_transactions dict → no parser call, no cache set."""
-    backend, parser, cache = _make_backend_with_parser([])
-    backend._prewarm_deserialize_cache({})
-    assert not parser.batch_parse_transactions.called
-    assert not cache.set.called
+    from index_core.backend import Backend
+
+    backend = Backend()
+    mock_parser = MagicMock()
+    mock_parser.batch_parse_transactions = MagicMock(return_value=[])
+    mock_cache = MagicMock()
+    mock_cache.set = MagicMock()
+
+    with patch.object(backend, "_parser", mock_parser), patch.object(backend, "deserialized_tx_cache", mock_cache):
+        backend._prewarm_deserialize_cache({})
+
+    assert not mock_parser.batch_parse_transactions.called
+    assert not mock_cache.set.called
 
 
 def test_prewarm_no_op_when_parser_unavailable():
@@ -81,13 +84,13 @@ def test_prewarm_no_op_when_parser_unavailable():
     from index_core.backend import Backend
 
     backend = Backend()
-    backend._parser = None
-    cache = MagicMock()
-    cache.set = MagicMock()
-    backend.deserialized_tx_cache = cache
+    mock_cache = MagicMock()
+    mock_cache.set = MagicMock()
 
-    backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
-    assert not cache.set.called
+    with patch.object(backend, "_parser", None), patch.object(backend, "deserialized_tx_cache", mock_cache):
+        backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
+
+    assert not mock_cache.set.called
 
 
 def test_prewarm_swallows_parser_exception():
@@ -96,30 +99,35 @@ def test_prewarm_swallows_parser_exception():
     from index_core.backend import Backend
 
     backend = Backend()
-    parser = MagicMock()
-    parser.batch_parse_transactions = MagicMock(side_effect=RuntimeError("boom"))
-    backend._parser = parser
-    cache = MagicMock()
-    cache.set = MagicMock()
-    backend.deserialized_tx_cache = cache
+    mock_parser = MagicMock()
+    mock_parser.batch_parse_transactions = MagicMock(side_effect=RuntimeError("boom"))
+    mock_cache = MagicMock()
+    mock_cache.set = MagicMock()
 
-    # Must not raise.
-    backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
-    assert not cache.set.called
+    with patch.object(backend, "_parser", mock_parser), patch.object(backend, "deserialized_tx_cache", mock_cache):
+        # Must not raise.
+        backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
+
+    assert not mock_cache.set.called
 
 
 def test_prewarm_handles_unknown_txid_in_result():
     """If the parser returns a TransactionInfo with an unexpected txid
     (shouldn't happen, but defensively): skip it, don't crash and don't
     blindly cache against a wrong tx_hex."""
+    from index_core.backend import Backend
+
     info_x = _tx_info("not_in_block")
-    raw_transactions = {"txid_A": "hex_A"}
+    backend = Backend()
+    mock_parser = MagicMock()
+    mock_parser.batch_parse_transactions = MagicMock(return_value=[info_x])
+    mock_cache = MagicMock()
+    mock_cache.set = MagicMock()
 
-    backend, parser, cache = _make_backend_with_parser([info_x])
-    backend._prewarm_deserialize_cache(raw_transactions)
+    with patch.object(backend, "_parser", mock_parser), patch.object(backend, "deserialized_tx_cache", mock_cache):
+        backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
 
-    # No cache set for the mystery txid; no crash.
-    assert not cache.set.called
+    assert not mock_cache.set.called
 
 
 def test_get_tx_list_invokes_prewarm_by_default():
@@ -127,19 +135,20 @@ def test_get_tx_list_invokes_prewarm_by_default():
     from index_core.backend import Backend
 
     backend = Backend()
-    parser = MagicMock()
+    mock_parser = MagicMock()
     raw = {"a": "hex_a"}
-    parser.parse_block = MagicMock(return_value=(["a"], raw, 1700000000, "prev_hash", None))
-    parser.batch_parse_transactions = MagicMock(return_value=[])
-    backend._parser = parser
-    backend.deserialized_tx_cache = MagicMock()
-    backend.rpc = MagicMock(return_value="raw_block_hex")
+    mock_parser.parse_block = MagicMock(return_value=(["a"], raw, 1700000000, "prev_hash", None))
+    mock_parser.batch_parse_transactions = MagicMock(return_value=[])
+    mock_cache = MagicMock()
 
-    # Default config (PREWARM_DESERIALIZE_CACHE=true).
-    with patch("index_core.backend.config", new=MagicMock(PREWARM_DESERIALIZE_CACHE=True)):
+    with patch.object(backend, "_parser", mock_parser), patch.object(
+        backend, "deserialized_tx_cache", mock_cache
+    ), patch.object(backend, "rpc", return_value="raw_block_hex"), patch(
+        "index_core.backend.config", new=MagicMock(PREWARM_DESERIALIZE_CACHE=True)
+    ):
         backend.get_tx_list("blockhash")
 
-    parser.batch_parse_transactions.assert_called_once()
+    mock_parser.batch_parse_transactions.assert_called_once()
 
 
 def test_get_tx_list_skips_prewarm_when_disabled():
@@ -147,15 +156,17 @@ def test_get_tx_list_skips_prewarm_when_disabled():
     from index_core.backend import Backend
 
     backend = Backend()
-    parser = MagicMock()
+    mock_parser = MagicMock()
     raw = {"a": "hex_a"}
-    parser.parse_block = MagicMock(return_value=(["a"], raw, 1700000000, "prev_hash", None))
-    parser.batch_parse_transactions = MagicMock(return_value=[])
-    backend._parser = parser
-    backend.deserialized_tx_cache = MagicMock()
-    backend.rpc = MagicMock(return_value="raw_block_hex")
+    mock_parser.parse_block = MagicMock(return_value=(["a"], raw, 1700000000, "prev_hash", None))
+    mock_parser.batch_parse_transactions = MagicMock(return_value=[])
+    mock_cache = MagicMock()
 
-    with patch("index_core.backend.config", new=MagicMock(PREWARM_DESERIALIZE_CACHE=False)):
+    with patch.object(backend, "_parser", mock_parser), patch.object(
+        backend, "deserialized_tx_cache", mock_cache
+    ), patch.object(backend, "rpc", return_value="raw_block_hex"), patch(
+        "index_core.backend.config", new=MagicMock(PREWARM_DESERIALIZE_CACHE=False)
+    ):
         backend.get_tx_list("blockhash")
 
-    assert not parser.batch_parse_transactions.called
+    assert not mock_parser.batch_parse_transactions.called

--- a/indexer/tests/test_prewarm_deserialize_cache.py
+++ b/indexer/tests/test_prewarm_deserialize_cache.py
@@ -1,0 +1,161 @@
+"""Tests for OPP-3 (#793) — Backend.deserialize cache pre-warming via the
+Rust parser's parallel ``batch_parse_transactions`` during ``get_tx_list``.
+
+Key invariants:
+- Pre-warmed entries match what ``deserialize`` would have produced per-tx
+  (cache key = tx_hex, cache value = TransactionInfo).
+- Non-included txs are NOT cached (Rust filters those out) — subsequent
+  ``deserialize`` calls fall through to the per-tx lazy path (status quo).
+- Any failure in ``_prewarm_deserialize_cache`` is swallowed and indexing
+  continues with the existing per-tx fallback — this method is pure
+  performance, must never break correctness.
+- ``config.PREWARM_DESERIALIZE_CACHE`` gates the call (default true).
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+os.environ["TESTING"] = "1"
+os.environ["USE_TEST_DB"] = "1"
+os.environ["MOCK_DB"] = "1"
+os.environ["RPC_USER"] = "rpc"
+os.environ["RPC_PASSWORD"] = "rpc"
+os.environ["RPC_IP"] = "127.0.0.1"
+os.environ["RPC_PORT"] = "8332"
+
+
+def _make_backend_with_parser(parser_result):
+    """Build a Backend instance with a mocked Rust parser whose
+    ``batch_parse_transactions`` returns ``parser_result``."""
+    from index_core.backend import Backend
+
+    backend = Backend()
+    parser = MagicMock()
+    parser.batch_parse_transactions = MagicMock(return_value=parser_result)
+    backend._parser = parser
+    # Replace the cache with a real instance so .set/.get behaves like prod.
+    cache = MagicMock()
+    cache.set = MagicMock()
+    cache.get = MagicMock(return_value=None)
+    backend.deserialized_tx_cache = cache
+    return backend, parser, cache
+
+
+def _tx_info(txid):
+    info = MagicMock()
+    info.txid = txid
+    return info
+
+
+def test_prewarm_caches_included_subset():
+    """The Rust batch returns the should_include subset; cache must be
+    keyed by tx_hex (not txid) so per-tx ``deserialize(tx_hex)`` hits."""
+    info_a = _tx_info("txid_A")
+    info_c = _tx_info("txid_C")
+    # Block has 3 txs; only A and C are stamp candidates per Rust filter.
+    raw_transactions = {"txid_A": "hex_A", "txid_B": "hex_B", "txid_C": "hex_C"}
+
+    backend, parser, cache = _make_backend_with_parser([info_a, info_c])
+    backend._prewarm_deserialize_cache(raw_transactions)
+
+    parser.batch_parse_transactions.assert_called_once()
+    # Cache set called twice (A and C), NOT three times.
+    assert cache.set.call_count == 2
+    cache.set.assert_any_call("hex_A", info_a)
+    cache.set.assert_any_call("hex_C", info_c)
+    # B was filtered out by Rust — must NOT be cached.
+    cached_hexes = {call.args[0] for call in cache.set.call_args_list}
+    assert "hex_B" not in cached_hexes
+
+
+def test_prewarm_no_op_when_empty():
+    """Empty raw_transactions dict → no parser call, no cache set."""
+    backend, parser, cache = _make_backend_with_parser([])
+    backend._prewarm_deserialize_cache({})
+    assert not parser.batch_parse_transactions.called
+    assert not cache.set.called
+
+
+def test_prewarm_no_op_when_parser_unavailable():
+    """If the Rust parser isn't loaded, the pre-warm is a silent no-op."""
+    from index_core.backend import Backend
+
+    backend = Backend()
+    backend._parser = None
+    cache = MagicMock()
+    cache.set = MagicMock()
+    backend.deserialized_tx_cache = cache
+
+    backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
+    assert not cache.set.called
+
+
+def test_prewarm_swallows_parser_exception():
+    """Any failure during pre-warm must NOT raise — correctness is preserved
+    by the existing per-tx lazy ``deserialize`` fallback."""
+    from index_core.backend import Backend
+
+    backend = Backend()
+    parser = MagicMock()
+    parser.batch_parse_transactions = MagicMock(side_effect=RuntimeError("boom"))
+    backend._parser = parser
+    cache = MagicMock()
+    cache.set = MagicMock()
+    backend.deserialized_tx_cache = cache
+
+    # Must not raise.
+    backend._prewarm_deserialize_cache({"txid_A": "hex_A"})
+    assert not cache.set.called
+
+
+def test_prewarm_handles_unknown_txid_in_result():
+    """If the parser returns a TransactionInfo with an unexpected txid
+    (shouldn't happen, but defensively): skip it, don't crash and don't
+    blindly cache against a wrong tx_hex."""
+    info_x = _tx_info("not_in_block")
+    raw_transactions = {"txid_A": "hex_A"}
+
+    backend, parser, cache = _make_backend_with_parser([info_x])
+    backend._prewarm_deserialize_cache(raw_transactions)
+
+    # No cache set for the mystery txid; no crash.
+    assert not cache.set.called
+
+
+def test_get_tx_list_invokes_prewarm_by_default():
+    """The pre-warm hook is wired into get_tx_list and runs by default."""
+    from index_core.backend import Backend
+
+    backend = Backend()
+    parser = MagicMock()
+    raw = {"a": "hex_a"}
+    parser.parse_block = MagicMock(return_value=(["a"], raw, 1700000000, "prev_hash", None))
+    parser.batch_parse_transactions = MagicMock(return_value=[])
+    backend._parser = parser
+    backend.deserialized_tx_cache = MagicMock()
+    backend.rpc = MagicMock(return_value="raw_block_hex")
+
+    # Default config (PREWARM_DESERIALIZE_CACHE=true).
+    with patch("index_core.backend.config", new=MagicMock(PREWARM_DESERIALIZE_CACHE=True)):
+        backend.get_tx_list("blockhash")
+
+    parser.batch_parse_transactions.assert_called_once()
+
+
+def test_get_tx_list_skips_prewarm_when_disabled():
+    """Operator can turn off the pre-warm via PREWARM_DESERIALIZE_CACHE=false."""
+    from index_core.backend import Backend
+
+    backend = Backend()
+    parser = MagicMock()
+    raw = {"a": "hex_a"}
+    parser.parse_block = MagicMock(return_value=(["a"], raw, 1700000000, "prev_hash", None))
+    parser.batch_parse_transactions = MagicMock(return_value=[])
+    backend._parser = parser
+    backend.deserialized_tx_cache = MagicMock()
+    backend.rpc = MagicMock(return_value="raw_block_hex")
+
+    with patch("index_core.backend.config", new=MagicMock(PREWARM_DESERIALIZE_CACHE=False)):
+        backend.get_tx_list("blockhash")
+
+    assert not parser.batch_parse_transactions.called


### PR DESCRIPTION
## Summary

Implements OPP-3 from the #754 Rust perf research. Wires the Rust parser's rayon-parallel \`batch_parse_transactions\` into \`Backend.get_tx_list\` so that per-tx \`deserialize\` calls hit a warm cache instead of re-doing the per-tx Rust call serially.

Closes #793.

## How it works

1. After \`parse_block\` returns \`(tx_hash_list, raw_transactions, ...)\`, call \`self._parser.batch_parse_transactions(list(raw_transactions.values()))\`.
2. The Rust batch processes EVERY tx through the per-tx pipeline in parallel (rayon), then returns the \`should_include\` subset as \`List[TransactionInfo]\`.
3. For each returned info, look up its tx_hex via the txid→tx_hex map (\`raw_transactions\`) and \`set\` it in \`self.deserialized_tx_cache\`.
4. Downstream code calls \`Backend.deserialize(tx_hex)\` → cache hit for stamp-candidate txs in this block.

Non-candidates are not cached by batch (Rust filters them out), so they fall through to the existing lazy per-tx path on demand — no regression, status quo for those.

## Safety properties

- **Pure-additive**: wrapped in try/except at every layer. Any failure during pre-warm is logged at DEBUG and swallowed. The block keeps being processed with identical correctness via the existing per-tx fallback. Only the perf benefit is forfeited on failure.
- **Cache value identity**: cached value is the exact same \`TransactionInfo\` shape \`deserialize\` returns per-tx — no schema drift between batch and per-tx code paths.
- **Defensive on unknown txids**: if the parser returns a TransactionInfo whose \`txid\` isn't in this block's \`raw_transactions\` (shouldn't happen, but...), the entry is skipped — no blind cache write against the wrong tx_hex.
- **Operator escape hatch**: \`PREWARM_DESERIALIZE_CACHE\` env var (default true). Set to \`false\` to disable without a code change.

## Consensus risk: LOW

Pure batching of the same per-tx parse already in use. The cached \`TransactionInfo\` is byte-identical to what \`deserialize\` would have produced per-tx (same Rust code path internally). Cache lookup is keyed by tx_hex; ordering is irrelevant. No new code path on the consensus surface.

## Expected speedup

Per the [#754 Rust perf research](https://github.com/stampchain-io/btc_stamps/issues/754#issuecomment-4789189411): **2-4x block-parse wall-clock on multi-core hosts**, concentrated on stamp-bearing blocks. Independent of #754, OPP-1 (#794), OPP-2 (#795) — can ship on its own. Foundational confidence-builder for the higher-risk Rust ports that follow.

## Test plan

- [x] 7 unit tests in \`test_prewarm_deserialize_cache.py\`:
  - caches included subset, keyed by tx_hex (not txid)
  - excluded txs are NOT cached
  - no-op when raw_transactions is empty
  - no-op when Rust parser is unavailable
  - swallows parser exceptions (correctness preserved)
  - defensively handles unknown txid in result
  - \`get_tx_list\` invokes pre-warm by default
  - \`get_tx_list\` skips pre-warm when \`PREWARM_DESERIALIZE_CACHE=false\`
- [x] Verified with \`pytest -n 4\` (xdist parallel) — all 7 pass
- [x] black + flake8 clean
- [ ] After merge: dev-stack soak shows reduced per-block parse latency (especially on multi-tx blocks). Reparse Consensus Validation CI stays green (proves no consensus drift).
- [ ] Optional: a benchmark commit running N=100 historical stamp-bearing blocks comparing wall-clock with/without the gate to quantify the speedup.

Refs #793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)