### PR TITLE
refactor(#774): name the reparse BTC_SRC20_GENESIS_BLOCK toggle + test it

### DIFF
--- a/indexer/src/index_core/reparse/validator.py
+++ b/indexer/src/index_core/reparse/validator.py
@@ -19,6 +19,7 @@ import importlib.util
 import json  # for debug dump of hash dicts
 import logging
 import time  # for measuring validation duration
+from contextlib import contextmanager
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -109,6 +110,42 @@ def main() -> None:
         reparse_caching.cache_manager.check_memory_pressure()
     logging.info("All blocks validated successfully")
     sys.exit(0)
+
+
+@contextmanager
+def _force_post_genesis_filter():
+    """Force ``filter_block_transactions`` to take its post-genesis branch.
+
+    ``block_validation.filter_block_transactions`` gates on
+    ``block_index < config.BTC_SRC20_GENESIS_BLOCK``: pre-genesis it keeps only
+    stamp-issuance txs, post-genesis it routes EVERY tx through the Rust parser.
+    For deterministic in-memory reparse we want the post-genesis behaviour for
+    every block (uniform parsing, no pre-genesis special-casing), so this
+    temporarily lowers the threshold to ``CP_STAMP_GENESIS_BLOCK``.
+
+    NOTE: this repurposes the ``BTC_SRC20_GENESIS_BLOCK`` config value as a
+    filter-mode toggle — it does NOT relocate the actual SRC-20-on-Bitcoin
+    genesis, which is unchanged for every other consumer. The value is restored
+    in ``finally`` so a transient bitcoind / CP-core error can't leak the
+    mutated threshold into later blocks for the process lifetime.
+
+    The restore-on-exit/exception behaviour is pinned by
+    ``test_force_post_genesis_filter``. The toggle is also correct today only
+    because no non-issuance tx in the CP era (779,652–793,067) carries a payload
+    the Rust parser classifies as protocol traffic; that empirical invariant is
+    guarded at integration level by the Tier-3 reparse of the CP-era curated
+    blocks — a leak would surface there as a consensus-hash mismatch. The toggle
+    goes away entirely once the Rust parser does CP/stamp pre-detection and every
+    block is decoded uniformly (#754). See #774.
+    """
+    import config as _cfg
+
+    orig = _cfg.BTC_SRC20_GENESIS_BLOCK
+    _cfg.BTC_SRC20_GENESIS_BLOCK = _cfg.CP_STAMP_GENESIS_BLOCK
+    try:
+        yield
+    finally:
+        _cfg.BTC_SRC20_GENESIS_BLOCK = orig
 
 
 class ValidationError(Exception):
@@ -253,19 +290,13 @@ class ReparseValidator:
     ) -> Dict[str, str]:
         """Compute hashes for a block using the same logic as production."""
         try:
-            # Sync util and config so that filtering treats our reparse genesis as post-genesis
+            # Sync util so that filtering treats our reparse genesis as post-genesis
             util.CURRENT_BLOCK_INDEX = block_index
             import config as _cfg
 
-            # Temporarily align BTC_SRC20_GENESIS_BLOCK to our CP_STAMP_GENESIS_BLOCK.
-            # The try/finally ensures the global is restored even if an inner
-            # call (getblock / fetch_xcp / filter_block_transactions) raises —
-            # otherwise a transient bitcoind / CP-core hiccup leaks the mutated
-            # value into every subsequent block's filtering for the lifetime of
-            # the process. Same pattern is already used below for CHECKPOINTS_MAINNET.
-            _orig_gen = _cfg.BTC_SRC20_GENESIS_BLOCK
-            _cfg.BTC_SRC20_GENESIS_BLOCK = _cfg.CP_STAMP_GENESIS_BLOCK
-            try:
+            # See _force_post_genesis_filter: force every tx through the Rust
+            # parser (post-genesis filter branch) for uniform in-memory reparse.
+            with _force_post_genesis_filter():
                 # Get block data from Bitcoin node
                 block_hash = backend_instance.getblockhash(block_index)
                 block_data = backend_instance.getblock(block_hash, 2)
@@ -285,8 +316,6 @@ class ReparseValidator:
                         for issuance in stamp_issuances
                         if issuance.get("tx_hash") in raw_transactions
                     }
-            finally:
-                _cfg.BTC_SRC20_GENESIS_BLOCK = _orig_gen
 
             # Process transactions using BlockProcessor if not provided
             # Initialize an in-memory processor if none provided

--- a/indexer/src/index_core/reparse/validator.py
+++ b/indexer/src/index_core/reparse/validator.py
@@ -8,7 +8,7 @@ import sys
 os.environ["USE_TEST_DB"] = "1"
 os.environ["MOCK_DB"] = "1"
 os.environ["TESTING"] = "1"
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Iterator, Optional, Union
 from unittest.mock import MagicMock
 
 if TYPE_CHECKING:
@@ -113,7 +113,7 @@ def main() -> None:
 
 
 @contextmanager
-def _force_post_genesis_filter():
+def _force_post_genesis_filter() -> Iterator[None]:
     """Force ``filter_block_transactions`` to take its post-genesis branch.
 
     ``block_validation.filter_block_transactions`` gates on

--- a/indexer/tests/test_force_post_genesis_filter.py
+++ b/indexer/tests/test_force_post_genesis_filter.py
@@ -11,6 +11,14 @@ block. These tests pin the two properties that make that safe:
      nested — so a transient bitcoind / CP-core error can't leak the mutated
      threshold into later blocks for the process lifetime.
 
+Other tests in the suite both mutate ``config.BTC_SRC20_GENESIS_BLOCK`` and
+``importlib.reload(config)`` (replacing the ``config`` object in
+``sys.modules``). The context manager does ``import config`` at call time, so to
+observe the SAME module object — not a stale one captured at import — each test
+resolves ``config`` inside the function body and pins the value via
+``monkeypatch`` (auto-restored at teardown). These tests therefore neither
+depend on nor pollute that global.
+
 The complementary CP-era invariant (no non-issuance tx in 779,652–793,067
 produces protocol payload under this toggle) is guarded at integration level by
 the Tier-3 reparse of the CP-era curated blocks — a leak surfaces there as a
@@ -19,35 +27,42 @@ consensus-hash mismatch.
 
 import pytest
 
-import config
 from index_core.reparse.validator import _force_post_genesis_filter
 
+# An arbitrary block height distinct from CP_STAMP_GENESIS_BLOCK, so the toggle
+# is a genuine change rather than a no-op.
+_SENTINEL = 808_080
 
-def test_toggle_lowers_threshold_to_cp_stamp_genesis():
-    orig = config.BTC_SRC20_GENESIS_BLOCK
-    # Precondition: the real SRC-20 genesis is above the stamp genesis, so the
-    # toggle is a genuine change, not a no-op.
-    assert orig != config.CP_STAMP_GENESIS_BLOCK
+
+def test_toggle_lowers_threshold_to_cp_stamp_genesis(monkeypatch):
+    import config  # resolve the same object the context manager imports at call time
+
+    monkeypatch.setattr(config, "BTC_SRC20_GENESIS_BLOCK", _SENTINEL)
+    assert _SENTINEL != config.CP_STAMP_GENESIS_BLOCK
     with _force_post_genesis_filter():
         assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
-    assert config.BTC_SRC20_GENESIS_BLOCK == orig
+    assert config.BTC_SRC20_GENESIS_BLOCK == _SENTINEL
 
 
-def test_toggle_restores_on_exception():
+def test_toggle_restores_on_exception(monkeypatch):
     """Restoration in finally is the 'can't leak into later blocks' guarantee."""
-    orig = config.BTC_SRC20_GENESIS_BLOCK
+    import config
+
+    monkeypatch.setattr(config, "BTC_SRC20_GENESIS_BLOCK", _SENTINEL)
     with pytest.raises(RuntimeError):
         with _force_post_genesis_filter():
             assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
             raise RuntimeError("simulated bitcoind/CP-core hiccup")
-    assert config.BTC_SRC20_GENESIS_BLOCK == orig
+    assert config.BTC_SRC20_GENESIS_BLOCK == _SENTINEL
 
 
-def test_toggle_is_nesting_safe():
-    orig = config.BTC_SRC20_GENESIS_BLOCK
+def test_toggle_is_nesting_safe(monkeypatch):
+    import config
+
+    monkeypatch.setattr(config, "BTC_SRC20_GENESIS_BLOCK", _SENTINEL)
     with _force_post_genesis_filter():
         with _force_post_genesis_filter():
             assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
         # inner exit restores to the value captured at inner enter (still toggled)
         assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
-    assert config.BTC_SRC20_GENESIS_BLOCK == orig
+    assert config.BTC_SRC20_GENESIS_BLOCK == _SENTINEL

--- a/indexer/tests/test_force_post_genesis_filter.py
+++ b/indexer/tests/test_force_post_genesis_filter.py
@@ -1,0 +1,53 @@
+"""Unit tests for the reparse validator's ``_force_post_genesis_filter`` toggle (#774).
+
+The context manager repurposes ``config.BTC_SRC20_GENESIS_BLOCK`` as a
+filter-mode toggle so the in-memory reparse forces ``filter_block_transactions``
+onto its post-genesis branch (decode every tx via the Rust parser) for every
+block. These tests pin the two properties that make that safe:
+
+  1. inside the context the threshold equals ``CP_STAMP_GENESIS_BLOCK`` (so the
+     post-genesis branch is taken for every block_index), and
+  2. the original value is ALWAYS restored — including on exceptions and when
+     nested — so a transient bitcoind / CP-core error can't leak the mutated
+     threshold into later blocks for the process lifetime.
+
+The complementary CP-era invariant (no non-issuance tx in 779,652–793,067
+produces protocol payload under this toggle) is guarded at integration level by
+the Tier-3 reparse of the CP-era curated blocks — a leak surfaces there as a
+consensus-hash mismatch.
+"""
+
+import pytest
+
+import config
+from index_core.reparse.validator import _force_post_genesis_filter
+
+
+def test_toggle_lowers_threshold_to_cp_stamp_genesis():
+    orig = config.BTC_SRC20_GENESIS_BLOCK
+    # Precondition: the real SRC-20 genesis is above the stamp genesis, so the
+    # toggle is a genuine change, not a no-op.
+    assert orig != config.CP_STAMP_GENESIS_BLOCK
+    with _force_post_genesis_filter():
+        assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
+    assert config.BTC_SRC20_GENESIS_BLOCK == orig
+
+
+def test_toggle_restores_on_exception():
+    """Restoration in finally is the 'can't leak into later blocks' guarantee."""
+    orig = config.BTC_SRC20_GENESIS_BLOCK
+    with pytest.raises(RuntimeError):
+        with _force_post_genesis_filter():
+            assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
+            raise RuntimeError("simulated bitcoind/CP-core hiccup")
+    assert config.BTC_SRC20_GENESIS_BLOCK == orig
+
+
+def test_toggle_is_nesting_safe():
+    orig = config.BTC_SRC20_GENESIS_BLOCK
+    with _force_post_genesis_filter():
+        with _force_post_genesis_filter():
+            assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
+        # inner exit restores to the value captured at inner enter (still toggled)
+        assert config.BTC_SRC20_GENESIS_BLOCK == config.CP_STAMP_GENESIS_BLOCK
+    assert config.BTC_SRC20_GENESIS_BLOCK == orig


### PR DESCRIPTION
## Summary

Closes #774. `validator.compute_block_hashes` temporarily set `config.BTC_SRC20_GENESIS_BLOCK = CP_STAMP_GENESIS_BLOCK` inline — which reads as "relocating the SRC-20 genesis" when it's really a **filter-mode toggle**: it forces `filter_block_transactions` (`block_validation.py:166`) onto its post-genesis branch so every tx is decoded via the Rust parser, giving uniform in-memory reparse with no pre-genesis special-casing.

## Changes

- **Extract** the mutation into a named `_force_post_genesis_filter()` context manager, with a docstring that documents the repurposing, the restore-in-`finally` leak guard, the CP-era empirical invariant (and that the Tier-3 reparse of CP-era curated blocks guards it at integration level), and that the whole toggle disappears once the Rust parser does CP/stamp pre-detection (#754).
- **Replace** the inline `try/finally` at the call site with `with _force_post_genesis_filter():`.
- **Test** (`tests/test_force_post_genesis_filter.py`): threshold equals `CP_STAMP_GENESIS_BLOCK` inside the context, and the original value is restored on normal exit, **on exception**, and when nested — the "can't leak the mutated threshold into later blocks" guarantee #774 is about.

## Scope note

This is a **pure refactor — no change to computed hashes**. On the deeper synthetic-tx invariant test the issue sketches: under the toggle a valid SRC-20 payload at, say, block 790k *would* parse (the threshold is lowered), so the "assert output stays empty" premise needs the downstream SRC-20 height-gating verified first. Rather than ship a possibly-wrong test, the CP-era invariant is documented as guarded by the existing Tier-3 reparse (a leak → consensus-hash mismatch → CI fail). Happy to add the synthetic-tx unit test as a follow-up once the gating is confirmed.

## Validation

Reparse suite 37 passed; block 784549 (CP-era) still validates `True`; black/isort/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)