### PR TITLE
perf(#818): batch prev_tx source-address lookups (biggest per-block lever)

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -93,7 +93,7 @@ from index_core.src20 import (
 from index_core.src20_holder_updater import get_holder_updater
 from index_core.src101 import Src101Dict, parse_src101, update_src101_owners
 from index_core.stamp import parse_stamp
-from index_core.transaction_utils import process_tx
+from index_core.transaction_utils import prefetch_source_prevouts, process_tx
 from index_core.zmq_utils import ZMQNotifier
 
 D = decimal.Decimal
@@ -1758,6 +1758,11 @@ def follow(
                         continue
 
                     tx_results = []
+
+                    # Pre-warm the raw-transaction cache so each candidate's vin[0]
+                    # source lookup in get_tx_info is a cache hit (one batched RPC
+                    # per block instead of N serial round-trips). Output-neutral.
+                    prefetch_source_prevouts(raw_transactions)
 
                     # Process transactions in parallel
                     futures = []

--- a/indexer/src/index_core/reparse/validator.py
+++ b/indexer/src/index_core/reparse/validator.py
@@ -35,7 +35,7 @@ from index_core.blocks import (
     backend_instance,
 )
 from index_core.fetch_utils import fetch_xcp_blocks_concurrent
-from index_core.transaction_utils import process_tx
+from index_core.transaction_utils import prefetch_source_prevouts, process_tx
 
 # Load .env from project root, falling back to .env.sample
 root_dir = Path(__file__).resolve().parents[3]
@@ -322,6 +322,10 @@ class ReparseValidator:
             if block_processor is None:
                 block_processor = InMemoryBlockProcessor()
                 tx_results = []
+                # Pre-warm the raw-transaction cache so each candidate's vin[0]
+                # source lookup in get_tx_info is a cache hit (one batched RPC per
+                # block instead of N serial round-trips). Output-neutral.
+                prefetch_source_prevouts(raw_transactions)
                 for tx_hash in raw_transactions.keys():
                     result = process_tx(None, tx_hash, block_index, stamp_issuances, raw_transactions)
                     if getattr(result, "data", None) is not None:

--- a/indexer/src/index_core/transaction_utils.py
+++ b/indexer/src/index_core/transaction_utils.py
@@ -151,6 +151,59 @@ def calculate_total_inputs(ctx):
         return 0
 
 
+def prefetch_source_prevouts(raw_transactions):
+    """Pre-warm ``backend_instance.raw_transactions_cache`` for source derivation.
+
+    ``get_tx_info`` derives a stamp candidate's ``source`` address by fetching the
+    previous transaction referenced by the candidate's FIRST input (``vin[0]``) via
+    ``backend_instance.getrawtransaction`` (see ``get_tx_info``). That call is
+    cache-backed by ``raw_transactions_cache``; when invoked once per candidate it
+    becomes N serial RPC round-trips per block.
+
+    This helper warms that cache with a SINGLE batched RPC before per-tx processing,
+    so each later ``vin[0]`` prev-tx lookup is a cache hit. It is STRICTLY
+    output-neutral: it fetches the exact same bytes ``get_tx_info`` would otherwise
+    fetch serially, and it never alters any returned value. The only observable
+    effect is fewer/batched RPCs.
+
+    It is purely additive: any failure is logged at DEBUG and swallowed, leaving the
+    existing per-candidate serial fetch as the unchanged fallback.
+
+    Only the FIRST input of each tx is prefetched, because ``get_tx_info`` only ever
+    uses ``vin[0]`` for source derivation.
+
+    Args:
+        raw_transactions: The block's ``{tx_hash: tx_hex}`` mapping.
+    """
+    try:
+        hashes = []
+        seen = set()
+
+        for tx_hex in raw_transactions.values():
+            ctx = backend_instance.deserialize(tx_hex)
+
+            # Mirror the coinbase/null-hash guard in calculate_total_inputs.
+            if not hasattr(ctx, "vin") or not ctx.vin:
+                continue
+
+            vin = ctx.vin[0]
+            if not hasattr(vin, "prevout") or not vin.prevout:
+                continue
+            if hasattr(vin.prevout, "hash") and vin.prevout.hash == b"\x00" * 32:
+                continue
+
+            prev_tx_hash = util.ib2h(vin.prevout.hash)
+            if prev_tx_hash not in seen:
+                seen.add(prev_tx_hash)
+                hashes.append(prev_tx_hash)
+
+        if hashes:
+            # Warm the cache only; the return value is intentionally discarded.
+            backend_instance.getrawtransaction_batch(hashes, skip_missing=True)
+    except Exception as e:
+        logger.debug(f"prefetch_source_prevouts skipped (non-fatal): {e}")
+
+
 def serialize_transaction(ctx):
     """
     Serialize a transaction to get its raw byte representation.

--- a/indexer/tests/test_prefetch_source_prevouts.py
+++ b/indexer/tests/test_prefetch_source_prevouts.py
@@ -1,0 +1,99 @@
+"""Tests for prefetch_source_prevouts cache pre-warming helper.
+
+prefetch_source_prevouts warms backend_instance.raw_transactions_cache with a
+single batched RPC so that the per-candidate vin[0] source lookup in get_tx_info
+becomes a cache hit. It must be strictly output-neutral and non-fatal: it only
+issues one batched getrawtransaction_batch over the deduped set of first-input
+prev hashes, skips coinbase/null-hash inputs, and swallows any backend error.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import index_core.util as util
+from index_core.transaction_utils import prefetch_source_prevouts
+
+
+def _ctx(prev_hash):
+    """Build a fake deserialized tx whose vin[0] spends prev_hash."""
+    prevout = SimpleNamespace(hash=prev_hash, n=0)
+    vin = SimpleNamespace(prevout=prevout)
+    return SimpleNamespace(vin=[vin])
+
+
+def _ctx_no_prevout():
+    """Build a fake coinbase-style tx whose vin[0] has no prevout."""
+    return SimpleNamespace(vin=[SimpleNamespace(prevout=None)])
+
+
+def test_prefetch_batches_deduped_vin0_hashes(monkeypatch):
+    h1 = b"\x11" * 32
+    h2 = b"\x22" * 32
+
+    # tx_c reuses h1 to exercise dedupe; insertion order must be preserved.
+    raw_transactions = {
+        "tx_a": "hexA",
+        "tx_b": "hexB",
+        "tx_c": "hexC",
+    }
+    ctx_by_hex = {"hexA": _ctx(h1), "hexB": _ctx(h2), "hexC": _ctx(h1)}
+
+    mock_backend = MagicMock()
+    mock_backend.deserialize.side_effect = lambda tx_hex: ctx_by_hex[tx_hex]
+
+    with patch("index_core.transaction_utils.backend_instance", mock_backend):
+        prefetch_source_prevouts(raw_transactions)
+
+    assert mock_backend.getrawtransaction_batch.call_count == 1
+    args, kwargs = mock_backend.getrawtransaction_batch.call_args
+    assert args[0] == [util.ib2h(h1), util.ib2h(h2)]
+    assert kwargs.get("skip_missing") is True
+
+
+def test_prefetch_excludes_coinbase_and_null_hash(monkeypatch):
+    h1 = b"\x33" * 32
+    null_hash = b"\x00" * 32
+
+    raw_transactions = {
+        "coinbase_null": "hexNull",
+        "coinbase_noprevout": "hexNoPrevout",
+        "real": "hexReal",
+    }
+    ctx_by_hex = {
+        "hexNull": _ctx(null_hash),
+        "hexNoPrevout": _ctx_no_prevout(),
+        "hexReal": _ctx(h1),
+    }
+
+    mock_backend = MagicMock()
+    mock_backend.deserialize.side_effect = lambda tx_hex: ctx_by_hex[tx_hex]
+
+    with patch("index_core.transaction_utils.backend_instance", mock_backend):
+        prefetch_source_prevouts(raw_transactions)
+
+    assert mock_backend.getrawtransaction_batch.call_count == 1
+    args, _ = mock_backend.getrawtransaction_batch.call_args
+    assert args[0] == [util.ib2h(h1)]
+
+
+def test_prefetch_no_candidates_skips_batch(monkeypatch):
+    raw_transactions = {"coinbase": "hexCb"}
+    mock_backend = MagicMock()
+    mock_backend.deserialize.side_effect = lambda tx_hex: _ctx_no_prevout()
+
+    with patch("index_core.transaction_utils.backend_instance", mock_backend):
+        prefetch_source_prevouts(raw_transactions)
+
+    mock_backend.getrawtransaction_batch.assert_not_called()
+
+
+def test_prefetch_swallows_backend_exception(monkeypatch):
+    raw_transactions = {"tx_a": "hexA"}
+    mock_backend = MagicMock()
+    mock_backend.deserialize.side_effect = RuntimeError("boom")
+
+    with patch("index_core.transaction_utils.backend_instance", mock_backend):
+        # Must not raise; failure leaves the existing serial fetch as fallback.
+        prefetch_source_prevouts(raw_transactions)
+
+    mock_backend.getrawtransaction_batch.assert_not_called()


### PR DESCRIPTION
## What

Adds `prefetch_source_prevouts(raw_transactions)` in `indexer/src/index_core/transaction_utils.py`, which warms `backend_instance.raw_transactions_cache` with a **single batched RPC per block** before per-tx processing. It deserializes each block tx (cached + pure), collects the unique `vin[0]` prevout hashes (mirroring the coinbase/null-hash guard in `calculate_total_inputs`), and issues one `getrawtransaction_batch(..., skip_missing=True)` to populate the cache.

It is called immediately before the per-tx loops in both call sites:
- `blocks.py` — before the `ThreadPoolExecutor` `process_tx` submission loop.
- `reparse/validator.py` — before the serial `process_tx` loop (the Reparse Consensus Validation path).

## Why

`get_tx_info` derives each stamp candidate's `source` address from its `vin[0]` prev_tx via a cache-backed `getrawtransaction` (`get_tx_info:539`). Run once per candidate this is N serial RPC round-trips — profiled at 115–350 ms/block, the biggest per-block lever (#818). Pre-warming the cache turns every `:539` lookup into a cache hit: one batched RPC per block, zero remaining serial round-trips on the hot path. The source-derivation logic at `:539` is left **unchanged**.

The helper is purely additive: any failure is logged at DEBUG and swallowed, leaving the existing serial `:539` fetch as the unchanged fallback.

Closes #818

## Output-neutral

source/TransactionInfo byte-identical; the helper fetches the exact same bytes `:539` would otherwise fetch and never alters any returned value. Validated by Reparse Consensus Validation (3.10/3.11/3.12) — the helper runs in the validator path so the consensus job proves byte-identical `source` / `txlist_hash` / `ledger_hash`.

## Local validation

- `black --check`, `isort --check-only`, `flake8 src/`, `mypy src/ --explicit-package-bases`, `bandit`: all pass (no issues).
- Full unit suite: `1871 passed, 26 skipped`.
- New focused unit test `tests/test_prefetch_source_prevouts.py`: 4 passed (dedupe + order, coinbase/null exclusion, no-candidate skip, exception swallow).
- Tier-3 reparse smoke (`ci/ci_reparse_subprocess.py --limit 5`): `5/5 passed, 0 failed` — no hash mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)