### PR TITLE
fix(#793): disable OPP-3 cache pre-warm by default (perf regression)

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -85,11 +85,21 @@ DEBUG_SKIP_REBUILD_BALANCES = os.getenv("DEBUG_SKIP_REBUILD_BALANCES", "false").
 DEBUG_PROFILING = os.getenv("DEBUG_PROFILING", "false").lower() == "true"
 DISABLE_RUST_PARSER = os.environ.get("DISABLE_RUST_PARSER", "False").lower() == "true"
 # OPP-3 (#793): pre-warm Backend.deserialize cache via the Rust parser's
-# rayon-parallel batch_parse_transactions during get_tx_list. Cuts per-tx
-# wall-clock by ~2-4x on multi-core hosts for stamp-bearing blocks. Pure-
-# additive — any failure in the pre-warm path falls back to the existing
-# per-tx lazy deserialize. Set to false to disable.
-PREWARM_DESERIALIZE_CACHE = os.environ.get("PREWARM_DESERIALIZE_CACHE", "true").lower() == "true"
+# rayon-parallel batch_parse_transactions during get_tx_list. **DISABLED BY
+# DEFAULT** — observed net perf regression for typical Bitcoin blocks
+# (dev catch-up of 90 blocks took 33 minutes / ~22s/block).
+#
+# Why it regresses: batch_parse_transactions runs the per-tx pipeline on
+# every tx in the block but only RETURNS the should_include subset (stamp
+# candidates). For excluded txs (typically >99% of a block) the cache is
+# never populated, so the subsequent per-tx Backend.deserialize() call
+# re-parses → net double work for the vast majority of txs.
+#
+# Re-enable conditions: either (a) Rust's batch_parse_transactions is
+# changed to return ALL parses (not just should_include), or (b) a
+# separate batch_parse_all entry point is added that returns the full
+# set so the cache can be fully pre-warmed.
+PREWARM_DESERIALIZE_CACHE = os.environ.get("PREWARM_DESERIALIZE_CACHE", "false").lower() == "true"
 DEBUG_VALIDATION = os.getenv("DEBUG_VALIDATION", "false").lower() == "true"
 
 # Consensus error handling


### PR DESCRIPTION
## Summary

Flips ``PREWARM_DESERIALIZE_CACHE`` default from ``true`` to ``false``. OPP-3 (#793 / PR #796) shipped enabled and was observed in stampsdev to take 33 minutes to catch up 90 blocks (~22s/block) — a major regression vs the existing per-tx lazy path.

## Why it regresses

- ``Backend.deserialize`` is called per-tx for every tx in the block via ``transaction_utils.get_tx_info:450``
- ``batch_parse_transactions`` runs the per-tx pipeline on ALL txs in the block (3000+) but only **returns** the ``should_include`` subset (typically <1% of a Bitcoin block — just stamp candidates)
- For excluded txs the cache is **never populated**, so the subsequent per-tx ``Backend.deserialize()`` call re-parses on demand → **net double work** for the vast majority of txs
- Batch's rayon parallelism doesn't recover the duplicated work; the per-tx parses on the excluded txs run serially after the batch completes

The math: a 3000-tx block with 5 stamp candidates does (1 parallel batch parse of 3000) + (2995 serial per-tx parses for the excluded) instead of just (3000 serial per-tx parses).

## Disposition — disable, don't rip out

Keeping the code in place so the design is easy to revive once Rust returns all parses. The env knob ``PREWARM_DESERIALIZE_CACHE`` also lets operators opt in for experimentation.

## Conditions to re-enable

1. Rust ``batch_parse_transactions`` is changed to return ALL per-tx parses (not just ``should_include``), **OR**
2. A separate ``batch_parse_all`` entry point is added that returns the full set
3. ``compare_tables.py`` + a benchmark on a heavy historical block range confirm the net win

## Scope

- Bitcoin per-tx parse path only — **no impact on the CP layer**
- CP fetch speedup is tracked separately in #754 (Rust CP pre-detection)

## Test plan

- [x] All 7 tests in ``test_prewarm_deserialize_cache.py`` pass (they patch ``PREWARM_DESERIALIZE_CACHE`` explicitly, so default flip doesn't break them)
- [x] black + flake8 clean
- [x] Sanity check: ``import config; assert config.PREWARM_DESERIALIZE_CACHE is False`` ✓
- [ ] After merge: dev catch-up wall-clock returns to baseline (~1-2s/block at tip)

Refs #793 / supersedes the default in #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)