### PR TITLE
fix(#821): CP-readiness re-poll + adaptive wait (tip latency)

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -138,6 +138,18 @@ ZMQ_TX_PORT: int = int(ZMQ_PORT_MAINNET_TX)
 ZMQ_BLOCK_PORT: int = int(ZMQ_PORT_MAINNET_BLOCK)
 ZMQ_NOTIFICATION_DELAY = float(os.environ.get("ZMQ_NOTIFICATION_DELAY", "5.0"))  # Delay in seconds after ZMQ notification
 
+# CP-readiness gate (issue #821): how long the indexer waits for Counterparty to
+# finish processing a block at chain tip before proceeding. The ZMQ tip path now
+# actively re-polls the SAME pending block (processing is strictly in-order, so
+# this is safe) instead of deferring to the next ZMQ notification, so a transient
+# CP parse spike no longer costs a full block interval. The per-attempt window was
+# a fixed 25s, below observed real spikes (35s, 164s); it is now 60s and bounded
+# by an overall re-poll cap so a genuinely stuck CP still surfaces. Keep the
+# re-poll interval modest (>= a couple seconds): the CP node is shared.
+CP_READY_MAX_WAIT = float(os.environ.get("CP_READY_MAX_WAIT", "60.0"))  # per-attempt wait window (was a fixed 25s)
+CP_READY_REPOLL_INTERVAL = float(os.environ.get("CP_READY_REPOLL_INTERVAL", "5.0"))  # gap between re-poll attempts
+CP_READY_REPOLL_MAX = float(os.environ.get("CP_READY_REPOLL_MAX", "300.0"))  # overall bound so a stuck CP still surfaces
+
 # CP RPC Configuration
 # Configuration hierarchy (first non-empty wins):
 # 1. CP_NODE_POOL - Advanced: comma-separated list of name::url pairs for multiple nodes

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -2088,11 +2088,18 @@ def follow(
                                         )
                                         time.sleep(delay_seconds)
 
-                                        # Verify CP has actually processed the block
-                                        from index_core.fetch_utils import wait_for_cp_block_processed
+                                        # Verify CP has actually processed the block. Actively re-poll the
+                                        # SAME pending block (issue #821) instead of deferring to the next
+                                        # ZMQ notification on a transient miss: processing is in-order, so a
+                                        # short bounded re-poll cuts multi-minute tip latency. Only after the
+                                        # overall bound is exhausted do we fall back to the next notification.
+                                        from index_core.fetch_utils import wait_for_cp_block_ready_with_repoll
 
-                                        if not wait_for_cp_block_processed(block_tip, max_wait=25.0):
-                                            logger.warning(f"CP not ready for block {block_tip}, will retry")
+                                        if not wait_for_cp_block_ready_with_repoll(block_tip):
+                                            logger.warning(
+                                                f"CP still not ready for block {block_tip} after re-poll bound; "
+                                                "deferring to next notification"
+                                            )
                                             time.sleep(config.BACKEND_POLL_INTERVAL)
                                             continue
 

--- a/indexer/src/index_core/fetch_utils.py
+++ b/indexer/src/index_core/fetch_utils.py
@@ -1831,6 +1831,70 @@ def wait_for_cp_block_processed(block_index: int, max_wait: float = 30.0, check_
     return False
 
 
+def wait_for_cp_block_ready_with_repoll(
+    block_index: int,
+    max_wait: Optional[float] = None,
+    repoll_interval: Optional[float] = None,
+    repoll_max: Optional[float] = None,
+) -> bool:
+    """
+    Actively re-poll CP readiness for a SINGLE pending block (issue #821).
+
+    Wraps ``wait_for_cp_block_processed`` in a bounded re-poll loop. On the ZMQ
+    tip path a transient "CP not ready" used to defer the block until the *next*
+    ZMQ notification arrived, costing a whole block interval (~14 min observed).
+    Because block processing is strictly in-order (we cannot index N+1 before N),
+    re-polling the SAME pending block is safe and lets us proceed as soon as CP
+    catches up.
+
+    The readiness gate itself (cp_height >= block AND db_caught_up) is unchanged:
+    this only changes the wait/retry cadence. Returns True as soon as the gate
+    passes, or False once the overall re-poll bound (``repoll_max``) is exhausted
+    so a genuinely stuck CP still surfaces to the caller.
+
+    Args:
+        block_index: The pending block to wait for.
+        max_wait: Per-attempt wait window. Defaults to ``config.CP_READY_MAX_WAIT``.
+        repoll_interval: Sleep between re-poll attempts. Defaults to
+            ``config.CP_READY_REPOLL_INTERVAL`` (kept modest; the CP node is shared).
+        repoll_max: Overall bound across all attempts. Defaults to
+            ``config.CP_READY_REPOLL_MAX``.
+
+    Returns:
+        True if CP became ready within the overall bound, False otherwise.
+    """
+    # Resolve config at call-time so env/test overrides are honored.
+    if max_wait is None:
+        max_wait = config.CP_READY_MAX_WAIT
+    if repoll_interval is None:
+        repoll_interval = config.CP_READY_REPOLL_INTERVAL
+    if repoll_max is None:
+        repoll_max = config.CP_READY_REPOLL_MAX
+
+    overall_start = time.time()
+    attempt = 0
+    while True:
+        attempt += 1
+        # Use the modest re-poll interval as the inner check cadence too, so total
+        # polling load stays at roughly one request per interval.
+        if wait_for_cp_block_processed(block_index, max_wait=max_wait, check_interval=repoll_interval):
+            return True
+
+        elapsed = time.time() - overall_start
+        if elapsed >= repoll_max:
+            logger.warning(
+                f"CP still not ready for block {block_index} after re-polling for {elapsed:.0f}s "
+                f"(bound={repoll_max}s, attempts={attempt}); surfacing to caller"
+            )
+            return False
+
+        logger.info(
+            f"CP not ready for block {block_index} (attempt {attempt}, {elapsed:.0f}s elapsed); "
+            f"re-polling same pending block in {repoll_interval}s"
+        )
+        time.sleep(repoll_interval)
+
+
 def get_xcp_block_hashes_batch(start_block: int, end_block: int) -> Dict[int, Optional[str]]:
     """Get block hashes for a range of blocks with caching and batching optimization."""
     results = {}

--- a/indexer/tests/test_cp_readiness_repoll.py
+++ b/indexer/tests/test_cp_readiness_repoll.py
@@ -1,0 +1,136 @@
+"""
+Tests for the active CP-readiness re-poll helper (issue #821).
+
+At chain tip a transient "CP not ready" used to defer a block until the *next*
+ZMQ notification arrived, costing a whole block interval (~14 min observed).
+``wait_for_cp_block_ready_with_repoll`` instead re-polls the SAME pending block
+on a short, bounded cadence so the indexer proceeds as soon as CP catches up.
+
+These tests verify (with all sleeps mocked, deterministically):
+1. transient not-ready -> ready re-polls and proceeds WITHOUT a new ZMQ
+   notification (the core regression);
+2. the overall re-poll bound is respected (gives up, does not spin forever);
+3. the readiness gate is NOT loosened: ``db_caught_up=False`` still blocks;
+4. config knobs are resolved at call-time (env/test overrides honored).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import config
+from src.index_core.fetch_utils import (
+    wait_for_cp_block_processed,
+    wait_for_cp_block_ready_with_repoll,
+)
+
+
+@pytest.mark.unit
+class TestCPReadinessRepoll:
+    """Bounded re-poll loop around wait_for_cp_block_processed."""
+
+    def test_transient_not_ready_then_ready_proceeds_without_new_notification(self):
+        """Core regression: a transient miss re-polls the SAME block and proceeds.
+
+        We do NOT wait for a new ZMQ notification; the helper itself retries.
+        """
+        with patch(
+            "src.index_core.fetch_utils.wait_for_cp_block_processed",
+            side_effect=[False, True],
+        ) as mock_wait:
+            with patch("time.sleep") as mock_sleep:
+                result = wait_for_cp_block_ready_with_repoll(850000, max_wait=60.0, repoll_interval=5.0, repoll_max=300.0)
+
+        assert result is True
+        assert mock_wait.call_count == 2  # re-polled the same pending block once
+        assert mock_sleep.call_count == 1  # slept once between attempts
+
+    def test_immediate_ready_does_not_sleep(self):
+        """If CP is already ready, return True without any re-poll sleep."""
+        with patch(
+            "src.index_core.fetch_utils.wait_for_cp_block_processed",
+            return_value=True,
+        ) as mock_wait:
+            with patch("time.sleep") as mock_sleep:
+                result = wait_for_cp_block_ready_with_repoll(850000, max_wait=60.0, repoll_interval=5.0, repoll_max=300.0)
+
+        assert result is True
+        assert mock_wait.call_count == 1
+        assert mock_sleep.call_count == 0
+
+    def test_overall_bound_respected_gives_up(self):
+        """A genuinely stuck CP surfaces (returns False) after the bound, no infinite spin."""
+        clock = {"t": 1000.0}
+
+        def fake_time():
+            return clock["t"]
+
+        def fake_sleep(seconds):
+            clock["t"] += seconds
+
+        with patch(
+            "src.index_core.fetch_utils.wait_for_cp_block_processed",
+            return_value=False,
+        ) as mock_wait:
+            with patch("time.sleep", side_effect=fake_sleep):
+                with patch("time.time", side_effect=fake_time):
+                    result = wait_for_cp_block_ready_with_repoll(850000, max_wait=10.0, repoll_interval=5.0, repoll_max=15.0)
+
+        assert result is False
+        # Bounded: start t=1000; attempts at elapsed 0,5,10 sleep each, attempt at
+        # elapsed 15 hits the bound and returns. 4 attempts, 3 sleeps.
+        assert mock_wait.call_count == 4
+        assert clock["t"] == 1015.0
+
+    def test_db_caught_up_false_still_blocks(self):
+        """The gate is NOT loosened: db_caught_up=False must keep blocking.
+
+        Exercises the real wait_for_cp_block_processed (height ok, db_caught_up
+        False) and confirms it times out to False, then the re-poll helper also
+        surfaces False after its bound.
+        """
+        not_caught_up = {"last_block": 850000, "db_caught_up": False, "version": "10.1.0"}
+        nodes = [{"url": "http://test-node:4000"}]
+
+        clock = {"t": 1000.0}
+
+        def fake_time():
+            return clock["t"]
+
+        def fake_sleep(seconds):
+            clock["t"] += seconds
+
+        with patch("src.index_core.fetch_utils.get_healthy_nodes", return_value=nodes):
+            with patch(
+                "src.index_core.fetch_utils.fetch_node_version_v2",
+                return_value=(True, not_caught_up),
+            ):
+                with patch("time.sleep", side_effect=fake_sleep):
+                    with patch("time.time", side_effect=fake_time):
+                        # Direct gate check: height is sufficient but db not caught up -> False.
+                        direct = wait_for_cp_block_processed(850000, max_wait=4.0, check_interval=2.0)
+                        assert direct is False
+
+                        # Reset clock for the re-poll wrapper and confirm it also surfaces False.
+                        clock["t"] = 1000.0
+                        wrapped = wait_for_cp_block_ready_with_repoll(
+                            850000, max_wait=4.0, repoll_interval=2.0, repoll_max=8.0
+                        )
+                        assert wrapped is False
+
+    def test_config_resolved_at_call_time(self, monkeypatch):
+        """When args are omitted, the helper reads CP_READY_* from config at call-time."""
+        monkeypatch.setattr(config, "CP_READY_MAX_WAIT", 42.0, raising=False)
+        monkeypatch.setattr(config, "CP_READY_REPOLL_INTERVAL", 3.0, raising=False)
+        monkeypatch.setattr(config, "CP_READY_REPOLL_MAX", 99.0, raising=False)
+
+        with patch(
+            "src.index_core.fetch_utils.wait_for_cp_block_processed",
+            return_value=True,
+        ) as mock_wait:
+            with patch("time.sleep"):
+                result = wait_for_cp_block_ready_with_repoll(850000)
+
+        assert result is True
+        # Inner call uses the configured per-attempt window and the modest interval.
+        mock_wait.assert_called_once_with(850000, max_wait=42.0, check_interval=3.0)


### PR DESCRIPTION
## What

At chain tip the ZMQ path verified Counterparty (CP) readiness with a fixed 25s `wait_for_cp_block_processed`. On timeout it logged "will retry" and `continue`d, which only re-attempted the block when the **next ZMQ block notification arrived** — so a transient miss cost a full block interval (~14 min observed on block 955716) even though CP had parsed the block in 0.2s. The fixed 25s window was also below real CP parse spikes (35s, 164s observed), dropping transient spikes into that deferred path.

This PR:
- Adds `wait_for_cp_block_ready_with_repoll` — a bounded re-poll loop that keeps polling the **same pending block** instead of deferring to the next ZMQ notification. Processing is strictly in-order (we cannot index N+1 before N), so re-polling the pending block is safe.
- Makes the wait adaptive/configurable via new env-driven knobs in `config.py`.
- Wires the ZMQ tip call site to the new helper. Deferral to the next notification now happens **only after the overall re-poll bound is exhausted**, so a genuinely stuck CP still surfaces.

## Why

Cut multi-minute tip latency caused by transient CP-readiness misses and parse spikes exceeding the old fixed 25s window.

## Consensus-neutral

CP-readiness wait/retry cadence only; parse/hash/ledger untouched; `db_caught_up` gate unchanged. The readiness gate condition (`cp_height >= block AND db_caught_up`) is deliberately left intact — relaxing it is a correctness risk.

## New config knobs (defaults)

| Knob | Default | Purpose |
|------|---------|---------|
| `CP_READY_MAX_WAIT` | `60.0` | per-attempt wait window (up from a fixed 25s) |
| `CP_READY_REPOLL_INTERVAL` | `5.0` | gap between re-poll attempts (kept modest; shared CP node) |
| `CP_READY_REPOLL_MAX` | `300.0` | overall bound so a genuinely stuck CP still surfaces |

## Local validation (CI parity)

- `black --check` ✅  `isort --check-only` ✅  `flake8 src/` ✅
- `mypy src/ --explicit-package-bases` ✅ (no issues, 74 files)
- `task bandit` ✅ (exit 0)
- Full unit suite: **1883 passed, 26 skipped** (`-n auto -m "not requires_bitcoin_node and not integration"`)
- New focused tests (`tests/test_cp_readiness_repoll.py`, sleeps mocked): transient not-ready→ready re-polls and proceeds without a new ZMQ notification; overall bound is respected (no infinite spin); `db_caught_up=False` still blocks; config resolved at call-time.

**Final validation is operational**: observe tip latency against the shared CP node after merge.

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)