### PR TITLE
feat(#754): detect Counterparty (CNTRPRTY) transactions in the Rust parser

### DIFF
--- a/indexer/src/rust_parser/src/constants.rs
+++ b/indexer/src/rust_parser/src/constants.rs
@@ -4,6 +4,11 @@ use std::collections::HashSet;
 // Define the PREFIX constant to match the Python implementation
 pub const PREFIX: &[u8] = b"stamp:";
 
+// Counterparty message prefix (CNTRPRTY). Used by the over-approximating
+// Counterparty-transaction detector (issue #754) to flag txs that carry
+// Counterparty data via any of CP's on-chain encodings.
+pub const CNTRPRTY: &[u8] = b"CNTRPRTY";
+
 // Define the BURNKEYS list to match the Python implementation
 lazy_static! {
     pub static ref BURNKEYS: HashSet<&'static str> = {

--- a/indexer/src/rust_parser/src/lib.rs
+++ b/indexer/src/rust_parser/src/lib.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
 
 use crate::arc4::{arc4_decrypt_chunk, init_arc4};
-use crate::constants::{BURNKEYS, PREFIX};
+use crate::constants::{BURNKEYS, CNTRPRTY, PREFIX};
 
 // Add a simple LRU cache implementation
 struct LruCache<K, V> {
@@ -786,6 +786,11 @@ pub struct TransactionInfo {
     pub keyburn: u32,
     #[pyo3(get)]
     pub should_include: bool,
+    // Over-approximating signal (issue #754): true if this tx carries Counterparty
+    // (CNTRPRTY) data via any of CP's on-chain encodings. Additive / consensus-neutral:
+    // it does NOT affect should_include or any existing field.
+    #[pyo3(get)]
+    pub has_counterparty_data: bool,
 }
 
 #[pyclass]
@@ -938,6 +943,10 @@ impl TransactionInfo {
         // 2. A valid OP_CHECKMULTISIG with keyburn and valid data
         let should_include = (keyburn == 1 || has_valid_pattern) && has_valid_data;
 
+        // Over-approximating Counterparty (CNTRPRTY) detection (issue #754).
+        // Additive only: independent of should_include and all existing fields.
+        let has_counterparty_data = tx_has_counterparty_data(tx);
+
         TransactionInfo {
             version: tx.version.0,
             txid: txid.to_string(),
@@ -947,8 +956,127 @@ impl TransactionInfo {
             has_valid_data,
             keyburn,
             should_include,
+            has_counterparty_data,
         }
     }
+}
+
+/// ARC4/RC4 helper: encrypt/decrypt `data` under `key` (RC4 is symmetric).
+fn arc4_apply(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut cipher = init_arc4(key);
+    arc4_decrypt_chunk(data, &mut cipher)
+}
+
+/// Over-approximating detector for Counterparty (CNTRPRTY) transactions (issue #754).
+///
+/// Replicates the authoritative detection rules from `counterparty-rs`
+/// (`indexer/src/indexer/bitcoin_client.rs` `parse_vout`). It is a strict
+/// OVER-approximation: it may over-report, but must NEVER miss a real CP tx
+/// (a false negative would cause permanent consensus divergence in #756, which
+/// consumes this signal to skip the CP API for CP-free blocks).
+///
+/// RC4 key = the first input's prevout txid bytes in DISPLAY/big-endian order
+/// (same key derivation the stamp multisig path uses). Coinbase / empty-input
+/// txs have no key and are skipped (RC4 panics on an empty key). All checks run
+/// at EVERY height (CP's height gates are dropped — running every check early
+/// only adds false positives, which are safe, never false negatives).
+///
+/// P2SH / segwit / P2WSH need no scan here: CP surfaces witness/taproot CP txs
+/// via the OP_RETURN `CNTRPRTY` marker (covered by check 1).
+fn tx_has_counterparty_data(tx: &Transaction) -> bool {
+    use bitcoin::blockdata::opcodes::all::{OP_CHECKMULTISIG, OP_CHECKSIG};
+    use bitcoin::blockdata::script::Instruction;
+
+    // Skip coinbase / empty-input txs: no first-input prevout txid -> no RC4 key.
+    if tx.is_coinbase() || tx.input.is_empty() {
+        return false;
+    }
+
+    // RC4 key = first input's prevout txid bytes in display/big-endian order.
+    // `txid.to_string()` yields display (reversed) order, matching the stamp path.
+    let key = match tx.input.first() {
+        Some(input) => hex::decode(input.previous_output.txid.to_string()).unwrap_or_default(),
+        None => return false,
+    };
+    // init_arc4 / Rc4::new panics on an empty key (modulo by zero), so guard.
+    if key.is_empty() {
+        return false;
+    }
+
+    for output in &tx.output {
+        let script = &output.script_pubkey;
+
+        // If the script does not decode cleanly, skip this output (don't panic).
+        let instructions = match script.instructions().collect::<Result<Vec<_>, _>>() {
+            Ok(ins) => ins,
+            Err(_) => continue,
+        };
+
+        // 1. OP_RETURN: plaintext `CNTRPRTY` marker (taproot/witness reveal) OR
+        //    arc4(key, pushdata) starts with the prefix at offset 0.
+        if script.is_op_return() {
+            if let [Instruction::Op(_), Instruction::PushBytes(pb)] = instructions.as_slice() {
+                let bytes = pb.as_bytes();
+                if bytes == CNTRPRTY {
+                    return true;
+                }
+                let dec = arc4_apply(&key, bytes);
+                if dec.len() >= CNTRPRTY.len() && dec[..CNTRPRTY.len()] == *CNTRPRTY {
+                    return true;
+                }
+            }
+            continue;
+        }
+
+        let last_opcode = instructions.last().and_then(|ins| ins.opcode());
+
+        // 2. OP_CHECKSIG / pubkeyhash: arc4(key, instructions[2]) has the prefix at
+        //    offset 1 (byte 0 is a length byte).
+        if last_opcode == Some(OP_CHECKSIG) {
+            if instructions.len() >= 3 {
+                if let Some(Instruction::PushBytes(pb)) = instructions.get(2) {
+                    let dec = arc4_apply(&key, pb.as_bytes());
+                    if dec.len() > CNTRPRTY.len() && dec[1..1 + CNTRPRTY.len()] == *CNTRPRTY {
+                        return true;
+                    }
+                }
+            }
+            continue;
+        }
+
+        // 3. OP_CHECKMULTISIG / bare multisig: take the pubkey pushes for ALL chunks
+        //    except the last; strip the first+last byte of each; concatenate;
+        //    arc4(key, concat) has the prefix at offset 1.
+        //
+        //    NOTE: distinct from the stamp keyburn path (BURNKEYS, first 2 pubkeys,
+        //    prefix at offset 2). The pubkey pushes sit between the leading `m`
+        //    marker and the trailing `n` marker + OP_CHECKMULTISIG, i.e.
+        //    instructions[1 .. len-2].
+        if last_opcode == Some(OP_CHECKMULTISIG) && instructions.len() >= 3 {
+            let pubkeys: Vec<&[u8]> = instructions[1..instructions.len() - 2]
+                .iter()
+                .filter_map(|ins| match ins {
+                    Instruction::PushBytes(b) => Some(b.as_bytes()),
+                    _ => None,
+                })
+                .collect();
+            if pubkeys.len() >= 2 {
+                let mut enc = Vec::new();
+                for pk in pubkeys.iter().take(pubkeys.len() - 1) {
+                    if pk.len() >= 2 {
+                        enc.extend_from_slice(&pk[1..pk.len() - 1]);
+                    }
+                }
+                let dec = arc4_apply(&key, &enc);
+                if dec.len() > CNTRPRTY.len() && dec[1..1 + CNTRPRTY.len()] == *CNTRPRTY {
+                    return true;
+                }
+            }
+            continue;
+        }
+    }
+
+    false
 }
 
 impl InputInfo {

--- a/indexer/tests/fixtures/parser_snapshots/parser_snapshots.json
+++ b/indexer/tests/fixtures/parser_snapshots/parser_snapshots.json
@@ -7,6 +7,7 @@
     {
       "block_height": 789352,
       "expected": {
+        "has_counterparty_data": true,
         "has_valid_data": false,
         "has_valid_pattern": false,
         "inputs": [
@@ -80,6 +81,7 @@
     {
       "block_height": 797973,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -143,6 +145,7 @@
     {
       "block_height": 831460,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -206,6 +209,7 @@
     {
       "block_height": 845869,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -259,6 +263,7 @@
     {
       "block_height": 790383,
       "expected": {
+        "has_counterparty_data": true,
         "has_valid_data": false,
         "has_valid_pattern": false,
         "inputs": [
@@ -322,6 +327,7 @@
     {
       "block_height": 877807,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": true,
         "inputs": [
@@ -395,6 +401,7 @@
     {
       "block_height": null,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -468,6 +475,7 @@
     {
       "block_height": 792483,
       "expected": {
+        "has_counterparty_data": true,
         "has_valid_data": false,
         "has_valid_pattern": false,
         "inputs": [
@@ -541,6 +549,7 @@
     {
       "block_height": 873710,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": true,
         "inputs": [
@@ -614,6 +623,7 @@
     {
       "block_height": 853693,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -667,6 +677,7 @@
     {
       "block_height": 790606,
       "expected": {
+        "has_counterparty_data": true,
         "has_valid_data": false,
         "has_valid_pattern": false,
         "inputs": [
@@ -730,6 +741,7 @@
     {
       "block_height": 855228,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -773,6 +785,7 @@
     {
       "block_height": 824110,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -826,6 +839,7 @@
     {
       "block_height": 790918,
       "expected": {
+        "has_counterparty_data": true,
         "has_valid_data": false,
         "has_valid_pattern": false,
         "inputs": [
@@ -899,6 +913,7 @@
     {
       "block_height": 872140,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": true,
         "inputs": [
@@ -977,6 +992,7 @@
     {
       "block_height": 874824,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -1045,6 +1061,7 @@
     {
       "block_height": 827140,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -1098,6 +1115,7 @@
     {
       "block_height": 827629,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -1171,6 +1189,7 @@
     {
       "block_height": null,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [
@@ -1234,6 +1253,7 @@
     {
       "block_height": 824112,
       "expected": {
+        "has_counterparty_data": false,
         "has_valid_data": true,
         "has_valid_pattern": false,
         "inputs": [

--- a/indexer/tests/parser_snapshot_utils.py
+++ b/indexer/tests/parser_snapshot_utils.py
@@ -50,6 +50,7 @@ def serialize_transaction_info(info: Any) -> Dict[str, Any]:
         "has_valid_data": info.has_valid_data,
         "keyburn": info.keyburn,
         "should_include": info.should_include,
+        "has_counterparty_data": info.has_counterparty_data,
         "inputs": [
             {
                 "prev_txid": inp.prev_txid,

--- a/indexer/tests/test_counterparty_detection.py
+++ b/indexer/tests/test_counterparty_detection.py
@@ -1,0 +1,129 @@
+"""Unit tests for the over-approximating Counterparty (CNTRPRTY) detector (issue #754).
+
+The Rust parser exposes ``TransactionInfo.has_counterparty_data`` — a strict
+OVER-approximation of "does this tx carry Counterparty data?". It must NEVER
+miss a real CP tx (a false negative would cause permanent consensus divergence
+once #756 consumes this signal to skip the CP API for CP-free blocks).
+
+These tests assert:
+  * known CP-era multisig stamp txs (classic CNTRPRTY issuances) are flagged True,
+  * native ``stamp:`` keyburn / P2WSH-OLGA stamps (NOT CP txs) are flagged False,
+  * the plaintext OP_RETURN ``CNTRPRTY`` reveal marker is flagged True,
+  * a coinbase / no-key tx does NOT panic and is False,
+  * a mundane P2PKH-only tx is False.
+
+DB-free and network-free: only the built ``btc_stamps_parser`` extension and the
+committed transaction-cache fixtures are required.
+"""
+
+import json
+import os
+
+import pytest
+
+FastTransactionParser = pytest.importorskip("btc_stamps_parser").FastTransactionParser
+
+_TRANSACTION_CACHE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "transaction_cache")
+
+# Classic CP-era stamps: the stamp image is a Counterparty asset issuance, so the
+# tx genuinely embeds a CNTRPRTY message (decrypts to "CNTRPRTY" at offset 1 of
+# the bare-multisig payload). These MUST be detected.
+CNTRPRTY_TXIDS = [
+    "0321905ca9053a5b8313be9524a2af146196982a479573e9a324e8b929231730",  # 789352
+    "2cc3be498d12247c47fc99b60d97c6db7b2f1dfdcaefc3fee3a36729fade6b19",  # 790383
+    "3809059d32b51e3c2e680c6ffbd8e15e152daa06554f62fc1b9f2aea3be39e32",  # 792483
+    "56bba57e6405e553cfff1b78ab8f7f0f0f419c5056c06b72a81e0e5deae48d15",  # 790606
+    "72f9bfb6c6553feabdb7b52428a33172090553fd9441209fb99d4b13455ca71d",  # 790918
+]
+
+# Native stamps that do NOT use Counterparty: keyburn-multisig and P2WSH-OLGA
+# stamps whose payload decrypts to "stamp:" (not "CNTRPRTY"). These are parsed
+# directly from Bitcoin (never via the CP API), so they must NOT be flagged.
+NON_CNTRPRTY_TXIDS = [
+    "049d1544e94c14deece7a468855ca9bff7c867476b3f4cba8c075000ed93babe",  # 797973 keyburn SRC-20
+    "4d89d7f69ee77c3ddda041f94270b4112d002fc67b88008f29710fadfb486da8",  # 853693 keyburn
+    "306cf746bbcc063825c95e5cdd47464ede62d4aa6e3d6629e80cd8affb7e71bf",  # 877807 P2WSH OLGA
+]
+
+
+def _load_tx_hex(txid: str) -> str:
+    path = os.path.join(_TRANSACTION_CACHE_DIR, f"{txid}.json")
+    with open(path) as fh:
+        data = json.load(fh)
+    tx_hex = data.get("hex")
+    assert tx_hex, f"fixture {txid} has no hex"
+    return tx_hex
+
+
+@pytest.mark.parametrize("txid", CNTRPRTY_TXIDS)
+def test_cp_era_stamps_are_detected(txid):
+    """Classic CP-era multisig stamps are genuine CNTRPRTY txs -> True."""
+    parser = FastTransactionParser()
+    info = parser.deserialize_transaction(_load_tx_hex(txid))
+    assert info.has_counterparty_data is True
+
+
+@pytest.mark.parametrize("txid", NON_CNTRPRTY_TXIDS)
+def test_native_stamps_are_not_flagged(txid):
+    """Native stamp:/OLGA stamps are not Counterparty txs -> False (no false positive)."""
+    parser = FastTransactionParser()
+    info = parser.deserialize_transaction(_load_tx_hex(txid))
+    assert info.has_counterparty_data is False
+
+
+def test_op_return_plaintext_marker_is_detected():
+    """A tx with a plaintext OP_RETURN ``CNTRPRTY`` reveal marker is flagged True.
+
+    Crafted tx: 1 normal input (non-coinbase, so a key is derived) + a single
+    ``OP_RETURN <push8 "CNTRPRTY">`` output. The plaintext check matches
+    regardless of the RC4 key.
+    """
+    tx_hex = (
+        "01000000"  # version
+        "01" + "11" * 32 + "00000000"  # 1 input  # prevout txid (non-null)  # prevout vout
+        "00"  # empty scriptSig
+        "ffffffff"  # sequence
+        "01"  # 1 output
+        "0000000000000000"  # value 0
+        "0a"  # scriptPubKey length (10)
+        "6a08434e545250525459"  # OP_RETURN PUSH8 "CNTRPRTY"
+        "00000000"  # locktime
+    )
+    parser = FastTransactionParser()
+    info = parser.deserialize_transaction(tx_hex)
+    assert info.has_counterparty_data is True
+
+
+def test_coinbase_does_not_panic_and_is_false():
+    """A coinbase tx has no first-input prevout key (RC4 would panic) -> skipped, False."""
+    tx_hex = (
+        "01000000"  # version
+        "01" + "00" * 32 + "ffffffff"  # 1 input  # null prevout txid (coinbase)  # prevout vout 0xffffffff (coinbase)
+        "0100"  # scriptSig: len 1, byte 0x00
+        "ffffffff"  # sequence
+        "01"  # 1 output
+        "0000000000000000"  # value 0
+        "00"  # empty scriptPubKey
+        "00000000"  # locktime
+    )
+    parser = FastTransactionParser()
+    info = parser.deserialize_transaction(tx_hex)
+    assert info.has_counterparty_data is False
+
+
+def test_plain_p2pkh_tx_is_not_flagged():
+    """A mundane P2PKH-only tx (exercises the OP_CHECKSIG path) is not CP -> False."""
+    tx_hex = (
+        "01000000"  # version
+        "01" + "22" * 32 + "00000000"  # 1 input  # prevout txid  # prevout vout
+        "00"  # empty scriptSig
+        "ffffffff"  # sequence
+        "01"  # 1 output
+        "8038010000000000"  # value
+        "19"  # scriptPubKey length (25)
+        "76a914" + "33" * 20 + "88ac"  # OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+        "00000000"  # locktime
+    )
+    parser = FastTransactionParser()
+    info = parser.deserialize_transaction(tx_hex)
+    assert info.has_counterparty_data is False


### PR DESCRIPTION
## What & why

**DETECTION ONLY** for issue #754. Adds an over-approximating per-tx signal — `TransactionInfo.has_counterparty_data: bool` (with a `#[pyo3(get)]` getter) — to the Rust parser that answers "does this transaction carry Counterparty (`CNTRPRTY`) data?".

This is **additive and consensus-neutral**: no existing field value changes and `should_include` is untouched. Nothing consumes the signal yet — this is the prerequisite for **#756 item 3**, which will use it to skip the per-block Counterparty API fetch for blocks with no `CNTRPRTY` transactions.

## Over-approximation guarantee

The detector replicates the authoritative detection rules from `counterparty-rs` (`parse_vout`). It is a strict **over-approximation**: it may over-report, but it must **never** miss a real CP tx — a single historical false negative would cause permanent consensus divergence once #756 skips the API. Accordingly, all checks run at **every height** (CP's height gates are intentionally dropped; running every check early only adds safe false positives, never false negatives).

RC4 key = the **first input's prevout txid bytes in display/big-endian order** (the same derivation the existing stamp multisig path uses). Coinbase / empty-input txs are skipped (no key → RC4 panics on an empty key).

## The three encodings

A tx carries `CNTRPRTY` data if **any** output matches:

1. **OP_RETURN** — the pushdata equals plaintext `CNTRPRTY` (taproot/witness reveal marker), **or** `arc4(key, pushdata)` starts with the prefix at offset 0.
2. **OP_CHECKSIG / pubkeyhash** — `arc4(key, instructions[2])` has the prefix at offset 1 (byte 0 is a length byte).
3. **OP_CHECKMULTISIG / bare multisig** — collect the pubkey pushes for all chunks **except the last**, strip first+last byte of each, concatenate, `arc4`, prefix at offset 1. (Distinct from the existing stamp keyburn path, which uses BURNKEYS + first two pubkeys + prefix at offset 2 — kept separate.)

**P2SH / segwit / P2WSH need no scan here:** CP surfaces witness/taproot CP txs via the OP_RETURN `CNTRPRTY` marker (covered by check 1), and native SRC-20 P2WSH/OLGA is parsed directly from Bitcoin, never via the CP API.

## #765 snapshot refresh

Adds `const CNTRPRTY: &[u8] = b"CNTRPRTY"`, updates `serialize_transaction_info()` to emit the new field, and regenerates the `#765` parser snapshot baseline. The diff is purely additive (one line per snapshot, no existing value changed). **5 classic CP-era multisig stamp fixtures** (blocks 789352–792483) correctly flip to `has_counterparty_data: true` — verified to decrypt to `CNTRPRTY` — while native `stamp:` keyburn/OLGA stamps remain `false` (they decrypt to `stamp:`, not `CNTRPRTY`).

## Tests & validation

- New `tests/test_counterparty_detection.py`: known CP-era stamps → `True`; native stamps → `False`; OP_RETURN plaintext marker → `True`; coinbase (no key) does not panic and is `False`; P2PKH-only tx → `False`.
- `tests/test_parser_snapshots.py` passes against the refreshed baseline.
- Full lint + suite green: `black`, `isort`, `flake8`, `mypy`, `bandit`, `check-rust` (rustfmt + clippy + cargo tests), and `1859 passed, 26 skipped` in the unit suite. Rust builds clean in release.

#756 will consume `has_counterparty_data` to skip the CP API, validated later by a differential reindex (skip ON vs OFF must be byte-identical).

Refs #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
