### PR TITLE
chore: refresh freeze.prod.lock (anyio 4.14.0 → 4.14.1)

### DIFF
--- a/indexer/ci/freeze.prod.lock
+++ b/indexer/ci/freeze.prod.lock
@@ -9,7 +9,7 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.13.3
 aiosignal==1.4.0
 annotated-types==0.7.0
-anyio==4.14.0
+anyio==4.14.1
 appdirs==1.4.4
 arrow==1.3.0
 arweave-python-client==1.0.19


### PR DESCRIPTION
## Summary

Regenerates the production-image package baseline `indexer/ci/freeze.prod.lock`, which had drifted from current `poetry.lock` resolution. The freeze-drift check surfaced this (it ran on #804 because that PR SHA-pins actions inside `freeze-drift.yml`).

## Diff

Single line:
```
-anyio==4.14.0
+anyio==4.14.1
```
A transitive patch bump — no direct dependency changed, and no consensus-critical package (`regex`/`PyNaCl`/`pybase64`) moved.

## How

`./indexer/ci/refresh-freeze.sh` (Python 3.12, `INSTALL_DEV=false`, `--target builder`) — the same build the freeze-drift workflow runs — then committed the result.

After this merges, #804 (SHA-pin actions) can rebase on `dev` and its freeze-drift check will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)