### PR TITLE
docs(#802): document backend injection seam as the sanctioned test/CI backend override

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -188,6 +188,32 @@ def test_src20_token_validation():
     assert validator.is_valid
 ```
 
+### Substituting the backend in tests
+
+`index_core.backend.Backend` is a process-wide singleton, and it exposes a
+first-class **injection seam** for swapping in a non-bitcoind backend (e.g. the
+public-endpoint reparse shim) in tests and CI. **Use the seam — do not reassign
+`backend_instance` on individual modules** (any module the reassignment misses
+silently falls through to the real bitcoind RPC and times out).
+
+```python
+from index_core.backend import set_backend_override, clear_backend_override
+
+set_backend_override(MyTestBackend())  # every subsequent Backend() returns it
+clear_backend_override()               # restore the real singleton
+```
+
+Or, import-order-independent (resolves lazily on first `Backend()`):
+
+```bash
+BTC_STAMPS_BACKEND_OVERRIDE="module:ClassName"
+```
+
+The autouse `tests/conftest.py::reset_backend_override` fixture clears the
+override (and env var) before/after every test, so it can never leak across the
+suite. See the seam docstrings in `index_core/backend.py` and the note in
+`indexer/tests/README.md`. (Refs #800, #802.)
+
 ## Debugging Tools
 
 The project includes several debugging tools to analyze transactions:

--- a/indexer/tests/README.md
+++ b/indexer/tests/README.md
@@ -131,6 +131,37 @@ The `apply_test_markers.py` tool detects test types based on:
 - Uses `@patch`, `MagicMock`, `Mock()`
 - No database or network patterns detected
 
+## Substituting the backend (test/CI backend override)
+
+`index_core.backend.Backend` is a process-wide singleton and exposes a
+first-class **injection seam** for substituting a non-bitcoind backend (e.g. the
+public-endpoint reparse shim) in tests and CI runners. **Use the seam — never
+reassign `backend_instance` on individual modules**: `Backend` is imported by
+value in many modules, and any module a per-module reassignment misses silently
+falls through to the real bitcoind RPC at `127.0.0.1:8332` and times out. (This
+is what took the Tier 3 reparse from 20/20 to 9/20 before the seam existed.)
+
+Two equivalent entry points:
+
+```python
+# Programmatic — preferred in tests when you control import order:
+from index_core.backend import set_backend_override, clear_backend_override
+
+set_backend_override(MyTestBackend())  # every subsequent Backend() returns it
+clear_backend_override()               # restore the real singleton
+```
+
+```bash
+# Env var — import-order-independent; resolves lazily on first Backend():
+BTC_STAMPS_BACKEND_OVERRIDE="module:ClassName"
+```
+
+The autouse `conftest.py::reset_backend_override` fixture clears `Backend._override`
+and the env var before/after every test, so an override can never leak across the
+suite. CI runner scripts (e.g. `smoke_parser_validation.py`) install the override
+inside `main()` before importing `index_core`, keeping import side-effect-free.
+See the seam docstrings in `index_core/backend.py`. (Refs #800, #802.)
+
 ## Maintaining Test Quality
 
 1. **Check for missing markers**: Run `poetry run python tools/apply_test_markers.py` regularly


### PR DESCRIPTION
## What

Adds the remaining acceptance item for #802: a discoverable contributor-facing note pointing to the backend injection seam introduced in #800.

Documents in two places:
- `indexer/tests/README.md` — new "Substituting the backend" section (the natural home for test-backend substitution).
- `docs/DEVELOPMENT.md` — a "Substituting the backend in tests" subsection under Testing.

## Why

`index_core.backend.Backend` is a process-wide singleton with a first-class injection seam (`set_backend_override` / `clear_backend_override` / `BTC_STAMPS_BACKEND_OVERRIDE`). Contributors must use the seam rather than reassigning `backend_instance` per-module — a missed module silently falls through to the real bitcoind RPC and times out (this regressed Tier 3 reparse 20/20 → 9/20 before the seam existed). All documented facts were verified against `backend.py`, `conftest.py::reset_backend_override`, and `ci/smoke_parser_validation.py`.

Docs-only; consensus-neutral; no code changes.

`Closes #802`

🤖 Generated with [Claude Code](https://claude.com/claude-code)