### PR TITLE
fix(#775): reparse ConsensusError at SRC-20 genesis+1 (block 788042)

### DIFF
--- a/indexer/ci/ci_reparse_subprocess.py
+++ b/indexer/ci/ci_reparse_subprocess.py
@@ -69,9 +69,14 @@ DEFAULT_PER_BLOCK_TIMEOUT = 120
 # 18 of 38 blocks failed (16 `'bytes' object has no attribute 'get'` errors
 # from OLGA payload extraction + 1 `ConsensusError` at block 788042 + 1
 # generic InMemoryBlockProcessor crash). See #775.
+#
+# 2026-06-26: block 788042 (the `ConsensusError`) fixed — the validator now
+# mirrors production by treating the previous ledger hash as unset at SRC-20
+# genesis+1 (validator.compute_block_hashes). It validates cleanly and was
+# removed from this list. 17 known failures remain (all `InMemoryBlockProcessor`
+# divergences tracked by #775).
 TIER3_KNOWN_FAILURES: Set[int] = {
     784551,
-    788042,
     789624,
     792369,
     792370,

--- a/indexer/src/index_core/reparse/validator.py
+++ b/indexer/src/index_core/reparse/validator.py
@@ -322,6 +322,18 @@ class ReparseValidator:
             orig_checkpoint = None
             if block_index in check_mod.CHECKPOINTS_MAINNET:
                 orig_checkpoint = check_mod.CHECKPOINTS_MAINNET.pop(block_index)
+            # Consensus rule (#775): at SRC-20 genesis+1, check.consensus_hash
+            # requires the *previous* ledger hash to be unset and seeds it to
+            # shash_string("") itself; a truthy previous_consensus_hash raises a
+            # ConsensusError. Production passes a falsy previous_ledger_hash here,
+            # but the validator otherwise feeds the prior block's snapshot hash
+            # (or the zero-hash default), which is truthy — so it must mirror
+            # production and pass "" for the ledger previous at this one block.
+            # Only the ledger previous is special-cased; txlist/messages still
+            # chain normally.
+            prev_ledger_hash = prev_hashes["ledger_hash"]
+            if block_index == _cfg.CP_SRC20_GENESIS_BLOCK + 1:
+                prev_ledger_hash = ""
             try:
                 new_ledger_hash, new_txlist_hash, new_messages_hash = create_check_hashes(
                     mock_db,
@@ -329,7 +341,7 @@ class ReparseValidator:
                     block_processor.valid_stamps_in_block,
                     block_processor.processed_src20_in_block,
                     txhash_list,
-                    prev_hashes["ledger_hash"],
+                    prev_ledger_hash,
                     prev_hashes["txlist_hash"],
                     prev_hashes["messages_hash"],
                 )


### PR DESCRIPTION
## Summary

First of the laddered #775 fixes — the isolated **Class-2 `ConsensusError`** at block **788042** (SRC-20 genesis+1). Reparse-harness-only; cannot change production consensus.

## Root cause

`check.consensus_hash` (`check.py:244`) enforces a consensus rule: at `CP_SRC20_GENESIS_BLOCK + 1`, the *previous* ledger hash must be unset — it seeds `shash_string("")` itself, and a truthy `previous_consensus_hash` raises `ConsensusError("Expected previous_consensus_hash to be unset for the SRC20 genesis block")`. Production passes a falsy `previous_ledger_hash` there. The reparse validator instead fed `prev_hashes["ledger_hash"]` — the prior block's snapshot value (or the `0000…0` default), both truthy — so 788042 always failed.

## Fix

In `validator.compute_block_hashes`, override **only the ledger previous-hash** to `""` when `block_index == CP_SRC20_GENESIS_BLOCK + 1` (txlist/messages still chain normally), mirroring production. Removed 788042 from `TIER3_KNOWN_FAILURES`.

## Validation

```
$ poetry run python ci/smoke_parser_validation.py --block 788042
validate_block(788042) = True          # was: ConsensusError

$ poetry run python ci/ci_reparse_subprocess.py
Skipping 17 known-failing blocks (#775)...
[7/21] block 788042: ✓
Subprocess reparse complete: 21/21 passed, 0 failed   # was 20/20
```
- `788042` now validates (hash **matches**, not just "doesn't crash") — confirms it was purely the ConsensusError.
- Reparse/consensus unit tests: 36 passed.

## Scope note

This is the validator only. The remaining 17 `TIER3_KNOWN_FAILURES` are the `InMemoryBlockProcessor` Class-1 (bytes/dict) divergences + one generic crash — they need the larger #775 realignment (drive the real `BlockProcessor` over a temp-schema DB) and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)