### PR TITLE
feat: flag-gated per-block perf logging (PERF_LOG, default off)

### DIFF
--- a/indexer/.env.sample
+++ b/indexer/.env.sample
@@ -258,6 +258,7 @@ DEBUG_PROFILING=false
 DEBUG_VALIDATION=false
 DEBUG_SKIP_REBUILD_BALANCES=false
 DISABLE_RUST_PARSER=false
+# PERF_LOG=true  PERF_LOG_PATH=perf_log.jsonl  — off by default; structured per-block timing for perf comparison
 
 # Testing environment variables
 # TESTING=1

--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -99,6 +99,12 @@ DEBUG_PROFILING = os.getenv("DEBUG_PROFILING", "false").lower() == "true"
 DISABLE_RUST_PARSER = os.environ.get("DISABLE_RUST_PARSER", "False").lower() == "true"
 DEBUG_VALIDATION = os.getenv("DEBUG_VALIDATION", "false").lower() == "true"
 
+# Structured per-block performance logging (off by default, consensus-neutral).
+# When enabled, the follow() loop appends one JSON object per block to
+# PERF_LOG_PATH with per-phase timings for reproducible perf comparison.
+PERF_LOG = os.environ.get("PERF_LOG", "false").lower() == "true"
+PERF_LOG_PATH = os.environ.get("PERF_LOG_PATH", "perf_log.jsonl")
+
 # Consensus error handling
 MAX_CONSENSUS_RETRIES = int(os.environ.get("MAX_CONSENSUS_RETRIES", "3"))  # Maximum retries for consensus hash mismatches
 

--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -72,6 +72,7 @@ from index_core.market_data_jobs import start_market_data_jobs
 from index_core.memory_manager import memory_manager
 from index_core.models import StampData, ValidStamp
 from index_core.node_health import is_shutdown_requested, register_shutdown_callback, set_shutdown_flag
+from index_core.perf_log import record_block_perf
 from index_core.pipeline_utils import CPBlocksPipeline
 from index_core.profiling import Profiler
 from index_core.resource_manager import cleanup_resources
@@ -1248,6 +1249,20 @@ def follow(
                     # Reset start_time to ensure accurate timing for each block
                     start_time = time.time()
 
+                    # Optional, consensus-neutral per-block perf logging (off by default).
+                    # All timers/counters are (re)initialised here so the emit path is
+                    # always well-defined regardless of which phases run for this block.
+                    perf_enabled = config.PERF_LOG
+                    if perf_enabled:
+                        perf_block_start = time.perf_counter()
+                        perf_t_fetch = 0.0
+                        perf_t_filter = 0.0
+                        perf_t_decode = 0.0
+                        perf_t_hash = 0.0
+                        perf_t_dbwrite = 0.0
+                        perf_n_txs = 0
+                        perf_n_candidates = 0
+
                     # Start profiling for this block
                     if profiler:
                         profiler.start_block_profiling()
@@ -1600,15 +1615,21 @@ def follow(
                         continue
 
                     # Get block hash and verify
+                    if perf_enabled:
+                        _perf_phase_start = time.perf_counter()
                     block_hash = backend_instance.getblockhash(block_index)
 
                     # Get full block data from backend
                     txhash_list_full, raw_transactions_full, block_time, previous_block_hash, difficulty = (
                         backend_instance.get_tx_list(block_hash)
                     )
+                    if perf_enabled:
+                        perf_t_fetch = time.perf_counter() - _perf_phase_start
 
                     # Log transaction counts for debugging
                     bitcoin_tx_count = len(txhash_list_full)
+                    if perf_enabled:
+                        perf_n_txs = bitcoin_tx_count
                     cp_tx_count = 0
                     if (
                         block_index in stamp_issuances_list
@@ -1678,7 +1699,12 @@ def follow(
                     block_data = {
                         "tx": [{"txid": tx_hash, "hex": raw_transactions_full[tx_hash]} for tx_hash in txhash_list_full]
                     }
+                    if perf_enabled:
+                        _perf_phase_start = time.perf_counter()
                     txhash_list, raw_transactions = filter_block_transactions(block_data, stamp_issuances=stamp_issuances)
+                    if perf_enabled:
+                        perf_t_filter = time.perf_counter() - _perf_phase_start
+                        perf_n_candidates = len(raw_transactions)
 
                     util.CURRENT_BLOCK_INDEX = block_index
                     progress_watchdog.tick(label=f"block {block_index}")
@@ -1727,6 +1753,8 @@ def follow(
 
                     if block_index < config.BTC_SRC20_GENESIS_BLOCK and not stamp_issuances_list[block_index]:
                         valid_src20_str = ""
+                        if perf_enabled:
+                            _perf_phase_start = time.perf_counter()
                         new_ledger_hash, new_txlist_hash, new_messages_hash = create_check_hashes(
                             db,
                             block_index,
@@ -1734,6 +1762,8 @@ def follow(
                             valid_src20_str,
                             txhash_list,
                         )
+                        if perf_enabled:
+                            perf_t_hash = time.perf_counter() - _perf_phase_start
 
                         stamp_issuances_list.pop(block_index, None)
                         log_block_info(
@@ -1747,7 +1777,27 @@ def follow(
                             0,
                             is_zmq_notification,
                         )
+                        if perf_enabled:
+                            _perf_block_index = block_index
+                            _perf_phase_start = time.perf_counter()
                         block_index = commit_and_update_block(db, block_index, block_tip, 0, block_hash)
+                        if perf_enabled:
+                            perf_t_dbwrite = time.perf_counter() - _perf_phase_start
+                            record_block_perf(
+                                config.PERF_LOG_PATH,
+                                {
+                                    "block_index": _perf_block_index,
+                                    "n_txs": perf_n_txs,
+                                    "n_candidates": perf_n_candidates,
+                                    "t_fetch_ms": round(perf_t_fetch * 1000, 3),
+                                    "t_filter_ms": round(perf_t_filter * 1000, 3),
+                                    "t_decode_ms": round(perf_t_decode * 1000, 3),
+                                    "t_hash_ms": round(perf_t_hash * 1000, 3),
+                                    "t_dbwrite_ms": round(perf_t_dbwrite * 1000, 3),
+                                    "t_total_ms": round((time.perf_counter() - perf_block_start) * 1000, 3),
+                                    "version": config.VERSION_STRING,
+                                },
+                            )
                         profiler.end_block_profiling()  # End profiling for this block
                         # Mark that we've successfully processed at least one block
                         if not first_block_processed:
@@ -1765,6 +1815,8 @@ def follow(
                     prefetch_source_prevouts(raw_transactions)
 
                     # Process transactions in parallel
+                    if perf_enabled:
+                        _perf_phase_start = time.perf_counter()
                     futures = []
                     for tx_hash in raw_transactions:  # Only process transactions we have raw data for
                         future = executor.submit(
@@ -1792,11 +1844,18 @@ def follow(
                     for i, result in enumerate(tx_results):
                         tx_results[i] = result._replace(tx_index=tx_index)
                         tx_index += 1
+                    if perf_enabled:
+                        perf_t_decode = time.perf_counter() - _perf_phase_start
 
                     try:
+                        if perf_enabled:
+                            _perf_phase_start = time.perf_counter()
                         block_processor = BlockProcessor(db)
                         block_processor.insert_transactions(tx_results)
                         block_processor.process_transaction_results(tx_results)
+                        if perf_enabled:
+                            perf_t_dbwrite = time.perf_counter() - _perf_phase_start
+                            _perf_phase_start = time.perf_counter()
 
                         (
                             new_ledger_hash,
@@ -1806,6 +1865,8 @@ def follow(
                             src20_in_block,
                             src101_in_block,
                         ) = block_processor.finalize_block(block_index, block_time, txhash_list, block_tip)
+                        if perf_enabled:
+                            perf_t_hash = time.perf_counter() - _perf_phase_start
 
                         stamp_issuances_list.pop(block_index, None)
                         log_block_info(
@@ -1819,7 +1880,27 @@ def follow(
                             src101_in_block,
                             is_zmq_notification,
                         )
+                        if perf_enabled:
+                            _perf_block_index = block_index
+                            _perf_phase_start = time.perf_counter()
                         block_index = commit_and_update_block(db, block_index, block_tip, src20_in_block, block_hash)
+                        if perf_enabled:
+                            perf_t_dbwrite += time.perf_counter() - _perf_phase_start
+                            record_block_perf(
+                                config.PERF_LOG_PATH,
+                                {
+                                    "block_index": _perf_block_index,
+                                    "n_txs": perf_n_txs,
+                                    "n_candidates": perf_n_candidates,
+                                    "t_fetch_ms": round(perf_t_fetch * 1000, 3),
+                                    "t_filter_ms": round(perf_t_filter * 1000, 3),
+                                    "t_decode_ms": round(perf_t_decode * 1000, 3),
+                                    "t_hash_ms": round(perf_t_hash * 1000, 3),
+                                    "t_dbwrite_ms": round(perf_t_dbwrite * 1000, 3),
+                                    "t_total_ms": round((time.perf_counter() - perf_block_start) * 1000, 3),
+                                    "version": config.VERSION_STRING,
+                                },
+                            )
                         logger.debug(f"After commit: block_index now {block_index}, continuing to next iteration")
 
                         # Mark that we've successfully processed at least one block

--- a/indexer/src/index_core/perf_log.py
+++ b/indexer/src/index_core/perf_log.py
@@ -1,0 +1,34 @@
+"""
+Lightweight, failure-isolated structured per-block performance logging.
+
+This module is consensus-neutral: it only serializes timing/counter data and
+appends it to a JSONL file. It must never affect block processing, so the
+single public entry point swallows all errors (logging them at DEBUG level).
+
+Activation is controlled by the ``PERF_LOG`` / ``PERF_LOG_PATH`` config flags;
+callers are expected to guard invocations behind ``config.PERF_LOG`` so there
+is zero overhead when the feature is disabled.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def record_block_perf(path, fields):
+    """Append one JSON object (a single JSONL line) describing a block's timings.
+
+    Args:
+        path: Destination JSONL file path (appended to, created if missing).
+        fields: Mapping of perf fields to serialize for this block.
+
+    Any error (serialization or I/O) is logged at DEBUG and swallowed so that
+    perf logging can never disrupt block processing.
+    """
+    try:
+        line = json.dumps(fields, separators=(",", ":"), sort_keys=False)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception as e:  # noqa: BLE001 - perf logging must never raise
+        logger.debug(f"perf log write failed (ignored): {e}")

--- a/indexer/tests/test_perf_log.py
+++ b/indexer/tests/test_perf_log.py
@@ -1,0 +1,83 @@
+"""Unit tests for the flag-gated per-block perf logger (index_core.perf_log).
+
+Pure-unit: no DB, no network. Verifies that ``record_block_perf`` writes a
+valid JSONL line with the expected keys and that any backend/IO error is
+swallowed (the helper must never raise, so perf logging can't disrupt block
+processing).
+"""
+
+import json
+
+from index_core.perf_log import record_block_perf
+
+EXPECTED_KEYS = {
+    "block_index",
+    "n_txs",
+    "n_candidates",
+    "t_fetch_ms",
+    "t_filter_ms",
+    "t_decode_ms",
+    "t_hash_ms",
+    "t_dbwrite_ms",
+    "t_total_ms",
+    "version",
+}
+
+
+def _sample_fields():
+    return {
+        "block_index": 840000,
+        "n_txs": 3000,
+        "n_candidates": 12,
+        "t_fetch_ms": 10.5,
+        "t_filter_ms": 1.25,
+        "t_decode_ms": 42.0,
+        "t_hash_ms": 3.0,
+        "t_dbwrite_ms": 7.5,
+        "t_total_ms": 64.25,
+        "version": "1.8.26+canary.322",
+    }
+
+
+def test_record_block_perf_writes_valid_jsonl_line(tmp_path):
+    """A single call appends one parseable JSON object with the expected keys."""
+    path = tmp_path / "perf_log.jsonl"
+    fields = _sample_fields()
+
+    record_block_perf(str(path), fields)
+
+    contents = path.read_text(encoding="utf-8")
+    lines = contents.splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert set(parsed.keys()) == EXPECTED_KEYS
+    assert parsed == fields
+
+
+def test_record_block_perf_appends_one_line_per_call(tmp_path):
+    """Repeated calls append; they do not truncate the file."""
+    path = tmp_path / "perf_log.jsonl"
+
+    record_block_perf(str(path), _sample_fields())
+    record_block_perf(str(path), _sample_fields())
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        assert set(json.loads(line).keys()) == EXPECTED_KEYS
+
+
+def test_record_block_perf_swallows_io_error(tmp_path):
+    """A backend/IO error (path is a directory) is swallowed -- no raise."""
+    # Opening a directory for append raises IsADirectoryError; the helper must
+    # log-and-swallow rather than propagate.
+    record_block_perf(str(tmp_path), _sample_fields())
+
+
+def test_record_block_perf_swallows_serialization_error(tmp_path):
+    """A non-JSON-serializable payload is swallowed -- no raise, no partial write."""
+    path = tmp_path / "perf_log.jsonl"
+
+    record_block_perf(str(path), {"block_index": object()})
+
+    assert not path.exists()


### PR DESCRIPTION
## What

Adds an **off-by-default**, structured per-block performance logger to the indexer `follow()` loop.

- **Flags** (`indexer/src/config.py`): `PERF_LOG` (default `false`) and `PERF_LOG_PATH` (default `perf_log.jsonl`), mirroring the existing flag style.
- **Helper** (`indexer/src/index_core/perf_log.py`): `record_block_perf(path, fields)` — builds one JSON object and appends it as a single JSONL line. Failure-isolated: any serialization/IO error is DEBUG-logged and swallowed (never raises).
- **Instrumentation** (`indexer/src/index_core/blocks.py`): minimal, additive `time.perf_counter()` timers around the **existing** phase boundaries in the per-block loop. When `PERF_LOG` is true, one JSON object is appended per committed block (both the pre-SRC20 empty-block fast path and the main path).
- **Test** (`indexer/tests/test_perf_log.py`): pure-unit (`tmp_path`, no DB/network) — asserts a valid JSONL line with the expected keys is written, that calls append, and that backend/IO + serialization errors are swallowed without raising.
- **Docs**: `indexer/.env.sample` documents the flag.

### JSON fields emitted (one object per block)

`block_index`, `n_txs`, `n_candidates`, `t_fetch_ms`, `t_filter_ms`, `t_decode_ms`, `t_hash_ms`, `t_dbwrite_ms`, `t_total_ms`, `version`.

Phase mapping to existing boundaries: `t_fetch` = backend `getblockhash` + `get_tx_list`; `t_filter` = `filter_block_transactions`; `t_decode` = parallel `process_tx` + result sort/index; `t_hash` = `finalize_block` / `create_check_hashes`; `t_dbwrite` = `insert_transactions` + `process_transaction_results` + `commit_and_update_block`. `version` = `config.VERSION_STRING`.

> Note: `process_tx` combines transaction parse + stamp decode with no clean intermediate boundary in the loop, so the separable `t_parse_ms` phase is intentionally omitted (captured within `t_decode_ms`) rather than refactoring the consensus-critical loop — per the minimal/additive constraint.

## Why

The prior reindex left **no recoverable timing data**, so before/after perf comparison was impossible. This makes future runs measurable and reproducible by flipping a single env flag.

**Consensus-neutral**: off by default; only times/logs; no parse/hash/ledger change; failure-isolated.

## Validation

Local heavy validation (full `pytest -n auto`, `poetry install`, Rust/maturin build) was **skipped to protect a long reindex running on the shared host**. The new code was byte-compiled and the helper's behavior was exercised directly (write/append/error-isolation). **CI is authoritative** here — it will run the full suite plus the Reparse Consensus Validation to confirm neutrality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
