### PR TITLE
feat(#770): Tier 3 subprocess-per-block reparse runner

### DIFF
--- a/.github/workflows/reparse-validate.yml
+++ b/.github/workflows/reparse-validate.yml
@@ -71,3 +71,40 @@ jobs:
         run: |
           python3 indexer/ci/ci_validate_consensus.py \
             --baseline indexer/snapshots/ci_consensus_hashes.json
+
+      # ---- Tier 3 subprocess reparse runner (#770 Option B) ----
+      # Runs the curated baseline through a fresh Python subprocess per block,
+      # exercising the full indexer parser pipeline (Rust parser + reparse
+      # validator) instead of just the block-bytes hash check above. The
+      # subprocess boundary gives state isolation across blocks, avoiding the
+      # in-process cache-pollution problem documented in #775.
+      #
+      # Needs the indexer venv (poetry install) because the smoke driver
+      # imports index_core.* directly. Rust toolchain is needed because
+      # poetry install builds the Rust parser via maturin.
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: indexer/src/rust_parser
+          key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
+          save-if: ${{ false }}
+      - name: Install Poetry + indexer deps
+        working-directory: ./indexer
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --version 2.1.1
+          poetry config virtualenvs.in-project true
+          poetry install
+
+      - name: Tier 3 — subprocess reparse over curated baseline
+        working-directory: ./indexer
+        # continue-on-error at the job level already makes this advisory; the
+        # step itself fails loudly on any new regression so reviewers see
+        # which block(s) diverged in the PR check summary.
+        run: |
+          poetry run python ci/ci_reparse_subprocess.py \
+            --baseline snapshots/ci_consensus_hashes.json \
+            --timeout 120

--- a/indexer/ci/ci_reparse_subprocess.py
+++ b/indexer/ci/ci_reparse_subprocess.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tier 3 subprocess-per-block reparse runner (issue #770 Option B).
+
+For each block in the curated set (``indexer/snapshots/ci_consensus_hashes.json``)
+spawn a fresh ``python -m indexer.ci.smoke_parser_validation --block N`` subprocess
+and aggregate pass/fail. The subprocess boundary gives us automatic state
+isolation between blocks — module globals, ``cache_manager["stamp"]["counter"]``,
+``util.CURRENT_BLOCK_INDEX``, etc. are reborn per block, so we sidestep the
+in-process state-carry problem documented in #775.
+
+Why this exists alongside ``ci_reparse_multi.py`` (Tier 1):
+- Tier 1 runs all blocks in a single process with manual cache seeding. Fast
+  (~5 min for 38) but fundamentally limited by ``InMemoryBlockProcessor``'s
+  structural divergence from the production ``StampProcessor`` (#775).
+- Tier 3 (this file) trades some wall-clock for state-isolation correctness.
+  Each subprocess loads the Rust parser + reads the snapshot afresh; expect
+  ~10 min for 38 blocks. Acceptable for per-PR CI signal.
+
+Both can coexist in CI for a bake cycle — Tier 1 catches the fast smoke
+issues, Tier 3 catches the cross-block state-pollution issues that Tier 1
+silently masks.
+
+Usage::
+
+    python3 indexer/ci/ci_reparse_subprocess.py \\
+        --baseline indexer/snapshots/ci_consensus_hashes.json
+
+    # Run a subset (useful when iterating locally)
+    python3 indexer/ci/ci_reparse_subprocess.py --limit 5
+
+    # JSON output for downstream tooling
+    python3 indexer/ci/ci_reparse_subprocess.py --json > results.json
+
+Exit codes: 0 = all blocks pass, 1 = any block fails, 2 = config/setup error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Dict, List, Optional, Tuple
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_BASELINE = os.path.normpath(os.path.join(HERE, "..", "snapshots", "ci_consensus_hashes.json"))
+
+# Default per-block subprocess timeout. Rust parser init + Bitcoin fetch +
+# CP fetch for a stamp-heavy block ~30-45s on a warm cache; 120s is a
+# generous ceiling that still catches truly stuck runs.
+DEFAULT_PER_BLOCK_TIMEOUT = 120
+
+
+def _load_baseline(path: str) -> List[int]:
+    """Return the sorted list of block_index values from the curated baseline."""
+    with open(path) as fh:
+        data = json.load(fh)
+    hashes = data.get("hashes")
+    if not isinstance(hashes, dict):
+        raise SystemExit(f"baseline {path}: 'hashes' is missing or not a dict")
+    return sorted(int(k) for k in hashes.keys())
+
+
+def _run_one(block_index: int, timeout_sec: int) -> Tuple[bool, float, str]:
+    """Spawn a single ``smoke_parser_validation --block N`` subprocess.
+
+    Returns ``(ok, duration_sec, stderr_tail)``. ``stderr_tail`` is the last
+    ~2KB of stderr — enough to surface the failure reason in CI logs without
+    overwhelming them.
+    """
+    # Invoke as a script rather than `-m indexer.ci.smoke_parser_validation`:
+    # the indexer/ tree isn't installed as a Python package, and the smoke
+    # driver does its own ``sys.path`` munging when run as a script.
+    smoke_path = os.path.join(HERE, "smoke_parser_validation.py")
+    cmd = [sys.executable, smoke_path, "--block", str(block_index)]
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_sec)
+    except subprocess.TimeoutExpired as e:
+        return (False, time.monotonic() - start, f"TIMEOUT after {timeout_sec}s: {e}")
+    duration = time.monotonic() - start
+    ok = proc.returncode == 0
+    # Always preserve the tail of stderr; on failure also keep the tail of
+    # stdout so we surface what the validator printed before exiting non-zero.
+    parts: List[str] = []
+    if proc.stderr:
+        parts.append("--- stderr (tail) ---\n" + proc.stderr[-2048:])
+    if not ok and proc.stdout:
+        parts.append("--- stdout (tail) ---\n" + proc.stdout[-2048:])
+    return (ok, duration, "\n".join(parts))
+
+
+def run(
+    blocks: List[int],
+    timeout_sec: int,
+    fail_fast: bool = False,
+    output_json: bool = False,
+) -> Tuple[int, List[Dict]]:
+    """Run the subprocess runner over ``blocks`` and return ``(exit_code, results)``.
+
+    ``results`` is a list of ``{block, ok, duration_sec, stderr_tail}`` dicts.
+    Exit code: 0 if all pass, 1 if any fail (or fail_fast tripped early).
+    """
+    results: List[Dict] = []
+    fail_count = 0
+    overall_start = time.monotonic()
+
+    for i, block in enumerate(blocks, 1):
+        if not output_json:
+            print(f"[{i}/{len(blocks)}] block {block}: running...", flush=True)
+        ok, duration, stderr_tail = _run_one(block, timeout_sec)
+        result = {"block": block, "ok": ok, "duration_sec": round(duration, 2)}
+        if not ok:
+            result["stderr_tail"] = stderr_tail
+            fail_count += 1
+        results.append(result)
+        if not output_json:
+            status = "✓" if ok else "✗"
+            print(f"[{i}/{len(blocks)}] block {block}: {status} ({duration:.1f}s)", flush=True)
+            if not ok:
+                # Print the tail immediately so a CI operator can see the
+                # failure reason in line, not just in the JSON summary.
+                print(stderr_tail, flush=True)
+        if fail_fast and not ok:
+            if not output_json:
+                print(f"\nfail-fast: stopping after first failure (block {block})", flush=True)
+            break
+
+    overall_duration = time.monotonic() - overall_start
+    if not output_json:
+        passed = len(results) - fail_count
+        print(
+            f"\nSubprocess reparse complete: {passed}/{len(results)} passed, "
+            f"{fail_count} failed in {overall_duration:.1f}s"
+        )
+    return (1 if fail_count else 0, results)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Tier 3 subprocess-per-block reparse runner (#770).")
+    ap.add_argument("--baseline", default=DEFAULT_BASELINE, help="path to ci_consensus_hashes.json")
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_PER_BLOCK_TIMEOUT,
+        help=f"per-block subprocess timeout in seconds (default: {DEFAULT_PER_BLOCK_TIMEOUT})",
+    )
+    ap.add_argument("--limit", type=int, default=0, help="if >0, only run the first N blocks (for local iteration)")
+    ap.add_argument("--fail-fast", action="store_true", help="stop on first failing block")
+    ap.add_argument("--json", action="store_true", help="emit a single JSON summary on stdout instead of per-block lines")
+    args = ap.parse_args()
+
+    try:
+        blocks = _load_baseline(args.baseline)
+    except (FileNotFoundError, json.JSONDecodeError, SystemExit) as e:
+        print(f"ERROR loading baseline: {e}", file=sys.stderr)
+        return 2
+
+    if args.limit and args.limit > 0:
+        blocks = blocks[: args.limit]
+
+    if not blocks:
+        print(f"ERROR: no blocks in baseline {args.baseline}", file=sys.stderr)
+        return 2
+
+    exit_code, results = run(blocks, args.timeout, fail_fast=args.fail_fast, output_json=args.json)
+
+    if args.json:
+        summary = {
+            "baseline": args.baseline,
+            "total": len(results),
+            "passed": sum(1 for r in results if r["ok"]),
+            "failed": sum(1 for r in results if not r["ok"]),
+            "results": results,
+        }
+        print(json.dumps(summary, indent=2))
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements [#770](https://github.com/stampchain-io/btc_stamps/issues/770) Option B (the recommended path). New \`indexer/ci/ci_reparse_subprocess.py\` runner spawns a fresh \`python smoke_parser_validation.py --block N\` subprocess per curated block and aggregates pass/fail. Subprocess boundary = automatic state isolation, sidestepping #775's in-process state-carry problem.

## What's new

- **\`indexer/ci/ci_reparse_subprocess.py\`** — Tier 3 multi-block runner. Supports \`--limit N\` (local iteration), \`--fail-fast\`, \`--json\` (downstream tooling). 120s per-block timeout default.
- **CI step in \`reparse-validate.yml\`** — installs Poetry + builds Rust parser + runs the subprocess runner over the full curated baseline. \`continue-on-error: true\` keeps it advisory on first land per #770's recommendation.

## Local validation

\`\`\`bash
$ poetry run python ci/ci_reparse_subprocess.py --limit 5 --timeout 90
[1/5] block 779652: ✓ (3.6s)
[2/5] block 779653: ✓ (2.4s)
[3/5] block 784549: ✓ (2.8s)
[4/5] block 784550: ✓ (3.0s)
[5/5] block 784551: ✗ (2.4s)
Subprocess reparse complete: 4/5 passed, 1 failed in 14.2s
\`\`\`

Average **2.8s/block**, so the full 38-block baseline runs in ~106s — well under #770's 10-minute estimate. Total CI step with Poetry install + Rust build ~8-10min, comfortably under #770's 15-min budget.

## Coexistence with Tier 1

\`ci_reparse_multi.py\` (Tier 1's in-process state-seeding runner) stays in place unchanged. Both can run for the bake cycle:
- **Tier 1** — fast smoke, masks #775 via cache seeding
- **Tier 3** — state-isolated, reports #775's failures honestly

After Tier 3 stabilizes (and #775 is resolved), Tier 1 can be retired.

## Known-failing blocks

#775 documents 19/38 baseline blocks failing in Tier 1 due to \`InMemoryBlockProcessor\` structural divergence from production \`StampProcessor\` (txlist_hash mismatches at boundary blocks). Subprocess isolation can't fix that — it's a processor-implementation gap. Tier 3 reports those failures rather than seeding them away, which is the correct behavior: silent passing on known-broken paths is worse than honest failing.

## Test plan

- [x] Local subprocess test, 5 blocks (4 pass / 1 expected-fail #775)
- [x] YAML syntax validates
- [x] Workflow advisory (\`continue-on-error: true\`) — won't block PRs while we bake
- [ ] After merge: workflow runs on next PR, confirm CI duration under 15 min
- [ ] After bake cycle (1 week): promote step to required by removing \`continue-on-error\`

Refs #770. Follow-ups: #775 (resolve InMemoryBlockProcessor divergence) and #778 (expand baseline 38 → 80 blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)