### PR TITLE
ci(#759): reparse-validate 3.10/3.11/3.12 matrix + consensus pkg pin guard

### DIFF
--- a/.github/workflows/reparse-validate.yml
+++ b/.github/workflows/reparse-validate.yml
@@ -32,6 +32,7 @@ on:
       - 'indexer/snapshots/ci_consensus_hashes.json'
       - 'indexer/snapshots/reference_hashes.json'
       - 'indexer/src/config.py'
+      - 'indexer/ci/**'
       - '.github/workflows/reparse-validate.yml'
   workflow_dispatch:
 
@@ -40,17 +41,26 @@ permissions:
 
 jobs:
   reparse-validate:
-    name: Reparse Consensus Validation
+    name: Reparse Consensus Validation (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     # Advisory on first land — promote to required after one bake cycle.
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # Validate consensus on every Python the project supports. Prod runs
+        # 3.10; the dev container runs 3.12. A code audit (#803) proved the
+        # consensus hashes are version-invariant across this range *today* —
+        # this matrix is the per-PR guard against a future code change
+        # reintroducing Python-version sensitivity.
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Cross-check CHECKPOINTS_MAINNET against reference_hashes.json
         # Catches the "someone edited check.py without refreshing
@@ -101,6 +111,14 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 - --version 2.1.1
           poetry config virtualenvs.in-project true
           poetry install
+
+      # Consensus-critical packages (regex, PyNaCl, pybase64) must be exact-
+      # pinned and install identically on every matrix Python — a version flip
+      # can silently change indexer output (#759). Runs per Python version, so
+      # it also proves the same versions resolve on 3.10 / 3.11 / 3.12.
+      - name: Consensus package pin guard
+        working-directory: ./indexer
+        run: poetry run python ci/check_consensus_pkg_pins.py
 
       - name: Tier 3 — subprocess reparse over curated baseline
         working-directory: ./indexer

--- a/indexer/ci/check_consensus_pkg_pins.py
+++ b/indexer/ci/check_consensus_pkg_pins.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Guard: consensus-critical packages must be exact-pinned AND installed at the pin.
+
+Issue #759. A version flip in any of these packages can silently change indexer
+output and break consensus with the production RDS:
+
+  * regex      — used in MIME-detection regexes
+  * PyNaCl     — signature / key handling
+  * pybase64   — SIMD base64 decoder; validate=True behavior varies across versions
+
+This script enforces two invariants in CI, on every Python version in the
+reparse-validate matrix (so it also proves the SAME versions install on
+3.10 / 3.11 / 3.12):
+
+  1. Each package is declared with an EXACT version in pyproject.toml
+     (a bare ``name = "x.y.z"`` — no caret/tilde/range/wildcard), so
+     ``poetry update`` cannot move it.
+  2. The version actually installed in the environment equals that pin.
+
+``btc_stamps_parser`` (the Rust wheel) is built per-environment rather than
+pinned as a PyPI version, so it is reported but not pin-checked here; the
+freeze-drift workflow + build pipeline cover it.
+
+Exit 0 if all invariants hold, 1 otherwise. No network, no indexer import.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+import os
+import re
+import sys
+
+# Distribution name -> import/metadata name. pyproject keys are lower-case.
+CONSENSUS_PACKAGES = ["regex", "pynacl", "pybase64"]
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PYPROJECT = os.path.normpath(os.path.join(HERE, "..", "pyproject.toml"))
+
+# Matches a bare exact pin in [tool.poetry.dependencies], e.g. `regex = "2026.2.28"`.
+# Deliberately rejects caret/tilde/range/wildcard/markers so a loosened
+# constraint fails the guard instead of silently allowing drift.
+_EXACT = re.compile(r'^\s*(?P<name>[A-Za-z0-9_.-]+)\s*=\s*"(?P<ver>[0-9][^"^~><=*,\s]*)"\s*$')
+
+
+def _declared_pins(path: str) -> dict[str, str]:
+    """Return {lower_name: exact_version} for bare-string deps in pyproject."""
+    pins: dict[str, str] = {}
+    for line in open(path, encoding="utf-8"):
+        m = _EXACT.match(line)
+        if m:
+            pins[m.group("name").lower()] = m.group("ver")
+    return pins
+
+
+def main() -> int:
+    pins = _declared_pins(PYPROJECT)
+    failures: list[str] = []
+
+    print(f"Consensus package pin guard (Python {sys.version.split()[0]})")
+    print(f"  pyproject: {PYPROJECT}\n")
+
+    for pkg in CONSENSUS_PACKAGES:
+        declared = pins.get(pkg)
+        try:
+            installed = md.version(pkg)
+        except md.PackageNotFoundError:
+            installed = None
+
+        if declared is None:
+            failures.append(f"{pkg}: not exact-pinned in pyproject.toml (must be a bare `\"x.y.z\"`)")
+            print(f"  ✗ {pkg}: no exact pin found in pyproject")
+            continue
+        if installed is None:
+            failures.append(f"{pkg}: pinned {declared} but not installed")
+            print(f"  ✗ {pkg}: pinned {declared}, not installed")
+            continue
+        if installed != declared:
+            failures.append(f"{pkg}: installed {installed} != pinned {declared}")
+            print(f"  ✗ {pkg}: installed {installed} != pinned {declared}")
+            continue
+        print(f"  ✓ {pkg}: {installed} (exact-pinned)")
+
+    # Informational: the Rust wheel is built per-env, not PyPI-pinned.
+    try:
+        print(f"\n  (info) btc-stamps-parser: {md.version('btc-stamps-parser')} — built per-env, not pin-checked")
+    except md.PackageNotFoundError:
+        pass
+
+    if failures:
+        print("\nCONSENSUS PIN DRIFT DETECTED:")
+        for f in failures:
+            print(f"  - {f}")
+        print("\nFix: pin the package to an exact version in indexer/pyproject.toml and "
+              "`poetry lock` so the installed version matches. See #759.")
+        return 1
+
+    print("\nAll consensus-critical packages are exact-pinned and match. ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/indexer/ci/check_consensus_pkg_pins.py
+++ b/indexer/ci/check_consensus_pkg_pins.py
@@ -68,7 +68,7 @@ def main() -> int:
             installed = None
 
         if declared is None:
-            failures.append(f"{pkg}: not exact-pinned in pyproject.toml (must be a bare `\"x.y.z\"`)")
+            failures.append(f'{pkg}: not exact-pinned in pyproject.toml (must be a bare `"x.y.z"`)')
             print(f"  ✗ {pkg}: no exact pin found in pyproject")
             continue
         if installed is None:
@@ -91,8 +91,10 @@ def main() -> int:
         print("\nCONSENSUS PIN DRIFT DETECTED:")
         for f in failures:
             print(f"  - {f}")
-        print("\nFix: pin the package to an exact version in indexer/pyproject.toml and "
-              "`poetry lock` so the installed version matches. See #759.")
+        print(
+            "\nFix: pin the package to an exact version in indexer/pyproject.toml and "
+            "`poetry lock` so the installed version matches. See #759."
+        )
         return 1
 
     print("\nAll consensus-critical packages are exact-pinned and match. ✓")


### PR DESCRIPTION
## Summary

Closes #759. The consensus-critical packages are already exact-pinned and identical prod↔dev, so this PR delivers the remaining acceptance criterion — a CI guard that catches drift before merge — plus cross-Python validation.

## Context

Prod runs **Python 3.10**, the dev container runs **3.12**, `pyproject.toml` is `^3.10`. A code audit (#803) proved the consensus hashes (`txlist/messages/ledger_hash`) are **version-invariant across 3.10–3.12** today (every hashed value reduces to `str()`/`repr()` of `{str,int,bool,None,Decimal}`; no set/dict-unsorted-iteration, float, `json.dumps`, or `hash()` in the path). But the reparse-validate job ran on 3.12 only — so a *future* change reintroducing version-sensitivity would slip through.

## What changed

- **Matrix `reparse-validate` on `['3.10','3.11','3.12']`** (`fail-fast: false`), mirroring the Code Quality matrix. CI now proves the curated boundary blocks hash identically on the Python prod computes with (3.10) and the one dev runs (3.12).
- **`indexer/ci/check_consensus_pkg_pins.py`** — asserts `regex` / `PyNaCl` / `pybase64` are exact-pinned in `pyproject.toml` (rejects `^`/`~`/range/`*`) **and** installed at the pin. Runs per matrix Python (also proves identical resolution across versions). `btc-stamps-parser` is built per-env → reported, not pin-checked.
- Added `indexer/ci/**` to the workflow path filter.

## Local validation

```
$ poetry run python ci/check_consensus_pkg_pins.py
  ✓ regex: 2026.2.28 (exact-pinned)
  ✓ pynacl: 1.6.2 (exact-pinned)
  ✓ pybase64: 1.4.3 (exact-pinned)
All consensus-critical packages are exact-pinned and match. ✓
```
Guard also unit-checked to reject `^`/`~`/`>=`/`*` constraints.

## Note

This does not touch prod. A deliberate prod 3.10→3.12 upgrade (if desired) is a separate, reindex-validated effort. The `repr`-coupling fragility the audit surfaced is tracked in #803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)