### PR TITLE
ci(#768): SHA-pin all third-party GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,15 @@ updates:
 
   # GitHub Actions — tj-actions/changed-files compromise (March 2025) made this
   # a real supply-chain vector; cooldown is essential here.
+  #
+  # PIN REQUIREMENT (#768): every third-party (non-actions/*) action in
+  # .github/workflows/ MUST be pinned to a full 40-char commit SHA with the
+  # version tag kept as a trailing comment, e.g.
+  #     uses: docker/build-push-action@<sha> # v7
+  # Mutable major tags (@v7, @v2) let a publisher re-point them at any commit;
+  # SHA pins + the cooldown below are the hardened posture. Dependabot proposes
+  # new SHAs here weekly. actions/*-namespace actions are GitHub-owned and left
+  # at tags by convention. When adding a new third-party action, SHA-pin it.
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "dev"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Create Release
         if: env.SKIP == 'false' && env.NEW_VERSION && github.ref == 'refs/heads/main'
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -257,7 +257,7 @@ jobs:
       - name: Create Release
         if: env.NEW_VERSION
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./indexer
 
       - name: Setup Rust and build parser
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Build Rust parser
         working-directory: ./indexer
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,12 +31,12 @@ jobs:
           python-version: '3.11'  # Use single version for coverage (same as integration tests)
           
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies (Restore Only)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
           save-if: ${{ false }}  # Don't save cache, only restore from main CI
@@ -64,7 +64,7 @@ jobs:
         working-directory: ./indexer
         
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: ./indexer/coverage.xml
           root_dir: ./indexer

--- a/.github/workflows/docker-auto-publish.yml
+++ b/.github/workflows/docker-auto-publish.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       
       - name: Extract version from pyproject.toml
         id: get-version
@@ -58,7 +58,7 @@ jobs:
           fi
       
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: btcstamps
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -99,7 +99,7 @@ jobs:
           fi
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./indexer
           push: true
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'btcstamps/indexer:${{ steps.set-tag.outputs.TAG }}'
           format: 'table'
@@ -120,7 +120,7 @@ jobs:
           skip-files: 'app/bootstrap/srcbackground.csv,/usr/src/app/files/**'
 
       - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4
         if: github.ref == 'refs/heads/main'
         with:
           username: btcstamps

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,17 +32,17 @@ jobs:
         uses: actions/checkout@v5
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: btcstamps
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: btcstamps/indexer
           tags: |
@@ -50,7 +50,7 @@ jobs:
             type=sha,prefix=,suffix=,format=short
       
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./indexer
           push: true
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'btc_stamps/indexer:${{ inputs.tag }}'
           format: 'table'
@@ -69,7 +69,7 @@ jobs:
           skip-files: 'app/bootstrap/srcbackground.csv,/usr/src/app/files/**'
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           format: spdx-json
           artifact-name: sbom.spdx.json

--- a/.github/workflows/freeze-drift.yml
+++ b/.github/workflows/freeze-drift.yml
@@ -37,10 +37,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build production-mode indexer image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: indexer
           file: indexer/Dockerfile

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           python-version: '3.11'
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
       - name: Cache Rust dependencies (Save + Restore)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
       - name: Install Poetry
@@ -58,11 +58,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
       - name: Cache Rust dependencies (Restore Only)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
           save-if: ${{ false }}
@@ -107,11 +107,11 @@ jobs:
         with:
           python-version: '3.11'
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
       - name: Cache Rust dependencies (Restore Only)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}
           save-if: ${{ false }}

--- a/.github/workflows/reparse-validate.yml
+++ b/.github/workflows/reparse-validate.yml
@@ -96,11 +96,11 @@ jobs:
       # Needs the indexer venv (poetry install) and the Rust parser build
       # because smoke_parser_validation imports index_core.* directly.
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: indexer/src/rust_parser
           key: rust-${{ runner.os }}-${{ hashFiles('indexer/src/rust_parser/rust-toolchain.toml') }}-${{ hashFiles('indexer/src/rust_parser/Cargo.lock') }}

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./indexer
 
       - name: Setup Rust and build parser
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Build Rust parser
         working-directory: ./indexer


### PR DESCRIPTION
## Summary

Closes #768. SHA-pins every third-party (non-`actions/*`) GitHub Action in `.github/workflows/` to a full 40-char commit SHA, keeping the version tag as a trailing comment. Mutable major tags (`@v7`, `@v2`, …) are re-pointable by the publisher; SHA pins + the existing dependabot cooldown are the hardened posture.

## What changed

- **12 third-party actions pinned** across 30 use-sites: `actions-rust-lang/setup-rust-toolchain`, `Swatinem/rust-cache`, `docker/{setup-buildx,build-push,login,metadata}-action`, `softprops/action-gh-release`, `aquasecurity/trivy-action`, `anthropics/claude-code-action`, `peter-evans/dockerhub-description`, `codecov/codecov-action`, `anchore/sbom-action`.
- `actions/*` (checkout, setup-python, cache, github-script, upload-artifact) left at tags — GitHub-owned, exempt by convention.
- `dependabot.yml` already manages the `github-actions` ecosystem (weekly, 7-day cooldown / 30-day major) so SHAs stay current; added an inline note documenting the pin requirement (no CONTRIBUTING.md in repo).

## Verification

- All workflow files parse as valid YAML.
- No third-party action remains on a bare tag.
- SHAs resolved from each action's current tag via the GitHub API at pin time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)