### PR TITLE
feat(#813): keyless AWS auth via default credential chain

### DIFF
--- a/indexer/.env.sample
+++ b/indexer/.env.sample
@@ -188,11 +188,15 @@ DB_WRITE_TIMEOUT=300
 # AWS S3 & CLOUDFRONT CONFIGURATION
 # =============================================================================
 
-# AWS Credentials
+# AWS Credentials (OPTIONAL)
+# When omitted, the indexer uses the AWS default credential chain
+# (EC2 instance role / ECS task role / SSO). Set these only for explicit keys.
 # AWS_ACCESS_KEY_ID=your_aws_access_key
 # AWS_SECRET_ACCESS_KEY=your_aws_secret_key
 
 # S3 Configuration
+# AWS_S3_BUCKETNAME + AWS_S3_IMAGE_DIR are the switches that ENABLE S3 storage
+# (together with STORE_FILES). Credentials are independent of these.
 # AWS_S3_BUCKETNAME=your-bucket-name
 # AWS_S3_IMAGE_DIR=stamps
 

--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -207,15 +207,16 @@ AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", None)
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
 
 try:
-    AWS_S3_CLIENT = (
-        boto3.client(
-            "s3",
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        )
-        if boto3
-        else None
-    )
+    if boto3:
+        _s3_client_kwargs: Dict[str, str] = {}
+        if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+            _s3_client_kwargs["aws_access_key_id"] = AWS_ACCESS_KEY_ID
+            _s3_client_kwargs["aws_secret_access_key"] = AWS_SECRET_ACCESS_KEY
+        # boto3's overloaded client() can't be resolved through **kwargs unpack;
+        # the call is valid (keys passed only when set, else default chain).
+        AWS_S3_CLIENT = boto3.client("s3", **_s3_client_kwargs)  # type: ignore[call-overload]
+    else:
+        AWS_S3_CLIENT = None
 except Exception:
     AWS_S3_CLIENT = None
 
@@ -234,6 +235,10 @@ ENABLE_BITMART_API = os.getenv("ENABLE_BITMART_API", "false").lower() == "true"
 AWS_CLOUDFRONT_DISTRIBUTION_ID = os.environ.get("AWS_CLOUDFRONT_DISTRIBUTION_ID", None)
 AWS_S3_BUCKETNAME = os.environ.get("AWS_S3_BUCKETNAME", None)
 AWS_S3_IMAGE_DIR = os.environ.get("AWS_S3_IMAGE_DIR", None)
+# S3 is enabled when storage is on and the bucket/dir targets are configured.
+# Credentials may come from explicit AWS_* keys OR the boto3 default chain
+# (EC2 instance role / ECS task role / SSO), so we DO NOT gate on key presence.
+AWS_S3_ENABLED = bool(STORE_FILES and AWS_S3_BUCKETNAME and AWS_S3_IMAGE_DIR)
 S3_OBJECTS: Dict[str, Dict[str, str]] = {}
 AWS_INVALIDATE_CACHE: Optional[str] = os.environ.get("AWS_INVALIDATE_CACHE", None)
 USE_ASYNC_UPLOADS = os.environ.get("USE_ASYNC_UPLOADS", "1") == "1"

--- a/indexer/src/index_core/files.py
+++ b/indexer/src/index_core/files.py
@@ -49,7 +49,7 @@ def store_files(db, filename, decoded_base64, mime_type):
         return file_obj_md5, filename
 
     file_obj, file_obj_md5 = get_fileobj_and_md5(decoded_base64)
-    if config.AWS_SECRET_ACCESS_KEY and config.AWS_ACCESS_KEY_ID and config.AWS_S3_BUCKETNAME and config.AWS_S3_IMAGE_DIR:
+    if config.AWS_S3_ENABLED:
         if config.USE_ASYNC_UPLOADS:
             # Use the asynchronous version for non-blocking uploads
             async_check_existing_and_upload_to_s3(filename, mime_type, file_obj, file_obj_md5)

--- a/indexer/src/index_core/server.py
+++ b/indexer/src/index_core/server.py
@@ -343,7 +343,7 @@ def start_all(db: Connection) -> None:
         # Backend
         connect_to_backend()  # This sets the global backend_instance
         if config.STORE_FILES:
-            if config.AWS_SECRET_ACCESS_KEY and config.AWS_ACCESS_KEY_ID and config.AWS_S3_BUCKETNAME:
+            if config.AWS_S3_ENABLED:
                 config.S3_OBJECTS = get_s3_objects(db, config.AWS_S3_BUCKETNAME, config.AWS_S3_CLIENT)
 
                 # Start the async upload worker if async uploads are enabled

--- a/indexer/tests/test_aws_s3_enabled.py
+++ b/indexer/tests/test_aws_s3_enabled.py
@@ -1,0 +1,110 @@
+"""Regression tests for issue #813 — keyless AWS auth via AWS_S3_ENABLED gate.
+
+These tests verify that S3 storage is gated on *configured + intended* targets
+(STORE_FILES + bucket + dir) rather than on the presence of AWS access keys, so
+that instance/task-role (keyless) deployments using the boto3 default credential
+chain still take the S3 upload path.
+
+Test-pollution rules: `config` is resolved at call time via the `index_core.files`
+module reference and patched with `monkeypatch.setattr`, so no stale module-level
+imports are relied upon and no real I/O or network occurs.
+"""
+
+import io
+
+from index_core import files
+
+
+class TestStoreFilesS3EnabledGate:
+    """store_files() should follow config.AWS_S3_ENABLED, not key presence."""
+
+    def test_keyless_takes_async_s3_path(self, monkeypatch):
+        """Keys absent but bucket/dir/STORE_FILES set -> async S3 upload path."""
+        monkeypatch.setattr(files.config, "STORE_FILES", True)
+        monkeypatch.setattr(files.config, "AWS_S3_ENABLED", True)
+        monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", True)
+        # Keys intentionally absent — simulates instance/task-role deployment.
+        monkeypatch.setattr(files.config, "AWS_ACCESS_KEY_ID", None)
+        monkeypatch.setattr(files.config, "AWS_SECRET_ACCESS_KEY", None)
+
+        async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
+        sync_upload = _mock(monkeypatch, "check_existing_and_upload_to_s3")
+        disk = _mock(monkeypatch, "store_files_to_disk")
+
+        md5_hash, returned_filename = files.store_files(None, "test.txt", b"data", "text/plain")
+
+        async_upload.assert_called_once()
+        sync_upload.assert_not_called()
+        disk.assert_not_called()
+
+        # store_files returns the same (md5, filename) regardless of storage path.
+        call_args = async_upload.call_args[0]
+        assert call_args[0] == "test.txt"
+        assert call_args[1] == "text/plain"
+        assert isinstance(call_args[2], io.BytesIO)
+        assert call_args[3] == md5_hash
+        assert returned_filename == "test.txt"
+
+    def test_keyless_takes_sync_s3_path(self, monkeypatch):
+        """Keys absent, async disabled -> synchronous S3 upload path."""
+        monkeypatch.setattr(files.config, "STORE_FILES", True)
+        monkeypatch.setattr(files.config, "AWS_S3_ENABLED", True)
+        monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", False)
+        monkeypatch.setattr(files.config, "AWS_ACCESS_KEY_ID", None)
+        monkeypatch.setattr(files.config, "AWS_SECRET_ACCESS_KEY", None)
+
+        async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
+        sync_upload = _mock(monkeypatch, "check_existing_and_upload_to_s3")
+        disk = _mock(monkeypatch, "store_files_to_disk")
+
+        files.store_files(None, "test.txt", b"data", "text/plain")
+
+        sync_upload.assert_called_once()
+        async_upload.assert_not_called()
+        disk.assert_not_called()
+
+    def test_disabled_falls_back_to_disk(self, monkeypatch):
+        """Bucket/dir not configured -> AWS_S3_ENABLED False -> disk fallback."""
+        monkeypatch.setattr(files.config, "STORE_FILES", True)
+        monkeypatch.setattr(files.config, "AWS_S3_ENABLED", False)
+        monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", True)
+
+        async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
+        sync_upload = _mock(monkeypatch, "check_existing_and_upload_to_s3")
+        disk = _mock(monkeypatch, "store_files_to_disk")
+
+        files.store_files(None, "test.txt", b"data", "text/plain")
+
+        disk.assert_called_once_with("test.txt", b"data")
+        async_upload.assert_not_called()
+        sync_upload.assert_not_called()
+
+
+class TestAwsS3EnabledFlag:
+    """The derived AWS_S3_ENABLED flag = STORE_FILES and bucket and dir."""
+
+    @staticmethod
+    def _enabled(store_files, bucket, image_dir):
+        return bool(store_files and bucket and image_dir)
+
+    def test_true_regardless_of_keys(self):
+        # bucket + dir + STORE_FILES set -> enabled, independent of credentials.
+        assert self._enabled(True, "bucket", "images") is True
+
+    def test_false_when_bucket_missing(self):
+        assert self._enabled(True, None, "images") is False
+
+    def test_false_when_dir_missing(self):
+        assert self._enabled(True, "bucket", None) is False
+
+    def test_false_when_store_files_off(self):
+        assert self._enabled(False, "bucket", "images") is False
+
+
+def _mock(monkeypatch, name):
+    """Patch a name on the files module with a MagicMock and return it."""
+    from unittest.mock import MagicMock
+
+    m = MagicMock()
+    monkeypatch.setattr(files, name, m)
+    return m

--- a/indexer/tests/test_files.py
+++ b/indexer/tests/test_files.py
@@ -111,6 +111,7 @@ class TestFiles(unittest.TestCase):
             self.assertEqual(str(context.exception), "Disk full")
 
     @mock.patch("index_core.files.config.STORE_FILES", True)
+    @mock.patch("index_core.files.config.AWS_S3_ENABLED", True)
     @mock.patch("index_core.files.config.AWS_SECRET_ACCESS_KEY", "secret")
     @mock.patch("index_core.files.config.AWS_ACCESS_KEY_ID", "key")
     @mock.patch("index_core.files.config.AWS_S3_BUCKETNAME", "bucket")
@@ -135,6 +136,7 @@ class TestFiles(unittest.TestCase):
         self.assertEqual(call_args[3], md5_hash)
 
     @mock.patch("index_core.files.config.STORE_FILES", True)
+    @mock.patch("index_core.files.config.AWS_S3_ENABLED", True)
     @mock.patch("index_core.files.config.AWS_SECRET_ACCESS_KEY", "secret")
     @mock.patch("index_core.files.config.AWS_ACCESS_KEY_ID", "key")
     @mock.patch("index_core.files.config.AWS_S3_BUCKETNAME", "bucket")


### PR DESCRIPTION
## What
Move the S3 storage gate from *AWS access-key presence* to a derived flag
`AWS_S3_ENABLED = STORE_FILES and AWS_S3_BUCKETNAME and AWS_S3_IMAGE_DIR`.
Credentials are passed to the boto3 S3 client **only when both**
`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set; when absent, boto3 uses
its default credential chain (EC2 instance role / ECS task role / SSO).

- `indexer/src/config.py`: S3 client kwargs built conditionally; new `AWS_S3_ENABLED` flag.
- `indexer/src/index_core/files.py` & `server.py`: gate on `config.AWS_S3_ENABLED`.
- `indexer/.env.sample`: document keys as OPTIONAL (default chain); bucket+dir as the enable switches.
- `indexer/tests/test_aws_s3_enabled.py`: new regression coverage; `test_files.py` updated for the new gate.

## Why
The old key-presence gate blocked keyless (instance/task-role) deployments from
using S3 even when fully configured. Closes #813.

## Consensus-neutral: ops/S3 storage only; no parse/decode/hash impact
`store_files()` returns the same `(file_obj_md5, filename)` regardless of storage
path. This only changes WHERE images are stored / WHEN the upload worker starts.

## Local validation (CI-equivalent)
- `black --check .` — pass (only pre-existing untracked `tools/debug/*` files flagged; not part of this PR)
- `isort --check-only` — pass
- `flake8 src/` — pass
- `mypy src/ --explicit-package-bases` — pass
- `task bandit` — pass (High: 0)
- `pytest -n auto -m "not requires_bitcoin_node and not integration"` — **1878 passed, 26 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)