### PR TITLE
fix(#783): remove dead reparse_mode code paths

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -899,7 +899,6 @@ def follow(
     cp_pipeline=True,
     update_cpids=True,
     single_block=False,
-    reparse_mode=False,
 ):
     """
     Continuously follows the blockchain, parsing and indexing new blocks
@@ -913,7 +912,6 @@ def follow(
         cp_pipeline: Whether to use CP pipeline
         update_cpids: Whether to update CPIDs
         single_block: Whether to process just one block and exit
-        reparse_mode: Whether running in reparse mode
     """
     # Register for shutdown notifications
     shutdown_requested = [False]  # Use list for mutable reference in callback
@@ -946,11 +944,10 @@ def follow(
         profiler = None
 
         # Initial database setup
-        if not reparse_mode:
-            initialize(db)
-            rebuild_balances(db)
-            rebuild_owners(db)
-            # update_src20_token_stats(db)  # Now handled by async holder updater
+        initialize(db)
+        rebuild_balances(db)
+        rebuild_owners(db)
+        # update_src20_token_stats(db)  # Now handled by async holder updater
 
         # Progress watchdog: pages ops if the main loop stalls (no block
         # processed for OPS_ALERT_STALL_SEC, default 30 min) — catches the
@@ -1071,7 +1068,7 @@ def follow(
         blocks_behind = block_tip - block_index if block_tip > block_index else 0
         market_data_threshold = 100  # Only start market data jobs when within 100 blocks of tip
 
-        if config.ENABLE_MARKET_DATA_SCHEDULER and not single_block and not reparse_mode:
+        if config.ENABLE_MARKET_DATA_SCHEDULER and not single_block:
             if blocks_behind <= market_data_threshold:
                 # Defer starting until first block is processed to avoid overwhelming endpoints on startup
                 logger.info(
@@ -1196,7 +1193,6 @@ def follow(
                     and first_block_processed
                     and config.ENABLE_MARKET_DATA_SCHEDULER
                     and not single_block
-                    and not reparse_mode
                 ):
                     blocks_behind = block_tip - block_index if block_tip > block_index else 0
                     market_data_threshold = 100  # Start when within 100 blocks of tip
@@ -1540,65 +1536,64 @@ def follow(
                         logger.debug(f"Block {block_index} has no stamp issuances - this is normal")
 
                     # Check for orphan blocks
-                    if not reparse_mode:
-                        requires_rollback = False
-                        while True:
-                            if block_index == config.BLOCK_FIRST:
-                                break
-                            logger.debug(f"Checking that block {block_index} is not orphan.")
-                            # Invalidate blockcount cache to ensure we have latest chain data for orphan check
-                            backend_instance.invalidate_blockcount_cache()
-                            current_hash = backend_instance.getblockhash(block_index)
-                            block_header = backend_instance.getblockheader(current_hash)
-                            backend_parent = block_header["previousblockhash"]
-                            cursor = db.cursor()
-                            block_query = """
-                            SELECT * FROM blocks WHERE block_index = %s
-                            """
-                            cursor.execute(block_query, (block_index - 1,))
-                            blocks = cursor.fetchall()
-                            columns = [desc[0] for desc in cursor.description]
-                            cursor.close()
-                            blocks_dict = [dict(zip(columns, row)) for row in blocks]
-                            if len(blocks_dict) != 1:
-                                break
-                            db_parent = blocks_dict[0]["block_hash"]
+                    requires_rollback = False
+                    while True:
+                        if block_index == config.BLOCK_FIRST:
+                            break
+                        logger.debug(f"Checking that block {block_index} is not orphan.")
+                        # Invalidate blockcount cache to ensure we have latest chain data for orphan check
+                        backend_instance.invalidate_blockcount_cache()
+                        current_hash = backend_instance.getblockhash(block_index)
+                        block_header = backend_instance.getblockheader(current_hash)
+                        backend_parent = block_header["previousblockhash"]
+                        cursor = db.cursor()
+                        block_query = """
+                        SELECT * FROM blocks WHERE block_index = %s
+                        """
+                        cursor.execute(block_query, (block_index - 1,))
+                        blocks = cursor.fetchall()
+                        columns = [desc[0] for desc in cursor.description]
+                        cursor.close()
+                        blocks_dict = [dict(zip(columns, row)) for row in blocks]
+                        if len(blocks_dict) != 1:
+                            break
+                        db_parent = blocks_dict[0]["block_hash"]
 
-                            if not isinstance(db_parent, str):
-                                raise TypeError("db_parent must be a string")
-                            if not isinstance(backend_parent, str):
-                                raise TypeError("backend_parent must be a string")
-                            if db_parent == backend_parent:
-                                break
-                            else:
-                                block_index -= 1
-                                requires_rollback = True
-
-                        if requires_rollback:
-                            logger.warning(f"Blockchain reorganization at block {block_index}.")
+                        if not isinstance(db_parent, str):
+                            raise TypeError("db_parent must be a string")
+                        if not isinstance(backend_parent, str):
+                            raise TypeError("backend_parent must be a string")
+                        if db_parent == backend_parent:
+                            break
+                        else:
                             block_index -= 1
+                            requires_rollback = True
 
-                            if check_rollback_loop(block_index):
-                                logger.error("Exiting due to rollback loop detection")
-                                handle_rollback_loop_failure(
-                                    error_message=f"Detected rollback loop at block {block_index}", block_index=block_index
-                                )
+                    if requires_rollback:
+                        logger.warning(f"Blockchain reorganization at block {block_index}.")
+                        block_index -= 1
 
-                            log_reorg_event(
-                                db,
-                                block_index=block_index,
-                                old_block_hash=db_parent,
-                                new_block_hash=backend_parent,
-                                rollback_depth=0,
-                                detection_method="orphan_block_check",
+                        if check_rollback_loop(block_index):
+                            logger.error("Exiting due to rollback loop detection")
+                            handle_rollback_loop_failure(
+                                error_message=f"Detected rollback loop at block {block_index}", block_index=block_index
                             )
-                            block_index = rollback_to_block(db, block_index, "Chain reorganization detected")
-                            if cp_pipeline_instance:
-                                logger.info(f"Resetting CP pipeline after chain reorg to block {block_index}")
-                                cp_pipeline_instance.reset(block_index)
-                            stamp_issuances_list = None
-                            time.sleep(60)  # delay waiting for CP to catch up
-                            continue
+
+                        log_reorg_event(
+                            db,
+                            block_index=block_index,
+                            old_block_hash=db_parent,
+                            new_block_hash=backend_parent,
+                            rollback_depth=0,
+                            detection_method="orphan_block_check",
+                        )
+                        block_index = rollback_to_block(db, block_index, "Chain reorganization detected")
+                        if cp_pipeline_instance:
+                            logger.info(f"Resetting CP pipeline after chain reorg to block {block_index}")
+                            cp_pipeline_instance.reset(block_index)
+                        stamp_issuances_list = None
+                        time.sleep(60)  # delay waiting for CP to catch up
+                        continue
 
                     # Get block hash and verify
                     block_hash = backend_instance.getblockhash(block_index)
@@ -1656,7 +1651,7 @@ def follow(
                     # Check if we're at or near the chain tip (where hash mismatches are more likely during sync)
                     near_tip = block_index >= block_tip - 2
 
-                    if xcp_hash and xcp_hash != block_hash and not reparse_mode:
+                    if xcp_hash and xcp_hash != block_hash:
                         if near_tip:
                             # For blocks near the tip, log as warning but continue - this is likely due to XCP lag
                             logger.warning(f"Hash mismatch at block {block_index} near chain tip - this is likely temporary")

--- a/indexer/src/index_core/server.py
+++ b/indexer/src/index_core/server.py
@@ -473,9 +473,3 @@ def start_all(db: Connection) -> None:
         # Ensure proper cleanup
         if executor:
             executor.shutdown(wait=True)
-
-
-def reparse(db, block_index=None, quiet=True):
-    """Reparse from a specific block index."""
-    connect_to_backend()  # This sets the global backend_instance
-    blocks.reparse(db, block_index=block_index, quiet=quiet)

--- a/indexer/tests/test_server.py
+++ b/indexer/tests/test_server.py
@@ -515,32 +515,6 @@ class TestStartAll:
                         )
 
 
-class TestReparse:
-    """Test reparse function."""
-
-    def test_reparse(self, mock_backend):
-        """Test reparse function."""
-        from index_core.server import reparse
-
-        mock_db = mock.MagicMock()
-
-        with mock.patch("index_core.server.blocks") as mock_blocks:
-            reparse(mock_db, block_index=12345, quiet=False)
-
-            mock_blocks.reparse.assert_called_once_with(mock_db, block_index=12345, quiet=False)
-
-    def test_reparse_default_params(self, mock_backend):
-        """Test reparse with default parameters."""
-        from index_core.server import reparse
-
-        mock_db = mock.MagicMock()
-
-        with mock.patch("index_core.server.blocks") as mock_blocks:
-            reparse(mock_db)
-
-            mock_blocks.reparse.assert_called_once_with(mock_db, block_index=None, quiet=True)
-
-
 class TestGlobalVariables:
     """Test global variables and their usage."""
 


### PR DESCRIPTION
## Summary

Audit confirmed three reparse-related code paths are unreachable at runtime — the canonical reparse pipeline runs through \`index_core.reparse.validator:main\` (\`poetry run reparse\`), and nothing in production touches the suspect sites. This PR deletes them.

Closes #783.

## What's removed

### \`server.py\` — broken \`reparse()\` function
\`def reparse(...)\` at lines 478-481 called \`blocks.reparse(...)\` which does not exist (\`hasattr(blocks, 'reparse')\` returns False — confirmed empirically). The function would AttributeError at runtime; tests "worked" only because they mocked \`index_core.server.blocks\` entirely. No production caller.

### \`test_server.py\` — \`TestReparse\` class
Two tests (\`test_reparse\`, \`test_reparse_default_params\`) covered the dead function via mocked blocks. Removed alongside.

### \`blocks.py\` — \`reparse_mode\` parameter + 5 gated branches
- \`def follow(..., reparse_mode=False)\` parameter removed. Only production caller is \`server.py:429 blocks.follow(db)\`; never passed \`reparse_mode=True\`. No test passes it either. The True branch was unreachable.
- 5 dead branches removed:
  - **L949**: \`if not reparse_mode:\` wrapping \`initialize + rebuild_balances + rebuild_owners\` — unwrapped (was always entered)
  - **L1074, L1199, L1659**: \`and not reparse_mode\` removed from market-data-scheduler and XCP-mismatch conditions
  - **L1543**: \`if not reparse_mode:\` wrapping the orphan-block check (~60 lines) — unwrapped and dedented

## Kept (with reason)

- \`test_market_data_scheduler_flag.py\` — uses \`reparse_mode\` as a local variable to test the scheduler-gate logic shape. Doesn't import blocks.py or call follow(). Tests pass identically after this change.
- \`tools/backfill_encoding_method.py:phase2_rust_reparse\` — separate one-off backfill, unrelated.
- Production reparse pipeline (\`index_core/reparse/*\`) untouched.

## Test plan

- [x] \`pytest tests/test_block_rollback.py tests/test_blocks_coverage.py tests/test_blocks_simple.py tests/test_rollback_functionality.py tests/test_server.py tests/test_market_data_scheduler_flag.py\`: 58 pass / 1 fail. The 1 failure (\`test_start_all_basic\`) is **pre-existing on dev** (verified). Unrelated to this PR.
- [x] black + flake8 clean on modified files (pre-existing F401/F841 in test_server.py are not regressions)
- [x] Sanity import: \`inspect.signature(blocks.follow).parameters\` no longer contains \`reparse_mode\`; \`hasattr(server, 'reparse') == False\`
- [ ] After merge: prod restart picks up smaller \`blocks.follow\` signature; no behavior change expected

Net diff: **59 insertions / 96 deletions** across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)