### PR TITLE
perf(#756): skip CP API fetch for blocks with no Counterparty txs (flag, default off)

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -67,6 +67,19 @@ try:
 except ValueError:
     CP_VERBOSE_PAGINATION_LIMIT = 100
 
+# Issue #756 (item 3): skip the Counterparty API fetch for Bitcoin blocks that
+# carry NO Counterparty data at all. The predicate is the over-approximating
+# `TransactionInfo.has_counterparty_data` signal added in #754 — it is SOUND
+# (a strict over-approximation: it never reports "no CP data" when CP data is
+# present), so skipping a block it marks CP-free can never drop a real CP
+# issuance and therefore can never perturb MAX(stamp)+1 numbering.
+#
+# This is consensus-affecting, so it ships **default OFF** (behavior-neutral on
+# merge). It is enabled explicitly for the validating differential reindex —
+# run once ON, once OFF, and require byte-identical hashes at every checkpoint
+# (== prod) before the default is flipped on in a follow-up.
+CP_SKIP_NO_COUNTERPARTY_BLOCKS = os.environ.get("CP_SKIP_NO_COUNTERPARTY_BLOCKS", "false").lower() == "true"
+
 # Production-optimized batch sizes for database operations
 # Larger batches reduce network round-trips to RDS - optimized defaults for production
 DB_TRANSACTION_BATCH_SIZE = int(os.environ.get("DB_TRANSACTION_BATCH_SIZE", "15000"))  # Optimized for RDS

--- a/indexer/src/index_core/block_validation.py
+++ b/indexer/src/index_core/block_validation.py
@@ -14,7 +14,7 @@ import logging
 import os
 import subprocess
 import sys
-from typing import List
+from typing import Any, Dict, List, Tuple
 
 import config
 import index_core.check as check
@@ -250,3 +250,135 @@ def filter_block_transactions(block_data, stamp_issuances=None):
 
     logger.debug(f"Final transaction count: {len(raw_transactions)} filtered, {len(tx_hash_list)} total for hash")
     return tx_hash_list, raw_transactions
+
+
+# ---------------------------------------------------------------------------
+# Issue #756 item 3 — skip the CP API fetch for blocks with no Counterparty data
+# ---------------------------------------------------------------------------
+#
+# Consumes #754's over-approximating ``TransactionInfo.has_counterparty_data``.
+# That signal is SOUND for skipping: it is a strict over-approximation that
+# never yields a false negative, so a block it reports as CP-free genuinely
+# carries no Counterparty data and the CP API call can be elided without ever
+# dropping an issuance (which would corrupt MAX(stamp)+1 numbering).
+#
+# Gated by ``config.CP_SKIP_NO_COUNTERPARTY_BLOCKS`` (default False); when the
+# flag is off everything below is a thin pass-through and behavior is byte-
+# identical to a normal fetch.
+
+
+def _empty_cp_block_data(block_index: int) -> Dict[str, Any]:
+    """Return the exact ``block_data`` shape a real CP fetch yields for a block
+    with zero Counterparty transactions.
+
+    Verified against ``fetch_utils`` — a CP-free block flows through
+    ``_fetch_block_transactions_verbose_safe_pagination`` with an empty
+    ``all_transactions`` list, producing::
+
+        {"block_index": n, "xcp_block_hash": None, "transactions": [], "issuances": []}
+
+    (``xcp_block_hash`` is taken from ``all_transactions[0]`` which is absent, so
+    it is ``None``.) Downstream consumers (blocks.py xcp_hash resolution,
+    filter_block_transactions) read exactly these keys, so the substitute is
+    behavior-identical to a real empty fetch.
+    """
+    return {"block_index": block_index, "xcp_block_hash": None, "transactions": [], "issuances": []}
+
+
+def txs_have_counterparty_data(raw_parser: Any, tx_hexes: List[str]) -> bool:
+    """Return True if ANY transaction hex carries Counterparty data.
+
+    Pure helper over the raw Rust ``FastTransactionParser`` (the inner parser,
+    NOT the ``Parser`` wrapper whose ``deserialize_transaction`` converts to a
+    ``CTransaction`` and drops the ``has_counterparty_data`` field). Short-
+    circuits on the first CP-bearing tx.
+
+    Fail-safe: if the parser predates #754 and a parsed tx lacks the
+    ``has_counterparty_data`` attribute, we cannot soundly skip, so we report
+    True (treat the block as CP-bearing -> fetch as normal).
+    """
+    for tx_hex in tx_hexes:
+        info = raw_parser.deserialize_transaction(tx_hex)
+        if not hasattr(info, "has_counterparty_data"):
+            return True
+        if info.has_counterparty_data:
+            return True
+    return False
+
+
+def block_has_counterparty_data(block_index: int) -> bool:
+    """Over-approximating predicate: does Bitcoin block ``block_index`` contain
+    any Counterparty transaction?
+
+    Sound for the #756 skip (never a false negative). Parses every transaction
+    in the block via the Rust parser's ``has_counterparty_data`` (issue #754).
+    The raw block is fetched from bitcoind here; the same block is fetched again
+    at processing time — an acceptable, cheap local RPC cost on this perf-gated
+    path.
+
+    Fail-safe: on ANY error or when the parser is unavailable, returns True so
+    the caller fetches from the CP API as normal (never skips on uncertainty).
+    """
+    parser_wrapper = getattr(backend_instance, "_parser", None)
+    raw_parser = getattr(parser_wrapper, "_parser", None)
+    if raw_parser is None:
+        return True
+    try:
+        block_hash = backend_instance.getblockhash(block_index)
+        block_hex = backend_instance.rpc("getblock", [block_hash, 0])
+        _tx_hash_list, raw_transactions, *_ = raw_parser.parse_block(block_hex)
+        return txs_have_counterparty_data(raw_parser, list(raw_transactions.values()))
+    except Exception as e:
+        logger.warning(
+            f"CP-skip predicate failed for block {block_index} ({e}); "
+            f"treating as CP-bearing and fetching from CP API to stay safe"
+        )
+        return True
+
+
+def _contiguous_runs(indices: List[int]) -> List[Tuple[int, int]]:
+    """Group a list of block indices into contiguous (start, end) inclusive runs."""
+    runs: List[List[int]] = []
+    for idx in sorted(indices):
+        if runs and idx == runs[-1][1] + 1:
+            runs[-1][1] = idx
+        else:
+            runs.append([idx, idx])
+    return [(a, b) for a, b in runs]
+
+
+def fetch_cp_blocks_skipping_empty(
+    start_block: int, end_block: int, progress_indicator: bool = False
+) -> Dict[int, Dict[str, Any]]:
+    """Fetch CP block data for ``[start_block, end_block]``, eliding the CP API
+    call for blocks that carry no Counterparty data (issue #756 item 3).
+
+    When ``config.CP_SKIP_NO_COUNTERPARTY_BLOCKS`` is False (default), this is a
+    direct pass-through to ``fetch_xcp_blocks_concurrent`` — byte-identical to
+    the prior behavior. When True, each block in the range is classified via
+    ``block_has_counterparty_data`` (the sound #754 predicate); CP-free blocks
+    get the exact empty-fetch shape substituted (no API call), and the CP-
+    bearing blocks are fetched in contiguous runs to preserve the concurrent
+    range-fetch contract and ordering.
+    """
+    # Lazy import to avoid a module-load import cycle (fetch_utils -> ... -> here).
+    from index_core.fetch_utils import fetch_xcp_blocks_concurrent
+
+    if not getattr(config, "CP_SKIP_NO_COUNTERPARTY_BLOCKS", False):
+        return fetch_xcp_blocks_concurrent(start_block, end_block, progress_indicator=progress_indicator)
+
+    cp_bearing: List[int] = []
+    results: Dict[int, Dict[str, Any]] = {}
+    for idx in range(start_block, end_block + 1):
+        if block_has_counterparty_data(idx):
+            cp_bearing.append(idx)
+        else:
+            logger.info(f"Block {idx}: no Counterparty data (issue #756) — skipping CP API fetch")
+            results[idx] = _empty_cp_block_data(idx)
+
+    for run_start, run_end in _contiguous_runs(cp_bearing):
+        fetched = fetch_xcp_blocks_concurrent(run_start, run_end, progress_indicator=progress_indicator)
+        if fetched:
+            results.update(fetched)
+
+    return results

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -30,6 +30,7 @@ import index_core.util as util
 from index_core.backend import Backend
 from index_core.block_validation import (
     create_check_hashes,
+    fetch_cp_blocks_skipping_empty,
     filter_block_transactions,
     validate_block_against_production,
 )
@@ -62,7 +63,6 @@ from index_core.exceptions import (
     LedgerMismatchError,
 )
 from index_core.fetch_utils import (
-    fetch_xcp_blocks_concurrent,
     get_xcp_assets_by_cpids,
     get_xcp_block_hash,
     is_valid_counterparty_asset,
@@ -1403,7 +1403,11 @@ def follow(
                                 if shutdown_requested[0] or is_shutdown_requested() or server.shutdown_flag.is_set():
                                     break
 
-                                stamp_issuances_list = fetch_xcp_blocks_concurrent(
+                                # Issue #756 item 3: when CP_SKIP_NO_COUNTERPARTY_BLOCKS is on, this
+                                # elides the CP API call for blocks the #754 predicate marks CP-free
+                                # (substituting the empty-fetch shape). Default off -> identical to
+                                # fetch_xcp_blocks_concurrent.
+                                stamp_issuances_list = fetch_cp_blocks_skipping_empty(
                                     block_index, end_block, progress_indicator=(block_index + 1 == block_tip)
                                 )
 

--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -11,7 +11,8 @@ import time
 
 import config
 from index_core.backend import Backend
-from index_core.fetch_utils import fetch_xcp_blocks_concurrent, wait_for_cp_block_processed
+from index_core.block_validation import fetch_cp_blocks_skipping_empty
+from index_core.fetch_utils import wait_for_cp_block_processed
 from index_core.node_health import get_healthy_nodes, is_shutdown_requested, update_healthy_nodes
 from index_core.reprocess_safety import (
     ReprocessSafetyError,
@@ -1422,9 +1423,12 @@ class CPBlocksPipeline:
                     except Exception as e:
                         logger.warning(f"Failed to update healthy nodes on retry: {e}")
 
-                # Use fetch_xcp_blocks_concurrent from fetch_utils
-                # This handles pagination, block formatting and concurrent fetching
-                blocks_data = fetch_xcp_blocks_concurrent(start_block, end_block)
+                # Use fetch_xcp_blocks_concurrent from fetch_utils (via the #756
+                # skip wrapper). This handles pagination, block formatting and
+                # concurrent fetching. When CP_SKIP_NO_COUNTERPARTY_BLOCKS is on,
+                # the wrapper elides the CP API call for blocks the #754 predicate
+                # marks CP-free; default off -> identical pass-through.
+                blocks_data = fetch_cp_blocks_skipping_empty(start_block, end_block)
 
                 if start_block <= 781141 <= end_block:
                     if 781141 in blocks_data:

--- a/indexer/src/index_core/reparse/validator.py
+++ b/indexer/src/index_core/reparse/validator.py
@@ -33,8 +33,8 @@ from index_core.block_validation import (
 from index_core.blocks import (
     BlockProcessor,
     backend_instance,
-    fetch_xcp_blocks_concurrent,
 )
+from index_core.fetch_utils import fetch_xcp_blocks_concurrent
 from index_core.transaction_utils import process_tx
 
 # Load .env from project root, falling back to .env.sample

--- a/indexer/tests/test_cp_readiness_checks.py
+++ b/indexer/tests/test_cp_readiness_checks.py
@@ -199,7 +199,7 @@ class TestBlockProcessingCPChecks:
             mock_pipeline_class.return_value = mock_pipeline
 
             # Mock fetch_xcp_blocks_concurrent to return data
-            with patch("src.index_core.blocks.fetch_xcp_blocks_concurrent") as mock_fetch:
+            with patch("src.index_core.blocks.fetch_cp_blocks_skipping_empty") as mock_fetch:
                 mock_fetch.return_value = {849990: {"issuances": []}}
 
                 # Simulate processing a block that's 10 blocks behind tip

--- a/indexer/tests/test_cp_readiness_integration.py
+++ b/indexer/tests/test_cp_readiness_integration.py
@@ -27,7 +27,7 @@ class TestCPReadinessIntegration:
         # Mock dependencies
         with patch("src.index_core.blocks.backend_instance") as mock_backend:
             with patch("src.index_core.blocks.CPBlocksPipeline") as mock_pipeline_class:
-                with patch("src.index_core.blocks.fetch_xcp_blocks_concurrent") as mock_fetch:
+                with patch("src.index_core.blocks.fetch_cp_blocks_skipping_empty") as mock_fetch:
                     with patch("src.index_core.fetch_utils.wait_for_cp_block_processed") as mock_wait_cp:
                         # Setup mocks
                         mock_backend.getblockcount.return_value = block_tip

--- a/indexer/tests/test_cp_skip_no_counterparty.py
+++ b/indexer/tests/test_cp_skip_no_counterparty.py
@@ -1,0 +1,203 @@
+"""Unit tests for issue #756 item 3 — skip the Counterparty (CP) API fetch for
+blocks that carry NO Counterparty data.
+
+The skip is gated by ``config.CP_SKIP_NO_COUNTERPARTY_BLOCKS`` (default False) and
+consumes #754's over-approximating ``TransactionInfo.has_counterparty_data``
+signal via ``block_validation.block_has_counterparty_data``. These tests assert:
+
+  * Flag OFF (default) -> the CP fetch is ALWAYS called (behavior preserved).
+  * Flag ON + a block whose parsed txs are all CP-free -> the CP fetch is NOT
+    called and the substituted ``block_data`` equals the empty-fetch shape.
+  * Flag ON + a block with >= 1 CP-bearing tx -> the CP fetch IS called.
+  * The predicate's detection truth is wired correctly to the real Rust parser
+    (``any`` over real CP-era / native stamp fixtures).
+
+DB-free and network-free: bitcoind RPC and the CP fetch are mocked; the
+detection truth test uses the built ``btc_stamps_parser`` extension and the
+committed transaction-cache fixtures.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+import config
+from index_core import block_validation
+
+FastTransactionParser = pytest.importorskip("btc_stamps_parser").FastTransactionParser
+
+_TRANSACTION_CACHE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "transaction_cache")
+
+# Classic CP-era multisig stamp (a genuine CNTRPRTY issuance) -> has CP data.
+_CP_TXID = "0321905ca9053a5b8313be9524a2af146196982a479573e9a324e8b929231730"  # block 789352
+# Native keyburn SRC-20 stamp (parsed from Bitcoin, never via the CP API) -> no CP data.
+_NATIVE_TXID = "049d1544e94c14deece7a468855ca9bff7c867476b3f4cba8c075000ed93babe"  # block 797973
+
+
+def _load_tx_hex(txid: str) -> str:
+    with open(os.path.join(_TRANSACTION_CACHE_DIR, f"{txid}.json")) as fh:
+        data = json.load(fh)
+    tx_hex = data.get("hex")
+    assert tx_hex, f"fixture {txid} has no hex"
+    return tx_hex
+
+
+@pytest.fixture
+def patch_fetch(monkeypatch):
+    """Patch ``fetch_xcp_blocks_concurrent`` (imported lazily inside the wrapper)
+    so we can assert whether / how the real CP fetch is invoked."""
+    fetch = MagicMock(
+        side_effect=lambda start, end, progress_indicator=False: {
+            idx: {"block_index": idx, "xcp_block_hash": "deadbeef", "transactions": [{"tx_hash": "a"}], "issuances": []}
+            for idx in range(start, end + 1)
+        }
+    )
+    monkeypatch.setattr("index_core.fetch_utils.fetch_xcp_blocks_concurrent", fetch)
+    return fetch
+
+
+# ---------------------------------------------------------------------------
+# Wrapper: fetch_cp_blocks_skipping_empty
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_always_fetches(monkeypatch, patch_fetch):
+    """Flag OFF (default) -> pass-through; CP fetch always called, predicate never consulted."""
+    monkeypatch.setattr(config, "CP_SKIP_NO_COUNTERPARTY_BLOCKS", False)
+    # Predicate must NOT be consulted when the flag is off.
+    monkeypatch.setattr(
+        block_validation,
+        "block_has_counterparty_data",
+        MagicMock(side_effect=AssertionError("predicate must not run when flag is off")),
+    )
+
+    result = block_validation.fetch_cp_blocks_skipping_empty(100, 102)
+
+    patch_fetch.assert_called_once_with(100, 102, progress_indicator=False)
+    assert set(result.keys()) == {100, 101, 102}
+
+
+def test_flag_on_all_cp_free_skips_fetch(monkeypatch, patch_fetch):
+    """Flag ON + every block CP-free -> CP fetch NOT called; empty-fetch shape substituted."""
+    monkeypatch.setattr(config, "CP_SKIP_NO_COUNTERPARTY_BLOCKS", True)
+    monkeypatch.setattr(block_validation, "block_has_counterparty_data", MagicMock(return_value=False))
+
+    result = block_validation.fetch_cp_blocks_skipping_empty(100, 102)
+
+    patch_fetch.assert_not_called()
+    assert result == {
+        100: {"block_index": 100, "xcp_block_hash": None, "transactions": [], "issuances": []},
+        101: {"block_index": 101, "xcp_block_hash": None, "transactions": [], "issuances": []},
+        102: {"block_index": 102, "xcp_block_hash": None, "transactions": [], "issuances": []},
+    }
+
+
+def test_flag_on_cp_bearing_block_is_fetched(monkeypatch, patch_fetch):
+    """Flag ON + one CP-bearing block -> only that block hits the CP API; the rest are empty."""
+    monkeypatch.setattr(config, "CP_SKIP_NO_COUNTERPARTY_BLOCKS", True)
+    # Only block 101 carries Counterparty data.
+    monkeypatch.setattr(
+        block_validation,
+        "block_has_counterparty_data",
+        MagicMock(side_effect=lambda idx: idx == 101),
+    )
+
+    result = block_validation.fetch_cp_blocks_skipping_empty(100, 102)
+
+    # The CP API is called exactly once, for the contiguous run covering block 101.
+    patch_fetch.assert_called_once_with(101, 101, progress_indicator=False)
+    assert result[100] == {"block_index": 100, "xcp_block_hash": None, "transactions": [], "issuances": []}
+    assert result[102] == {"block_index": 102, "xcp_block_hash": None, "transactions": [], "issuances": []}
+    # Block 101 is the real fetched payload, not the empty shape.
+    assert result[101]["transactions"] == [{"tx_hash": "a"}]
+
+
+def test_flag_on_all_cp_bearing_fetches_full_range(monkeypatch, patch_fetch):
+    """Flag ON + every block CP-bearing -> single fetch over the whole range (no skips)."""
+    monkeypatch.setattr(config, "CP_SKIP_NO_COUNTERPARTY_BLOCKS", True)
+    monkeypatch.setattr(block_validation, "block_has_counterparty_data", MagicMock(return_value=True))
+
+    result = block_validation.fetch_cp_blocks_skipping_empty(100, 102)
+
+    patch_fetch.assert_called_once_with(100, 102, progress_indicator=False)
+    assert set(result.keys()) == {100, 101, 102}
+
+
+# ---------------------------------------------------------------------------
+# Predicate plumbing: block_has_counterparty_data
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_plumbs_through_to_parser(monkeypatch):
+    """block_has_counterparty_data fetches the raw block, parses ALL txs, and
+    returns any(has_counterparty_data) — exercised with a stub parser/backend."""
+
+    class _StubInfo:
+        def __init__(self, has_cp):
+            self.has_counterparty_data = has_cp
+
+    class _StubRawParser:
+        def __init__(self, flags):
+            # flags: ordered list of has_counterparty_data values per tx hex
+            self._flags = flags
+
+        def parse_block(self, block_hex):
+            raw = {f"tx{i}": f"hex{i}" for i in range(len(self._flags))}
+            return (list(raw.keys()), raw, 0, None, None)
+
+        def deserialize_transaction(self, tx_hex):
+            return _StubInfo(self._flags[int(tx_hex.replace("hex", ""))])
+
+    def make_backend(flags):
+        backend = MagicMock()
+        backend._parser._parser = _StubRawParser(flags)
+        backend.getblockhash.return_value = "hash"
+        backend.rpc.return_value = "blockhex"
+        return backend
+
+    # No CP-bearing tx -> False (block can be skipped).
+    monkeypatch.setattr(block_validation, "backend_instance", make_backend([False, False]))
+    assert block_validation.block_has_counterparty_data(500) is False
+
+    # At least one CP-bearing tx -> True.
+    monkeypatch.setattr(block_validation, "backend_instance", make_backend([False, True, False]))
+    assert block_validation.block_has_counterparty_data(500) is True
+
+
+def test_predicate_fail_safe_on_error(monkeypatch):
+    """Any error in the predicate path -> True (never skip on uncertainty)."""
+    backend = MagicMock()
+    backend._parser._parser.parse_block.side_effect = RuntimeError("bitcoind down")
+    backend.getblockhash.return_value = "hash"
+    backend.rpc.return_value = "blockhex"
+    monkeypatch.setattr(block_validation, "backend_instance", backend)
+    assert block_validation.block_has_counterparty_data(500) is True
+
+
+def test_predicate_no_parser_returns_true(monkeypatch):
+    """If the Rust parser is unavailable -> True (cannot soundly skip)."""
+    backend = MagicMock()
+    backend._parser = None
+    monkeypatch.setattr(block_validation, "backend_instance", backend)
+    assert block_validation.block_has_counterparty_data(500) is True
+
+
+# ---------------------------------------------------------------------------
+# Detection truth: txs_have_counterparty_data over real Rust parser + fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_detection_truth_with_real_parser():
+    """The aggregate predicate consumes #754's signal correctly: a CP-era stamp
+    is detected, a native stamp is not, and any() over a mix is True."""
+    parser = FastTransactionParser()
+    cp_hex = _load_tx_hex(_CP_TXID)
+    native_hex = _load_tx_hex(_NATIVE_TXID)
+
+    assert block_validation.txs_have_counterparty_data(parser, [cp_hex]) is True
+    assert block_validation.txs_have_counterparty_data(parser, [native_hex]) is False
+    assert block_validation.txs_have_counterparty_data(parser, [native_hex, cp_hex]) is True
+    # Empty / coinbase-only blocks -> no CP data.
+    assert block_validation.txs_have_counterparty_data(parser, []) is False

--- a/indexer/tests/test_pipeline_executor_lifecycle.py
+++ b/indexer/tests/test_pipeline_executor_lifecycle.py
@@ -51,7 +51,7 @@ class TestPipelineExecutorLifecycle(unittest.TestCase):
             patch("index_core.pipeline_utils.backend_instance"),
             patch("index_core.pipeline_utils.config.CP_STAMP_GENESIS_BLOCK", 100000),
             patch("index_core.pipeline_utils.update_healthy_nodes"),
-            patch("index_core.pipeline_utils.fetch_xcp_blocks_concurrent", return_value={}),
+            patch("index_core.pipeline_utils.fetch_cp_blocks_skipping_empty", return_value={}),
             patch("index_core.pipeline_utils.is_shutdown_requested", return_value=False),
             patch("index_core.node_health.get_healthy_nodes", return_value=[]),
             patch("index_core.node_health.update_healthy_nodes"),
@@ -72,7 +72,7 @@ class TestPipelineExecutorLifecycle(unittest.TestCase):
         ), patch("index_core.pipeline_utils.update_healthy_nodes"), patch(
             "index_core.pipeline_utils.get_healthy_nodes", return_value=[{"name": "test_node", "url": "http://test:4000/v2"}]
         ), patch(
-            "index_core.pipeline_utils.fetch_xcp_blocks_concurrent", return_value={}
+            "index_core.pipeline_utils.fetch_cp_blocks_skipping_empty", return_value={}
         ), patch(
             "index_core.pipeline_utils.is_shutdown_requested", return_value=False
         ), patch.object(
@@ -147,7 +147,7 @@ class TestPipelineExecutorLifecycle(unittest.TestCase):
         ), patch("index_core.pipeline_utils.update_healthy_nodes"), patch(
             "index_core.pipeline_utils.get_healthy_nodes", return_value=[{"name": "test_node", "url": "http://test:4000/v2"}]
         ), patch(
-            "index_core.pipeline_utils.fetch_xcp_blocks_concurrent", return_value={}
+            "index_core.pipeline_utils.fetch_cp_blocks_skipping_empty", return_value={}
         ), patch(
             "index_core.pipeline_utils.is_shutdown_requested", return_value=False
         ), patch.object(
@@ -204,7 +204,7 @@ class TestPipelineExecutorLifecycle(unittest.TestCase):
         ), patch("index_core.pipeline_utils.update_healthy_nodes"), patch(
             "index_core.pipeline_utils.get_healthy_nodes", return_value=[{"name": "test_node", "url": "http://test:4000/v2"}]
         ), patch(
-            "index_core.pipeline_utils.fetch_xcp_blocks_concurrent", return_value={}
+            "index_core.pipeline_utils.fetch_cp_blocks_skipping_empty", return_value={}
         ), patch(
             "index_core.pipeline_utils.is_shutdown_requested", return_value=False
         ), patch.object(
@@ -272,7 +272,7 @@ class TestPipelineExecutorLifecycle(unittest.TestCase):
         ), patch("index_core.pipeline_utils.update_healthy_nodes"), patch(
             "index_core.pipeline_utils.get_healthy_nodes", return_value=[{"name": "test_node", "url": "http://test:4000/v2"}]
         ), patch(
-            "index_core.pipeline_utils.fetch_xcp_blocks_concurrent", return_value={}
+            "index_core.pipeline_utils.fetch_cp_blocks_skipping_empty", return_value={}
         ), patch(
             "index_core.pipeline_utils.is_shutdown_requested", return_value=False
         ), patch.object(

--- a/indexer/tests/test_quick_consensus.py
+++ b/indexer/tests/test_quick_consensus.py
@@ -10,7 +10,7 @@ from index_core import check as check_mod
 from index_core.block_validation import create_check_hashes  # noqa: F401
 from index_core.block_validation import filter_block_transactions  # noqa: F401
 from index_core.blocks import backend_instance  # noqa: F401  (used in live mode)
-from index_core.blocks import fetch_xcp_blocks_concurrent  # noqa: F401
+from index_core.fetch_utils import fetch_xcp_blocks_concurrent  # noqa: F401
 
 # ---------------------------------------------------------------------------
 # Test Environment Isolation


### PR DESCRIPTION
## Summary

Implements **issue #756 item 3**: skip the Counterparty (CP) API fetch for Bitcoin blocks that carry **no Counterparty data**, eliminating a CP round-trip per CP-free block (the majority of blocks post-OLGA).

The skip consumes the over-approximating `TransactionInfo.has_counterparty_data` signal added in **#754**. That signal is a **strict over-approximation** (it never reports "no CP data" when CP data is present — i.e. no false negatives), so it is **sound** for skipping: a block it marks CP-free genuinely carries no Counterparty data, and the CP call can be elided without ever dropping an issuance. Therefore `MAX(stamp)+1` numbering cannot drift.

## Behavior-neutral merge

Gated behind a new config flag `CP_SKIP_NO_COUNTERPARTY_BLOCKS` (env, **default `False`**). With the flag off this is a thin pass-through to `fetch_xcp_blocks_concurrent` and behavior is **byte-identical** to before. The flag is enabled explicitly only for the validating reindex; the default is flipped on in a follow-up once proven.

## How it works

- `block_validation.block_has_counterparty_data(block_index)` — sound predicate. Fetches the raw block from bitcoind and parses **every** tx via the raw Rust `FastTransactionParser` (note: the `Parser` wrapper's `deserialize_transaction` converts to `CTransaction` and drops the field, so the inner parser is used). `batch_parse_transactions` is unusable here because it returns only the `should_include` subset, which would hide CP-era SRC-20/SRC-721/plain CP issuances. **Fail-safe**: any error, or a missing parser/signal, returns `True` (never skip on uncertainty).
- `block_validation.fetch_cp_blocks_skipping_empty(start, end)` — wraps the range fetch. Flag off ⇒ pass-through. Flag on ⇒ classify each block; for CP-free blocks substitute the **exact** empty-fetch shape and skip the API call (logged at info); fetch CP-bearing blocks in **contiguous runs** to preserve ordering and the concurrent range-fetch contract.
- Wired at both CP-fetch call sites: the `blocks.py` direct-fetch fallback and the `pipeline_utils._fetch_blocks_batch` concurrent pipeline (the primary path).

### Empty-block shape (verified against the real fetch)

A CP-free block flows through `_fetch_block_transactions_verbose_safe_pagination` with an empty `all_transactions`, yielding:

```python
{"block_index": n, "xcp_block_hash": None, "transactions": [], "issuances": []}
```

(`xcp_block_hash` derives from `all_transactions[0]`, absent ⇒ `None`.) The substitute replicates this exactly; downstream consumers (blocks.py xcp_hash resolution, `filter_block_transactions`) read only these keys.

## Integration note

Neither CP-fetch call site holds the block's parsed txs at fetch time (the raw bitcoind block is read later, at processing). The predicate therefore fetches+parses the raw block at the skip point — a cheap local RPC on this perf-gated path. The decision (flag + predicate) lives at the caller/wrapper; `fetch_utils` is untouched.

## Tests

`indexer/tests/test_cp_skip_no_counterparty.py` (DB-free, network-free):
- flag off ⇒ CP fetch always called;
- flag on + all CP-free ⇒ CP fetch **not** called, empty shape substituted;
- flag on + a CP-bearing block ⇒ CP fetch called for that block only;
- predicate plumbing + fail-safe paths;
- detection truth over the **real** Rust parser using CP-era vs native stamp fixtures.

Tests that patched the moved `fetch_xcp_blocks_concurrent` re-export were repointed to its canonical location.

Full unit suite: **1867 passed, 26 skipped**. `black`/`isort`/`flake8`/`mypy`/`bandit` clean.

## Validation gate (before flipping the default)

A **differential full reindex**: run once with the flag **on**, compare resulting hashes to `reference_hashes.json` (= prod). They MUST be **byte-identical** at every checkpoint before `CP_SKIP_NO_COUNTERPARTY_BLOCKS` defaults to on. Not run here.

Refs #756 (item 3), consumes #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)