### PR TITLE
style(#749,#817): fix black + isort on debug tools merged via #826

### DIFF
--- a/indexer/tools/debug/perf_probe.py
+++ b/indexer/tools/debug/perf_probe.py
@@ -23,9 +23,10 @@ import sys
 import time
 
 sys.path.insert(0, "src")
+import pymysql  # noqa: E402
+
 import config  # noqa: E402
 import index_core.util as util  # noqa: E402
-import pymysql  # noqa: E402
 from index_core.block_validation import filter_block_transactions  # noqa: E402
 from index_core.transaction_utils import backend_instance as B  # noqa: E402
 from index_core.transaction_utils import get_tx_info  # noqa: E402

--- a/indexer/tools/debug/probe_phases.py
+++ b/indexer/tools/debug/probe_phases.py
@@ -23,6 +23,7 @@ import time
 
 sys.path.insert(0, "src")
 import pymysql  # noqa: E402
+
 from index_core.transaction_utils import backend_instance as B  # noqa: E402
 
 PARSER = B._parser

--- a/indexer/tools/debug/scan_issue749.py
+++ b/indexer/tools/debug/scan_issue749.py
@@ -30,10 +30,11 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 sys.path.insert(0, "src")
+from bitcoin.core import CBlock  # noqa: E402
+
 import config  # noqa: E402
 import index_core.arc4 as arc4  # noqa: E402
 import index_core.script as script  # noqa: E402
-from bitcoin.core import CBlock  # noqa: E402
 
 RPC_URL = os.environ.get("RPC_URL", f"http://{os.environ.get('RPC_IP', '127.0.0.1')}:{os.environ.get('RPC_PORT', '8332')}")
 RPC_AUTH = base64.b64encode(f"{os.environ.get('RPC_USER', 'rpc')}:{os.environ.get('RPC_PASSWORD', 'rpc')}".encode()).decode()

--- a/indexer/tools/debug/scan_issue749_fast.py
+++ b/indexer/tools/debug/scan_issue749_fast.py
@@ -31,10 +31,11 @@ import urllib.request
 from collections import Counter
 
 sys.path.insert(0, "src")
+import pymysql  # noqa: E402
+
 import config  # noqa: E402
 import index_core.arc4 as arc4  # noqa: E402
 import index_core.script as script  # noqa: E402
-import pymysql  # noqa: E402
 from index_core.transaction_utils import backend_instance  # noqa: E402
 
 PREFIX = config.PREFIX


### PR DESCRIPTION
#826 was squash-merged before its formatting-fix commits landed on the branch, so the four debug scripts added to `indexer/tools/debug/` currently **fail `black` and `isort`** on `dev` (this is what failed CI on #826).

This PR applies `black` (line-length 127) and `isort` (profile=black) to:
- `scan_issue749.py`, `scan_issue749_fast.py`, `perf_probe.py`, `probe_phases.py`

No logic changes — formatting only. Verified locally: `black --check` and `isort --check-only` both pass; all four parse clean.

Refs #749, #817. Follow-up to #826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)