### PR TITLE
chore(#749,#817): add research/profiling debug tools

### DIFF
--- a/indexer/tools/debug/README.md
+++ b/indexer/tools/debug/README.md
@@ -22,6 +22,17 @@ This directory contains debug tools for troubleshooting and analyzing the Bitcoi
 | test_rust_parser_basic.py | Basic Rust parser smoke test | `python test_rust_parser_basic.py` |
 | test_block_transactions.py | Tests SRC-20 processing in reference blocks | `python test_block_transactions.py --block=865002 [--verbose]` |
 | verify_olga_fix.py | Verifies OLGA protocol transition fix | `python verify_olga_fix.py` |
+| scan_issue749_fast.py | Scans the chain for consensus-divergent drops (#749: multisig stamp shadowed by a P2WSH output), using the Rust prefilter + DB diff | `python tools/debug/scan_issue749_fast.py --start 865000 --end 955722` |
+| scan_issue749.py | Slower standalone variant of the #749 scan (burnkey byte-scan + Python classify; no DB needed) | `python tools/debug/scan_issue749.py --start 865000 --end 870000` |
+| perf_probe.py | Per-block indexing profiler (fetch / parse_block / filter / get_tx_info decode) + PREWARM on/off A/B + swap/DB latency (#817) | `python tools/debug/perf_probe.py [block ...]` |
+| probe_phases.py | Fills the write/hash gap left by perf_probe (consensus-hash CPU + realistic DB insert cost via a TEMP table) (#817) | `python tools/debug/probe_phases.py [block ...]` |
+
+### Research / evidence tools (#749, #817)
+
+These were written while diagnosing the #749 consensus bug and profiling per-block performance (#817). They read configuration from the standard environment variables (`RPC_USER`/`RPC_PASSWORD`/`RPC_IP`/`RPC_PORT`, `RDS_HOSTNAME`/`RDS_PORT`/`RDS_USER`/`RDS_PASSWORD`/`RDS_DATABASE`) — no credentials are hard-coded.
+
+- **scan_issue749_fast.py** — for each block, takes the Rust prefilter's accepted candidates, subtracts txids present in `transactions`, and classifies the remainder against the `get_tx_info` decode logic. Used to prove the #749 blast radius (one transaction across the post-OLGA range). Supports `--sleep` to throttle load on a shared bitcoind.
+- **perf_probe.py / probe_phases.py** — the profiling harness behind #817 (the `prev_tx` source-lookup hotspot, the redundant-parse finding, and the PREWARM net-negative result). Read-only; safe to run against a live node/DB.
 
 ### Deprecated Scripts
 

--- a/indexer/tools/debug/perf_probe.py
+++ b/indexer/tools/debug/perf_probe.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Read-only indexing performance probe (stampsdev).
+
+Measures, per sampled block, where per-block time goes and whether
+PREWARM_DESERIALIZE_CACHE actually helps:
+
+  A) Per-phase timing (real functions, read-only):
+       fetch (getblockhash + getblock v0) | parse_block | filter (batch_parse)
+       | per-candidate decode (get_tx_info incl. prev_tx fetch)
+  B) PREWARM off vs on, modeled on the real main-loop sequence:
+       OFF: parse_block + filter_batch_parse + per-candidate deserialize(MISS)
+       ON : parse_block + prewarm_batch_parse + filter_batch_parse + deserialize(HIT)
+
+Also captures swap activity (/proc/vmstat) over the run and DB read/write
+latency (non-destructive: a TEMPORARY table) to gauge memory-pressure impact.
+
+Usage: poetry run python tools/debug/perf_probe.py [block ...]
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, "src")
+import config  # noqa: E402
+import index_core.util as util  # noqa: E402
+import pymysql  # noqa: E402
+from index_core.block_validation import filter_block_transactions  # noqa: E402
+from index_core.transaction_utils import backend_instance as B  # noqa: E402
+from index_core.transaction_utils import get_tx_info  # noqa: E402
+
+PARSER = B._parser
+
+
+def vmstat_swap():
+    d = {}
+    with open("/proc/vmstat") as f:
+        for line in f:
+            k, v = line.split()
+            if k in ("pswpin", "pswpout"):
+                d[k] = int(v)
+    return d
+
+
+def t(fn):
+    s = time.perf_counter()
+    r = fn()
+    return (time.perf_counter() - s) * 1000.0, r
+
+
+def probe_block(height):
+    bh = B.getblockhash(height)
+    util.CURRENT_BLOCK_INDEX = height
+
+    ms_fetch, raw = t(lambda: B.rpc("getblock", [bh, 0]))
+    ms_parse, parsed = t(lambda: PARSER.parse_block(raw))
+    thl, rawtx = parsed[0], parsed[1]
+    hexes = list(rawtx.values())
+
+    block_data = {"tx": [{"txid": h, "hex": rawtx[h]} for h in thl]}
+    ms_filter, filt = t(lambda: filter_block_transactions(block_data, stamp_issuances=None))
+    cand_hexes = list(filt[1].values())
+
+    # per-candidate decode (the real consensus path, incl. prev_tx RPC fetch)
+    s = time.perf_counter()
+    decoded = 0
+    for hx in cand_hexes:
+        try:
+            info = get_tx_info(hx, block_index=height, db=None, stamp_issuance=None)
+            if info and info.data:
+                decoded += 1
+        except Exception:
+            pass
+    ms_decode = (time.perf_counter() - s) * 1000.0
+
+    # ---- B: prewarm OFF vs ON, modeled on the real loop ----
+    # OFF: parse_block + filter_batch + per-candidate deserialize(miss)
+    B.deserialized_tx_cache.clear()
+    off_parse, _ = t(lambda: PARSER.parse_block(raw))
+    off_filter, _ = t(lambda: PARSER.batch_parse_transactions(hexes))
+    s = time.perf_counter()
+    for hx in cand_hexes:
+        B.deserialize(hx)
+    off_deser = (time.perf_counter() - s) * 1000.0
+    off_total = off_parse + off_filter + off_deser
+
+    # ON: parse_block + prewarm_batch + filter_batch + per-candidate deserialize(hit)
+    B.deserialized_tx_cache.clear()
+    on_parse, _ = t(lambda: PARSER.parse_block(raw))
+    on_prewarm, _ = t(lambda: B._prewarm_deserialize_cache(rawtx))
+    on_filter, _ = t(lambda: PARSER.batch_parse_transactions(hexes))
+    s = time.perf_counter()
+    for hx in cand_hexes:
+        B.deserialize(hx)
+    on_deser = (time.perf_counter() - s) * 1000.0
+    on_total = on_parse + on_prewarm + on_filter + on_deser
+
+    return {
+        "block": height,
+        "ntx": len(thl),
+        "ncand": len(cand_hexes),
+        "ndecoded": decoded,
+        "fetch": ms_fetch,
+        "parse_block": ms_parse,
+        "filter": ms_filter,
+        "decode_all_cand": ms_decode,
+        "off_total": off_total,
+        "off_deser": off_deser,
+        "on_total": on_total,
+        "on_prewarm": on_prewarm,
+        "on_deser": on_deser,
+        "prewarm_delta": on_total - off_total,  # >0 => prewarm is SLOWER
+    }
+
+
+def db_latency():
+    conn = pymysql.connect(host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"), port=int(os.environ.get("RDS_PORT", "3306")), user=os.environ.get("RDS_USER", "root"), password=os.environ.get("RDS_PASSWORD", ""), database=os.environ.get("RDS_DATABASE", "btc_stamps"))
+    out = {}
+    with conn.cursor() as cur:
+        s = time.perf_counter()
+        cur.execute("SELECT COUNT(*) FROM SRC20Valid WHERE tick=%s", ("IRONB",))
+        cur.fetchall()
+        out["select_indexed_ms"] = (time.perf_counter() - s) * 1000.0
+
+        s = time.perf_counter()
+        cur.execute("SELECT COUNT(*) FROM transactions WHERE block_index BETWEEN %s AND %s", (900000, 900500))
+        cur.fetchall()
+        out["select_range_ms"] = (time.perf_counter() - s) * 1000.0
+
+        cur.execute("CREATE TEMPORARY TABLE _perf_probe (id INT, h CHAR(64), d VARCHAR(255))")
+        rows = [(i, "%064x" % i, "stamp:{...payload...}") for i in range(2000)]
+        s = time.perf_counter()
+        cur.executemany("INSERT INTO _perf_probe VALUES (%s,%s,%s)", rows)
+        conn.commit()
+        out["insert_2000_ms"] = (time.perf_counter() - s) * 1000.0
+        cur.execute("DROP TEMPORARY TABLE _perf_probe")
+    conn.close()
+    return out
+
+
+def main():
+    blocks = [int(b) for b in sys.argv[1:]] or [867000, 920000, 951939, 955000]
+    print(f"PREWARM_DESERIALIZE_CACHE config = {config.PREWARM_DESERIALIZE_CACHE}")
+    sw0 = vmstat_swap()
+    print(f"\n{'block':>8} {'ntx':>5} {'cand':>4} {'fetch':>7} {'parse':>7} {'filter':>7} {'decode':>8} "
+          f"{'OFFtot':>7} {'ONtot':>7} {'prewarmΔ':>9}")
+    rows = []
+    for b in blocks:
+        try:
+            r = probe_block(b)
+            rows.append(r)
+            print(f"{r['block']:>8} {r['ntx']:>5} {r['ncand']:>4} {r['fetch']:>7.0f} {r['parse_block']:>7.0f} "
+                  f"{r['filter']:>7.0f} {r['decode_all_cand']:>8.0f} {r['off_total']:>7.0f} {r['on_total']:>7.0f} "
+                  f"{r['prewarm_delta']:>+9.0f}")
+        except Exception as e:
+            print(f"{b:>8} ERROR {e}")
+    sw1 = vmstat_swap()
+
+    print("\n--- swap during run (pages; 1 page = 4KB) ---")
+    print(f"  pswpin  +{sw1['pswpin']-sw0['pswpin']}   pswpout +{sw1['pswpout']-sw0['pswpout']}")
+
+    print("\n--- DB latency (current memory pressure) ---")
+    for k, v in db_latency().items():
+        print(f"  {k}: {v:.0f} ms")
+
+    if rows:
+        n = len(rows)
+        print("\n--- averages ---")
+        for k in ("fetch", "parse_block", "filter", "decode_all_cand", "off_total", "on_total", "prewarm_delta"):
+            print(f"  {k}: {sum(r[k] for r in rows)/n:.0f} ms")
+        print("\nNOTE: prewarmΔ > 0 means PREWARM=true is SLOWER for that block.")
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/tools/debug/perf_probe.py
+++ b/indexer/tools/debug/perf_probe.py
@@ -17,6 +17,7 @@ latency (non-destructive: a TEMPORARY table) to gauge memory-pressure impact.
 
 Usage: poetry run python tools/debug/perf_probe.py [block ...]
 """
+
 import os
 import sys
 import time
@@ -114,7 +115,13 @@ def probe_block(height):
 
 
 def db_latency():
-    conn = pymysql.connect(host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"), port=int(os.environ.get("RDS_PORT", "3306")), user=os.environ.get("RDS_USER", "root"), password=os.environ.get("RDS_PASSWORD", ""), database=os.environ.get("RDS_DATABASE", "btc_stamps"))
+    conn = pymysql.connect(
+        host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"),
+        port=int(os.environ.get("RDS_PORT", "3306")),
+        user=os.environ.get("RDS_USER", "root"),
+        password=os.environ.get("RDS_PASSWORD", ""),
+        database=os.environ.get("RDS_DATABASE", "btc_stamps"),
+    )
     out = {}
     with conn.cursor() as cur:
         s = time.perf_counter()
@@ -142,16 +149,20 @@ def main():
     blocks = [int(b) for b in sys.argv[1:]] or [867000, 920000, 951939, 955000]
     print(f"PREWARM_DESERIALIZE_CACHE config = {config.PREWARM_DESERIALIZE_CACHE}")
     sw0 = vmstat_swap()
-    print(f"\n{'block':>8} {'ntx':>5} {'cand':>4} {'fetch':>7} {'parse':>7} {'filter':>7} {'decode':>8} "
-          f"{'OFFtot':>7} {'ONtot':>7} {'prewarmΔ':>9}")
+    print(
+        f"\n{'block':>8} {'ntx':>5} {'cand':>4} {'fetch':>7} {'parse':>7} {'filter':>7} {'decode':>8} "
+        f"{'OFFtot':>7} {'ONtot':>7} {'prewarmΔ':>9}"
+    )
     rows = []
     for b in blocks:
         try:
             r = probe_block(b)
             rows.append(r)
-            print(f"{r['block']:>8} {r['ntx']:>5} {r['ncand']:>4} {r['fetch']:>7.0f} {r['parse_block']:>7.0f} "
-                  f"{r['filter']:>7.0f} {r['decode_all_cand']:>8.0f} {r['off_total']:>7.0f} {r['on_total']:>7.0f} "
-                  f"{r['prewarm_delta']:>+9.0f}")
+            print(
+                f"{r['block']:>8} {r['ntx']:>5} {r['ncand']:>4} {r['fetch']:>7.0f} {r['parse_block']:>7.0f} "
+                f"{r['filter']:>7.0f} {r['decode_all_cand']:>8.0f} {r['off_total']:>7.0f} {r['on_total']:>7.0f} "
+                f"{r['prewarm_delta']:>+9.0f}"
+            )
         except Exception as e:
             print(f"{b:>8} ERROR {e}")
     sw1 = vmstat_swap()

--- a/indexer/tools/debug/probe_phases.py
+++ b/indexer/tools/debug/probe_phases.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Fill the write/hash gap left by perf_probe.py (read-only / non-mutating).
+
+Measures, per sampled block, the per-block costs perf_probe.py did NOT cover:
+  - hashing CPU: building the three consensus-hash content strings
+    (txlist / ledger / messages) + a sha256 over each. The messages_hash
+    content is str(txhash_list) over EVERY tx in the block, so this scales
+    with block size. Proxy for create_check_hashes()'s CPU (excludes its DB writes).
+  - DB write: insert N rows into a TEMPORARY table mirroring the real
+    `transactions` schema (12 cols) -> realistic per-block insert latency.
+
+NOTE: CP issuance fetch (per-block Counterparty RPC) is intentionally NOT
+measured here — that path is owned by the #754/#756 work.
+
+Usage: poetry run python tools/debug/probe_phases.py [block ...]
+"""
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, "src")
+import pymysql  # noqa: E402
+from index_core.transaction_utils import backend_instance as B  # noqa: E402
+
+PARSER = B._parser
+
+
+def hashing_cost(txhash_list):
+    s = time.perf_counter()
+    # mirror create_check_hashes content building; stamps/src20 are small per block,
+    # the messages_hash over the full txhash_list is the size-scaling part.
+    for content in (str([]), str([]), str(txhash_list)):
+        hashlib.sha256(content.encode()).hexdigest()
+    return (time.perf_counter() - s) * 1000.0
+
+
+def db_insert_cost(nrows):
+    conn = pymysql.connect(host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"), port=int(os.environ.get("RDS_PORT", "3306")), user=os.environ.get("RDS_USER", "root"), password=os.environ.get("RDS_PASSWORD", ""), database=os.environ.get("RDS_DATABASE", "btc_stamps"))
+    with conn.cursor() as cur:
+        cur.execute(
+            """CREATE TEMPORARY TABLE _pp_tx (
+                 tx_index BIGINT, tx_hash CHAR(64), block_index INT, block_hash CHAR(64),
+                 block_time DATETIME, source VARCHAR(64), destination TEXT, btc_amount BIGINT,
+                 fee BIGINT, fee_rate_sat_vb DOUBLE, data BLOB, keyburn TINYINT)"""
+        )
+        rows = [
+            (i, "%064x" % i, 900000, "%064x" % 0, "2024-01-01 00:00:00",
+             "bc1qexamplesource", "bc1qexampledest", 0, 1430, 5.0,
+             b'{"p":"src-20","op":"transfer","tick":"TEST","amt":"1000"}', 1)
+            for i in range(nrows)
+        ]
+        s = time.perf_counter()
+        cur.executemany(
+            "INSERT INTO _pp_tx VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", rows
+        )
+        conn.commit()
+        ms = (time.perf_counter() - s) * 1000.0
+        cur.execute("DROP TEMPORARY TABLE _pp_tx")
+    conn.close()
+    return ms
+
+
+def main():
+    blocks = [int(b) for b in sys.argv[1:]] or [867000, 920000, 951939, 955000]
+    print(f"{'block':>8} {'ntx':>6} {'hash_ms':>8} {'insert/blk_ms':>14}")
+    for h in blocks:
+        raw = B.rpc("getblock", [B.getblockhash(h), 0])
+        thl, rawtx, *_ = PARSER.parse_block(raw)
+        hm = hashing_cost(thl)
+        # the indexer only inserts stamp txs (data != None); ~candidate count per block.
+        infos = PARSER.batch_parse_transactions(list(rawtx.values()))
+        ncand = len(infos)
+        im = db_insert_cost(max(ncand, 1))
+        print(f"{h:>8} {len(thl):>6} {hm:>8.1f} {im:>14.1f}  (stamp_rows={ncand})")
+
+    print("\n--- DB insert scaling (rows -> ms, temp table) ---")
+    for n in (10, 100, 1000, 5000):
+        print(f"  {n:>5} rows: {db_insert_cost(n):.0f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/tools/debug/probe_phases.py
+++ b/indexer/tools/debug/probe_phases.py
@@ -15,6 +15,7 @@ measured here — that path is owned by the #754/#756 work.
 
 Usage: poetry run python tools/debug/probe_phases.py [block ...]
 """
+
 import hashlib
 import os
 import sys
@@ -37,24 +38,37 @@ def hashing_cost(txhash_list):
 
 
 def db_insert_cost(nrows):
-    conn = pymysql.connect(host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"), port=int(os.environ.get("RDS_PORT", "3306")), user=os.environ.get("RDS_USER", "root"), password=os.environ.get("RDS_PASSWORD", ""), database=os.environ.get("RDS_DATABASE", "btc_stamps"))
+    conn = pymysql.connect(
+        host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"),
+        port=int(os.environ.get("RDS_PORT", "3306")),
+        user=os.environ.get("RDS_USER", "root"),
+        password=os.environ.get("RDS_PASSWORD", ""),
+        database=os.environ.get("RDS_DATABASE", "btc_stamps"),
+    )
     with conn.cursor() as cur:
-        cur.execute(
-            """CREATE TEMPORARY TABLE _pp_tx (
+        cur.execute("""CREATE TEMPORARY TABLE _pp_tx (
                  tx_index BIGINT, tx_hash CHAR(64), block_index INT, block_hash CHAR(64),
                  block_time DATETIME, source VARCHAR(64), destination TEXT, btc_amount BIGINT,
-                 fee BIGINT, fee_rate_sat_vb DOUBLE, data BLOB, keyburn TINYINT)"""
-        )
+                 fee BIGINT, fee_rate_sat_vb DOUBLE, data BLOB, keyburn TINYINT)""")
         rows = [
-            (i, "%064x" % i, 900000, "%064x" % 0, "2024-01-01 00:00:00",
-             "bc1qexamplesource", "bc1qexampledest", 0, 1430, 5.0,
-             b'{"p":"src-20","op":"transfer","tick":"TEST","amt":"1000"}', 1)
+            (
+                i,
+                "%064x" % i,
+                900000,
+                "%064x" % 0,
+                "2024-01-01 00:00:00",
+                "bc1qexamplesource",
+                "bc1qexampledest",
+                0,
+                1430,
+                5.0,
+                b'{"p":"src-20","op":"transfer","tick":"TEST","amt":"1000"}',
+                1,
+            )
             for i in range(nrows)
         ]
         s = time.perf_counter()
-        cur.executemany(
-            "INSERT INTO _pp_tx VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", rows
-        )
+        cur.executemany("INSERT INTO _pp_tx VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", rows)
         conn.commit()
         ms = (time.perf_counter() - s) * 1000.0
         cur.execute("DROP TEMPORARY TABLE _pp_tx")

--- a/indexer/tools/debug/scan_issue749.py
+++ b/indexer/tools/debug/scan_issue749.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Scan for transactions affected by issue #749: a valid bare-multisig SRC-20 stamp
+whose data is silently dropped because the tx also has a P2WSH output (idx>0)
+that shadows the multisig branch in get_tx_info().
+
+Strategy (see issue #749 analysis):
+  1. Every affected tx MUST carry a keyburn pubkey (valid multisig SRC-20 needs
+     keyburn==1). Burnkeys are fixed 33-byte constants, so we byte-search each
+     raw block's hex for them instead of deserializing every tx.
+  2. For burnkey-hit blocks we deserialize and, per tx, mirror get_tx_info()'s
+     exact SRC-20 branch logic (reusing index_core.script / index_core.arc4 /
+     config so we don't diverge from consensus).
+  3. affected = (P2WSH chunk present) AND (P2WSH path yields NO stamp data)
+               AND (multisig path WOULD yield valid stamp data).
+     These are exactly the txs get_tx_info drops via its `elif` short-circuit.
+  4. Cross-check: affected txids must be ABSENT from the `transactions` table.
+
+Usage:
+  poetry run python tools/debug/scan_issue749.py --start 865000 --end 870000 [--workers 1]
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+sys.path.insert(0, "src")
+import config  # noqa: E402
+import index_core.arc4 as arc4  # noqa: E402
+import index_core.script as script  # noqa: E402
+from bitcoin.core import CBlock  # noqa: E402
+
+RPC_URL = os.environ.get("RPC_URL", f"http://{os.environ.get('RPC_IP', '127.0.0.1')}:{os.environ.get('RPC_PORT', '8332')}")
+RPC_AUTH = base64.b64encode(f"{os.environ.get('RPC_USER', 'rpc')}:{os.environ.get('RPC_PASSWORD', 'rpc')}".encode()).decode()
+PREFIX = config.PREFIX
+OLGA = config.BTC_SRC20_OLGA_BLOCK
+BURNKEYS = [bytes.fromhex(b) for b in config.BURNKEYS]
+
+
+def rpc(method, params):
+    body = json.dumps({"jsonrpc": "1.0", "id": "s", "method": method, "params": params}).encode()
+    req = urllib.request.Request(
+        RPC_URL, data=body, headers={"Authorization": "Basic " + RPC_AUTH, "Content-Type": "text/plain"}
+    )
+    for attempt in range(5):
+        try:
+            return json.load(urllib.request.urlopen(req, timeout=120))["result"]
+        except Exception as e:
+            if attempt == 4:
+                raise
+            time.sleep(0.5 * (attempt + 1))
+
+
+def multisig_yields_data(ctx, pubkeys_compiled):
+    """Mirror decode_checkmultisig() data-extraction: RC4 + PREFIX + length check."""
+    if not pubkeys_compiled:
+        return None
+    chunk = b"".join(pubkey[1:-1] for pubkey in pubkeys_compiled)
+    key = arc4.init_arc4(ctx.vin[0].prevout.hash[::-1])
+    chunk = arc4.arc4_decrypt_chunk(chunk, key)
+    if chunk[2 : 2 + len(PREFIX)] == PREFIX:
+        n = int(chunk[:2].hex(), 16)
+        if len(chunk) < 2 + n:
+            return None  # DecodeError("invalid data length")
+        data = chunk[2 + len(PREFIX) : 2 + n]
+        return data or None
+    return None
+
+
+def p2wsh_yields_data(p2wsh_data_chunks):
+    """Mirror get_tx_info() P2WSH SRC-20 path: returns extracted data or None."""
+    if not p2wsh_data_chunks:
+        return None
+    p2wsh = b"".join(p2wsh_data_chunks).rstrip(b"\x00")
+    if p2wsh and len(p2wsh) >= 2 + len(PREFIX):
+        n = int.from_bytes(p2wsh[:2], byteorder="big")
+        if len(p2wsh) >= 2 + n:
+            data_chunk = p2wsh[2 : 2 + n]
+            if data_chunk.startswith(PREFIX):
+                return data_chunk[len(PREFIX) :] or None
+    return None
+
+
+def classify_tx(ctx, block_index):
+    """Return (affected: bool, decoded_multisig_data_or_None, has_p2wsh_chunk: bool)."""
+    pubkeys_compiled = []
+    p2wsh_data_chunks = []
+    keyburn = None
+    for idx, vout in enumerate(ctx.vout):
+        try:
+            asm = script.get_asm(vout.scriptPubKey)
+        except Exception:
+            continue
+        if not asm:
+            continue
+        if asm[-1] == "OP_CHECKMULTISIG":
+            try:
+                pubkeys, _req, kb = script.get_checkmultisig(asm)
+            except Exception:
+                continue
+            if kb is not None:
+                keyburn = kb
+            pubkeys_compiled += list(pubkeys)
+        elif asm[0] == "OP_RETURN":
+            pass
+        elif asm[0] == 0 and len(asm[1]) == 32:
+            if block_index >= OLGA and idx > 0:
+                p2wsh_data_chunks.append(asm[1])
+
+    ms_data = multisig_yields_data(ctx, pubkeys_compiled)
+    p2_data = p2wsh_yields_data(p2wsh_data_chunks)
+    # Affected: get_tx_info enters the `if p2wsh_data_chunks` branch (because chunks
+    # exist), it produces no data, and the `elif` multisig branch (which WOULD have
+    # produced data) is never reached.
+    affected = bool(p2wsh_data_chunks) and p2_data is None and ms_data is not None and keyburn == 1
+    return affected, ms_data, bool(p2wsh_data_chunks), (ms_data is not None and keyburn == 1)
+
+
+def scan_block(height):
+    bh = rpc("getblockhash", [height])
+    raw = rpc("getblock", [bh, 0])
+    rawb = bytes.fromhex(raw)
+    if not any(bk in rawb for bk in BURNKEYS):
+        return height, [], 0  # no burnkey -> no multisig stamp -> not affected
+    block = CBlock.deserialize(rawb)
+    affected = []
+    clean_ms = 0
+    for tx in block.vtx:
+        try:
+            is_aff, ms_data, has_p2wsh, valid_ms = classify_tx(tx, height)
+        except Exception:
+            continue
+        if valid_ms and not has_p2wsh:
+            clean_ms += 1  # ordinary multisig stamp, should be in transactions table
+        if is_aff:
+            txid = tx.GetTxid()[::-1].hex()
+            try:
+                payload = ms_data.decode("utf-8", "replace")
+            except Exception:
+                payload = ms_data.hex()
+            affected.append({"txid": txid, "block": height, "data": payload})
+    return height, affected, clean_ms
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", type=int, required=True)
+    ap.add_argument("--end", type=int, required=True)
+    ap.add_argument("--workers", type=int, default=1)
+    ap.add_argument("--out", default="/tmp/issue749_affected.json")
+    args = ap.parse_args()
+
+    heights = list(range(args.start, args.end + 1))
+    t0 = time.time()
+    affected_all = []
+    clean_total = 0
+    burnkey_blocks = 0
+    done = 0
+
+    def emit_progress():
+        el = time.time() - t0
+        rate = done / el if el else 0
+        eta = (len(heights) - done) / rate / 60 if rate else 0
+        print(
+            f"  [{done}/{len(heights)}] {el:.0f}s  {rate:.1f} blk/s  ETA {eta:.1f}m  "
+            f"affected={len(affected_all)} burnkey_blks={burnkey_blocks} clean_ms={clean_total}",
+            flush=True,
+        )
+
+    if args.workers <= 1:
+        for h in heights:
+            _, aff, clean = scan_block(h)
+            if aff:
+                burnkey_blocks += 1  # at least had a burnkey + candidate; recount below
+            affected_all += aff
+            clean_total += clean
+            done += 1
+            if done % 250 == 0:
+                emit_progress()
+    else:
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            futs = {ex.submit(scan_block, h): h for h in heights}
+            for fut in as_completed(futs):
+                _, aff, clean = fut.result()
+                affected_all += aff
+                clean_total += clean
+                done += 1
+                if done % 250 == 0:
+                    emit_progress()
+
+    el = time.time() - t0
+    print(f"\nDONE {args.start}-{args.end}: {len(heights)} blocks in {el:.0f}s ({len(heights)/el:.1f} blk/s)")
+    print(f"affected(pre-DB-check)={len(affected_all)}  clean_multisig_stamps={clean_total}")
+    with open(args.out, "w") as f:
+        json.dump(affected_all, f, indent=2)
+    print(f"wrote {args.out}")
+    for a in affected_all[:25]:
+        print("  AFFECTED", a["txid"], a["block"], a["data"][:90])
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/tools/debug/scan_issue749.py
+++ b/indexer/tools/debug/scan_issue749.py
@@ -19,6 +19,7 @@ Strategy (see issue #749 analysis):
 Usage:
   poetry run python tools/debug/scan_issue749.py --start 865000 --end 870000 [--workers 1]
 """
+
 import argparse
 import base64
 import json

--- a/indexer/tools/debug/scan_issue749_fast.py
+++ b/indexer/tools/debug/scan_issue749_fast.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Fast scan for issue #749 affected txs, using the native (rayon-parallel) Rust
+parser. batch_parse_transactions returns the prefilter-accepted candidates
+ALREADY deserialized (EnhancedCTransaction._ctx) plus {should_include,
+has_valid_data, keyburn} — so the heavy work (deserialize every tx + filter)
+happens in Rust across all cores; Python only classifies the tiny dropped set.
+
+Per block:
+  1. getblock v0 (raw hex)               -> cheap fetch
+  2. parser.parse_block(raw)             -> all per-tx hexes (native)
+  3. parser.batch_parse_transactions(..) -> prefilter-accepted candidates (native)
+  4. dropped = accepted candidates NOT present in the `transactions` table
+  5. classify each dropped tx (on the Rust-deserialized ._ctx) and bucket by reason:
+       multisig_shadowed_by_p2wsh  <- issue #749 (the target)
+       multisig_valid_but_dropped  <- valid multisig stamp dropped, no p2wsh (unexpected)
+       p2wsh_valid_but_dropped     <- valid OLGA data dropped (unexpected, other bug)
+       prefilter_false_positive    <- no valid stamp data either path (legit skip)
+
+Usage:
+  poetry run python tools/debug/scan_issue749_fast.py --start 865000 --end 955722
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.request
+from collections import Counter
+
+sys.path.insert(0, "src")
+import config  # noqa: E402
+import index_core.arc4 as arc4  # noqa: E402
+import index_core.script as script  # noqa: E402
+import pymysql  # noqa: E402
+from index_core.transaction_utils import backend_instance  # noqa: E402
+
+PREFIX = config.PREFIX
+OLGA = config.BTC_SRC20_OLGA_BLOCK
+PARSER = backend_instance._parser
+RPC_URL = os.environ.get("RPC_URL", f"http://{os.environ.get('RPC_IP', '127.0.0.1')}:{os.environ.get('RPC_PORT', '8332')}")
+RPC_AUTH = base64.b64encode(f"{os.environ.get('RPC_USER', 'rpc')}:{os.environ.get('RPC_PASSWORD', 'rpc')}".encode()).decode()
+
+
+def rpc(method, params):
+    body = json.dumps({"jsonrpc": "1.0", "id": "s", "method": method, "params": params}).encode()
+    req = urllib.request.Request(
+        RPC_URL, data=body, headers={"Authorization": "Basic " + RPC_AUTH, "Content-Type": "text/plain"}
+    )
+    for attempt in range(5):
+        try:
+            return json.load(urllib.request.urlopen(req, timeout=180))["result"]
+        except Exception:
+            if attempt == 4:
+                raise
+            time.sleep(0.5 * (attempt + 1))
+
+
+def load_indexed_txids():
+    conn = pymysql.connect(host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"), port=int(os.environ.get("RDS_PORT", "3306")), user=os.environ.get("RDS_USER", "root"), password=os.environ.get("RDS_PASSWORD", ""), database=os.environ.get("RDS_DATABASE", "btc_stamps"))
+    ids = set()
+    with conn.cursor() as cur:
+        cur.execute("SELECT tx_hash FROM transactions WHERE block_index >= %s", (OLGA,))
+        for (h,) in cur.fetchall():
+            ids.add(h)
+    conn.close()
+    return ids
+
+
+def classify(ctx, block_index):
+    """Mirror get_tx_info() decode on a deserialized ctx.
+    Returns (reason, multisig_data_or_None)."""
+    pubkeys_compiled = []
+    keyburn = None
+    p2wsh_chunks = []
+    for idx, vout in enumerate(ctx.vout):
+        try:
+            asm = script.get_asm(vout.scriptPubKey)
+        except Exception:
+            continue
+        if not asm:
+            continue
+        if asm[-1] == "OP_CHECKMULTISIG":
+            try:
+                pubkeys, _r, kb = script.get_checkmultisig(asm)
+            except Exception:
+                continue
+            if kb is not None:
+                keyburn = kb
+            pubkeys_compiled += list(pubkeys)
+        elif asm[0] == 0 and len(asm[1]) == 32 and idx > 0 and block_index >= OLGA:
+            p2wsh_chunks.append(asm[1])
+
+    # multisig path (decode_checkmultisig data extraction)
+    ms = None
+    if pubkeys_compiled and keyburn == 1:
+        chunk = b"".join(pk[1:-1] for pk in pubkeys_compiled)
+        chunk = arc4.arc4_decrypt_chunk(chunk, arc4.init_arc4(ctx.vin[0].prevout.hash[::-1]))
+        if chunk[2 : 2 + len(PREFIX)] == PREFIX:
+            n = int(chunk[:2].hex(), 16)
+            if len(chunk) >= 2 + n:
+                ms = chunk[2 + len(PREFIX) : 2 + n] or None
+
+    # p2wsh path (get_tx_info SRC-20 branch)
+    p2 = None
+    has_p2wsh = bool(p2wsh_chunks)
+    if has_p2wsh:
+        pj = b"".join(p2wsh_chunks).rstrip(b"\x00")
+        if pj and len(pj) >= 2 + len(PREFIX):
+            n = int.from_bytes(pj[:2], "big")
+            if len(pj) >= 2 + n and pj[2 : 2 + n].startswith(PREFIX):
+                p2 = pj[2 + len(PREFIX) : 2 + n] or None
+
+    if ms is not None and has_p2wsh and p2 is None:
+        return "multisig_shadowed_by_p2wsh", ms
+    if ms is not None and not has_p2wsh:
+        return "multisig_valid_but_dropped", ms
+    if p2 is not None:
+        return "p2wsh_valid_but_dropped", p2
+    return "prefilter_false_positive", None
+
+
+def scan_block(height, indexed):
+    raw = rpc("getblock", [rpc("getblockhash", [height]), 0])
+    _thl, rawtx, *_ = PARSER.parse_block(raw)
+    infos = PARSER.batch_parse_transactions(list(rawtx.values()))
+    out = []
+    for info in infos:
+        txid = info._extra_attrs.get("txid")
+        if txid in indexed:
+            continue  # successfully indexed -> not dropped
+        reason, data = classify(info._ctx, height)
+        if reason == "prefilter_false_positive":
+            continue  # legitimately not a stamp; skip noise
+        try:
+            payload = data.decode("utf-8", "replace") if data else ""
+        except Exception:
+            payload = data.hex() if data else ""
+        out.append({"txid": txid, "block": height, "reason": reason, "data": payload})
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", type=int, required=True)
+    ap.add_argument("--end", type=int, required=True)
+    ap.add_argument("--out", default="/tmp/issue749_affected.json")
+    ap.add_argument("--sleep", type=float, default=0.0, help="seconds to sleep between blocks (throttle shared bitcoind)")
+    args = ap.parse_args()
+
+    print(f"loading indexed txids (block >= {OLGA}) ...", flush=True)
+    indexed = load_indexed_txids()
+    print(f"  {len(indexed)} indexed txids loaded", flush=True)
+
+    heights = list(range(args.start, args.end + 1))
+    t0 = time.time()
+    found = []
+    done = 0
+    for h in heights:
+        try:
+            found += scan_block(h, indexed)
+        except Exception as e:
+            print(f"  block {h} error: {e}", flush=True)
+        done += 1
+        if args.sleep:
+            time.sleep(args.sleep)
+        if done % 500 == 0:
+            el = time.time() - t0
+            rate = done / el
+            eta = (len(heights) - done) / rate / 60
+            print(
+                f"  [{done}/{len(heights)}] {el:.0f}s {rate:.1f} blk/s ETA {eta:.1f}m found={len(found)}",
+                flush=True,
+            )
+            with open(args.out, "w") as f:  # checkpoint
+                json.dump(found, f, indent=2)
+
+    el = time.time() - t0
+    found.sort(key=lambda a: a["block"])
+    with open(args.out, "w") as f:
+        json.dump(found, f, indent=2)
+    print(f"\nDONE {args.start}-{args.end}: {len(heights)} blocks in {el/60:.1f} min ({len(heights)/el:.1f} blk/s)")
+    print(f"total flagged = {len(found)}")
+    print("by reason:", dict(Counter(a["reason"] for a in found)))
+    print(f"-> {args.out}")
+    for a in found[:40]:
+        print("  ", a["block"], a["txid"], a["reason"], a["data"][:70])
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/tools/debug/scan_issue749_fast.py
+++ b/indexer/tools/debug/scan_issue749_fast.py
@@ -20,6 +20,7 @@ Per block:
 Usage:
   poetry run python tools/debug/scan_issue749_fast.py --start 865000 --end 955722
 """
+
 import argparse
 import base64
 import json
@@ -58,7 +59,13 @@ def rpc(method, params):
 
 
 def load_indexed_txids():
-    conn = pymysql.connect(host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"), port=int(os.environ.get("RDS_PORT", "3306")), user=os.environ.get("RDS_USER", "root"), password=os.environ.get("RDS_PASSWORD", ""), database=os.environ.get("RDS_DATABASE", "btc_stamps"))
+    conn = pymysql.connect(
+        host=os.environ.get("RDS_HOSTNAME", "127.0.0.1"),
+        port=int(os.environ.get("RDS_PORT", "3306")),
+        user=os.environ.get("RDS_USER", "root"),
+        password=os.environ.get("RDS_PASSWORD", ""),
+        database=os.environ.get("RDS_DATABASE", "btc_stamps"),
+    )
     ids = set()
     with conn.cursor() as cur:
         cur.execute("SELECT tx_hash FROM transactions WHERE block_index >= %s", (OLGA,))


### PR DESCRIPTION
Adds the scan + profiling scripts written while diagnosing the #749 consensus bug and profiling per-block performance (#817), so they're version-controlled for future research/evidence rather than living as untracked files.

### Added to `indexer/tools/debug/`
- **scan_issue749_fast.py** — for each block, takes the Rust prefilter's accepted candidates, subtracts txids present in `transactions`, and classifies the remainder against the `get_tx_info` decode logic. Used to prove the **#749 blast radius is a single transaction** across the post-OLGA range. `--sleep` throttles load on a shared bitcoind.
- **scan_issue749.py** — slower standalone variant (burnkey byte-scan + Python classify; no DB needed).
- **perf_probe.py / probe_phases.py** — the per-block profiling harness behind **#817** (the `prev_tx` source-lookup hotspot → #818/#822, the redundant-parse finding → #794, and the PREWARM net-negative result → #820).

### Notes
- Credentials read from the standard env vars (`RPC_*` / `RDS_*`); **none hard-coded**.
- Read-only against node/DB (the scans never write; `--sleep` available to spare shared infra).
- `README.md` updated with usage + a short "research/evidence tools" section.

Refs #749, #817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)