### PR TITLE
docs: refresh top-5 high-value docs (protocols/architecture/database/ci/README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Block 779652.
 A fair, accessible fungible token protocol where users only pay standard BTC
 miner fees. Inspired by BRC-20 but enhanced with the immutability guarantees of Stamps.
 
-**History**: The first SRC-20 Token, "KEVIN," was deployed by Reinamora in Block 788041.
+**History**: The first SRC-20 Token, "KEVIN," was deployed by Reinamora in Block 788041
+(on Counterparty). SRC-20 moved to direct Bitcoin transactions at Block 793068 and adopted
+the OLGA / P2WSH encoding at **Block 865000**.
 
 ### 🖼️ SRC-721 STAMPS
 An advanced NFT format that uses JSON manifests to construct complex, layered images from data
@@ -64,7 +66,8 @@ A technical breakthrough that eliminates Base64 encoding overhead, reducing
 transaction size by 50% and lowering costs by 60-70% compared to the original OP_MULTISIG format.
 OLGA maintains full functionality while being significantly more efficient.
 
-**History**: First deployed in Block 833000 and now the standard for new Classic Stamps.
+**History**: OLGA activated per-protocol — Classic Stamps at Block 833000, SRC-20 at Block
+865000, and SRC-101 at Block 940000. It is now the standard for new Classic Stamps.
 
 ### 🔄 SRC-721r STAMPS
 The next evolution of SRC-721, enabling complex recursive images created using
@@ -341,7 +344,7 @@ poetry run run_checks
 poetry run check-code     # Run only code quality checks
 poetry run check-rust     # Run only Rust checks
 poetry run check-integration  # Run only integration tests
-poetry run bandit         # Run security checks with bandit
+poetry run task bandit    # Run security checks with bandit
 ```
 
 3. **Build Rust Parser During Development**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,30 +37,61 @@ flowchart TD
 - Coordinates processing pipeline
 - Handles error recovery
 
-### 2. Transaction Filter (`filter_block_transactions`)
-- Orchestrates the transaction filtering process
+### 2. Transaction Filter (`indexer/src/index_core/block_validation.py`)
+- `filter_block_transactions()` orchestrates the transaction filtering process
+  (defined in `block_validation.py`, imported and called from `blocks.py`)
 - Handles Counterparty issuances and direct Bitcoin transactions
 - Coordinates with the Rust parser for efficient filtering
 - Prepares filtered protocol data for handlers
+- Per-transaction decode is delegated to `transaction_utils.get_tx_info()`
 
-### 3. Rust Parser (`indexer/src/rust_parser/src/lib.rs`)
+### 3. Rust Parser (`indexer/src/rust_parser/`)
 - High-performance transaction parsing (20-50x faster than Python)
-- Performs the actual filtering of raw Bitcoin transactions
-- Memory-efficient caching with LRU implementation
-- Pattern matching and prefix detection for stamp protocols
+- Built as a **PyO3 native extension named `btc_stamps_parser`**
+  (`Cargo.toml` / `src/rust_parser/src/lib.rs`, `#[pyo3(name = "btc_stamps_parser")]`)
+- Imported into the Python pipeline through the thin wrapper package
+  `indexer/src/index_core/fast_parser/` (`from btc_stamps_parser import FastTransactionParser, TransactionInfo`)
+- Built with `poetry run task build` (maturin); `index_core` falls back to the pure-Python
+  path when the extension is unavailable or `DISABLE_RUST_PARSER` is set
+- Memory-efficient LRU caching, pattern matching, and prefix detection
 
-### 4. Protocol Handlers
+### 4. Backend Injection Seam (`indexer/src/index_core/backend.py`)
+- `Backend()` is a singleton over the bitcoind RPC connection
+- **`set_backend_override()` / `clear_backend_override()`** and the
+  **`BTC_STAMPS_BACKEND_OVERRIDE` env var** (`"module:ClassName"`) let CI and tests inject
+  a drop-in backend (e.g. a public-endpoint shim) without a local bitcoind (#800 / #802)
+- In production the override is `None` and the real singleton is returned unchanged
+
+### 5. Protocol Handlers
 - **Stamp Processor** (`indexer/src/index_core/stamp.py`): Base layer for all protocols
 - **SRC-20 Processor** (`indexer/src/index_core/src20.py`): Fungible token handling
+- **SRC-721 Processor** (`indexer/src/index_core/src721.py`): Recursive/composite NFT handling
 - **SRC-101 Processor** (`indexer/src/index_core/src101.py`): Domain name system
 
-### 5. Database Layer (`indexer/src/index_core/database.py`)
-- Structured data storage in MySQL
-- Transaction management
-- Atomic state updates
-- Balance calculation and ownership tracking
+### 6. Database Layer
+- `indexer/src/index_core/database.py`: structured MySQL storage, inserts, rollback
+  (`purge_block_db()`, `rebuild_balances()`, `rebuild_owners()`, `perform_complete_rollback()`)
+- `indexer/src/index_core/database_manager.py`: `ConnectionPool` / `PooledConnection`
+  queue-based connection pooling
+- Atomic state updates, balance calculation, and ownership tracking
 
-### 6. Web Interface at https://github.com/stampchain-io/BTCStampsExplorer
+### 7. Reparse / Consensus Validation (`indexer/src/index_core/reparse/`)
+- `validator.py`, `snapshot.py`, `db_manager.py` — replays curated blocks and validates
+  `txlist_hash` / `ledger_hash` / `messages_hash` against checked-in baselines
+- Exposed via taskipy: `poetry run task reparse`, `save-snapshot`, `validate-snapshot`
+- Drives the `reparse-validate.yml` CI consensus checks
+
+### 8. Market Data & Caching
+- Market-data services: `market_data_service.py`, `market_data_jobs.py`,
+  `stamp_market_processor.py`, `src20_market_processor.py`, `source_reliability_service.py`,
+  `sales_history_processor.py` — populate the `*_market_data` / `stamp_sales_history` cache
+  tables to avoid live external API calls
+- Caching layer: `caching.py`, `cache_utils.py`, `cache_types.py`, plus `memory_manager.py`
+  and `resource_manager.py` for memory-aware processing
+- Background orchestration: `background_coordinator.py`, `background_validator.py`,
+  `validation_queue.py`, `reprocessing_queue.py`
+
+### 9. Web Interface at https://github.com/stampchain-io/BTCStampsExplorer
 - Deno/Fresh implementation
 - REST API for protocol data
 - User interface for exploration

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -52,6 +52,49 @@ erDiagram
     }
 ```
 
+## Full Table Inventory
+
+The schema is defined in [`indexer/table_schema.sql`](../indexer/table_schema.sql) and
+currently contains **30 tables**. The list below is generated from that file (every
+`CREATE TABLE`), with a one-line purpose each. Detailed column references for the most
+important tables follow in the next sections.
+
+| # | Table | Purpose |
+|---|-------|---------|
+| 1 | `blocks` | Bitcoin block headers plus consensus hashes (`ledger_hash` / `txlist_hash` / `messages_hash`) and `indexed` flag |
+| 2 | `transactions` | All processed transactions: source/destination, data payload, fee, `keyburn`, `fee_rate_sat_vb` |
+| 3 | `StampTableV4` | Canonical stamp records — image data, mimetype, cpid, creator, supply, detected encoding method |
+| 4 | `srcbackground` | Background images / fonts used to render SRC-20 tokens (keyed by `tick` / `tick_hash`) |
+| 5 | `creator` | Maps a creator `address` to an optional display name |
+| 6 | `SRC20` | Raw (unvalidated) SRC-20 operations parsed from transactions |
+| 7 | `SRC20Valid` | Validated SRC-20 operations (deploy / mint / transfer) with `status` |
+| 8 | `balances` | Current SRC-20 token balances by address + tick |
+| 9 | `s3objects` | Tracks stamp files uploaded to S3 storage |
+| 10 | `collections` | Stamp collection definitions |
+| 11 | `collection_creators` | Maps collections to their creator addresses |
+| 12 | `collection_stamps` | Membership: which stamps belong to which collection |
+| 13 | `src20_metadata` | Descriptive/off-chain metadata for SRC-20 tokens (description, social links) |
+| 14 | `SRC101` | Raw (unvalidated) SRC-101 domain operations |
+| 15 | `SRC101Valid` | Validated SRC-101 operations (reg / transfer / renew) with `status` |
+| 16 | `owners` | Current SRC-101 domain ownership (`index`, `id`, `p`, `deploy_hash`, owner, expiry) |
+| 17 | `recipients` | SRC-101 recipient address records per operation |
+| 18 | `src101price` | SRC-101 registration pricing by name length per deploy |
+| 19 | `src20_token_stats` | Aggregated per-token SRC-20 stats (`total_minted`, `holders_count`) |
+| 20 | `stamp_views` | Per-stamp view counters |
+| 21 | `stamp_market_data` | Multi-source market-data cache per stamp (floor price, volume, holders) |
+| 22 | `stamp_holder_cache` | Cached per-stamp holder details for holder pages |
+| 23 | `market_data_sources` | Reliability / performance tracking of external market-data sources |
+| 24 | `src20_market_data` | Exchange-based market-data cache for SRC-20 tokens |
+| 25 | `collection_market_data` | Collection-level aggregated market data |
+| 26 | `stamp_sales_history` | Unified sales history across all stamp transactions |
+| 27 | `api_call_log` | Logs external (Counterparty) API calls for health / failure tracking |
+| 28 | `sales_history_checkpoints` | Checkpoints enabling incremental sales-history catchup |
+| 29 | `node_version_history` | Per-component indexer/node version history (`is_current` flag) |
+| 30 | `reorg_events` | Records blockchain reorganization events for observability / debugging |
+
+Tables 21–30 implement the market-data cache and operational/observability layers
+documented in [MARKET_DATA_CACHE_TABLES.md](./MARKET_DATA_CACHE_TABLES.md).
+
 ## Core Tables
 
 ### `blocks`
@@ -171,14 +214,23 @@ Store SRC-101 domain operations and validated domain operations.
 
 ### `owners`
 
-Tracks current domain ownership.
+Tracks current SRC-101 domain/token ownership. (Columns below match
+`table_schema.sql`; a `recipients` table holds per-operation recipient records.)
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `id` | INT | Ownership ID (Primary Key) |
-| `name` | VARCHAR(63) | Domain name (Primary Key) |
-| `owner` | VARCHAR(64) | Owner address |
-| `exp_block` | INT | Expiration block height |
+| `id` | VARCHAR(255) | Ownership record ID (Primary Key) |
+| `index` | INT | Ordering index within the deploy |
+| `p` | VARCHAR(32) | Protocol identifier |
+| `deploy_hash` | VARCHAR(64) | Hash of the SRC-101 deploy |
+| `tokenid` | VARCHAR(255) | Domain/token identifier (hex) |
+| `tokenid_utf8` | VARCHAR(255) | UTF-8 form of the domain name |
+| `preowner` | VARCHAR(64) | Previous owner address |
+| `owner` | VARCHAR(64) | Current owner address |
+| `prim` | BOOLEAN | Whether this is the owner's primary name |
+| `address_btc` / `address_eth` | VARCHAR(255) | Resolver address records |
+| `expire_timestamp` | BIGINT UNSIGNED | Expiration (unix timestamp) |
+| `last_update` | INT | Block height of last update |
 
 ## Indexes
 
@@ -195,90 +247,63 @@ The database uses strategic indexes to optimize common query patterns:
 
 ## Common Database Operations
 
-### Reindexing Blocks
+### Reindexing / Rollback
 
-```sql
--- Replace @block_index with the target block
-SET @block_index = 850000;
-SET FOREIGN_KEY_CHECKS = 0;
+**Do not hand-write rollback SQL.** Rolling back a block range is consensus-sensitive
+(balances and domain ownership must be rebuilt deterministically), so it is implemented in
+[`indexer/src/index_core/database.py`](../indexer/src/index_core/database.py) and driven
+through the `rollback` CLI task:
 
--- Core tables
-DELETE FROM transactions WHERE block_index >= @block_index;
-DELETE FROM blocks WHERE block_index >= @block_index;
-
--- Stamp related
-DELETE FROM StampTableV4 WHERE block_index >= @block_index;
-
--- SRC-20 related
-DELETE FROM SRC20 WHERE block_index >= @block_index;
-DELETE FROM SRC20Valid WHERE block_index >= @block_index;
-DELETE FROM balances;  -- Will be rebuilt
-
--- SRC-101 related
-DELETE FROM SRC101 WHERE block_index >= @block_index;
-DELETE FROM SRC101Valid WHERE block_index >= @block_index;
-DELETE FROM owners;  -- Will be rebuilt
-
-SET FOREIGN_KEY_CHECKS = 1;
+```shell
+cd indexer
+poetry run rollback   # tools/rollback_db.py — interactive/target-block rollback
 ```
 
-### Rebuild Balances
+The relevant functions in `database.py` are:
 
-The `rebuild_balances` function recalculates token balances based on validated operations:
+| Function | Purpose |
+|----------|---------|
+| `purge_block_db(db, block_index)` | Delete all rows at/after `block_index` across the block-scoped tables |
+| `rebuild_balances(db, block_index=None)` | Recompute SRC-20 `balances` from `SRC20Valid` |
+| `rebuild_owners(db, block_index=None)` | Recompute SRC-101 `owners` from `SRC101Valid` |
+| `perform_complete_rollback(block_index, force=False)` | Full, atomic rollback orchestration |
 
-```python
-def rebuild_balances(db):
-    """Rebuild SRC-20 balances from validated operations."""
-    with db.cursor() as cursor:
-        # Clear existing balances
-        cursor.execute("TRUNCATE TABLE balances")
-        
-        # Get all valid mint and transfer operations
-        cursor.execute("""
-            SELECT op, tick, tick_hash, amt, creator, destination, block_index
-            FROM SRC20Valid
-            WHERE op in ('mint', 'transfer')
-            ORDER BY block_index, id
-        """)
-        
-        # Process operations in batches
-        batch_size = 1000
-        operations = []
-        balances = defaultdict(Decimal)
-        
-        for operation in cursor.fetchall():
-            # Process operation and update balances dictionary
-            # ...
-        
-        # Insert updated balances in batches
-        insert_query = """
-            INSERT INTO balances (address, tick, tick_hash, balance)
-            VALUES (%s, %s, %s, %s)
-            ON DUPLICATE KEY UPDATE balance = VALUES(balance)
-        """
-        cursor.executemany(insert_query, balance_records)
-        db.commit()
-```
+For a full re-index from genesis, drop/recreate the schema with `table_schema.sql` and let
+the indexer replay from `BLOCK_FIRST_MAINNET` (`CP_STAMP_GENESIS_BLOCK` = 779652).
+
+### Rebuild Balances / Owners
+
+SRC-20 balances and SRC-101 owners are derived state, recomputed from the `*Valid` tables
+by `rebuild_balances(db, block_index=None)` and `rebuild_owners(db, block_index=None)` in
+[`indexer/src/index_core/database.py`](../indexer/src/index_core/database.py). Use those
+functions (or the `rollback` task above) rather than ad-hoc SQL, so the recomputation stays
+consistent with consensus.
 
 ### Database Connection Management
 
-The codebase uses a connection pool for efficient database access:
+Connection pooling is implemented in
+[`indexer/src/index_core/database_manager.py`](../indexer/src/index_core/database_manager.py).
+The real API is a `queue.Queue`-backed `ConnectionPool` that hands out `PooledConnection`
+wrappers (calling `.close()` on a wrapper returns the connection to the pool instead of
+closing it):
 
 ```python
-class DatabaseManager:
-    def __init__(self, **kwargs):
-        self.pool = pymysql.cursors.DictCursor(**kwargs)
-        
-    def connect(self):
-        """Get a connection from the pool."""
-        return self.pool.get_connection()
-        
-    def get_long_running_connection(self):
-        """Get a connection for long operations."""
-        conn = self.connect()
-        conn.ping(reconnect=True)
-        return conn
+# indexer/src/index_core/database_manager.py
+class ConnectionPool:
+    def __init__(self, **kwargs): ...          # min/max connections, timeout
+    def get_connection(self) -> PooledConnection: ...   # blocks up to `timeout`, else grows
+    def return_connection(self, connection): ...        # validates before reuse
+    def get_pool_size(self) -> int: ...
+    def close_all(self): ...
+
+class PooledConnection:
+    def close(self):                            # returns the conn to the pool
+        self.pool.return_connection(self.connection)
+    def __enter__(self): ...                     # usable as a context manager
+    def __exit__(self, *exc): ...
 ```
+
+There is **no** `DatabaseManager` class; refer to `ConnectionPool` / `PooledConnection`.
 
 ## Performance Considerations
 

--- a/docs/PROTOCOLS.md
+++ b/docs/PROTOCOLS.md
@@ -8,14 +8,15 @@ This document details all protocols supported by the Bitcoin Stamps indexer, inc
 ## Table of Contents
 
 1. [Common Concepts](#common-concepts)
-2. [Classic Stamps](#classic-stamps)
-3. [SRC-20 Tokens](#src-20-tokens)
-4. [SRC-721 NFTs](#src-721-nfts)
-5. [SRC-721r Recursive NFTs](#src-721r-recursive-nfts)
-6. [SRC-101 Domains](#src-101-domains)
-7. [OLGA Format](#olga-format)
-8. [Transaction Sources](#transaction-sources)
-9. [Transaction Detection](#transaction-detection)
+2. [Protocol Activation Heights](#protocol-activation-heights)
+3. [Classic Stamps](#classic-stamps)
+4. [SRC-20 Tokens](#src-20-tokens)
+5. [SRC-721 NFTs](#src-721-nfts)
+6. [SRC-721r Recursive NFTs](#src-721r-recursive-nfts)
+7. [SRC-101 Domains](#src-101-domains)
+8. [OLGA Format](#olga-format)
+9. [Transaction Sources](#transaction-sources)
+10. [Transaction Detection](#transaction-detection)
 
 ## Common Concepts
 
@@ -26,6 +27,31 @@ All Bitcoin Stamps protocols share certain common attributes:
 - **Transaction Validation**: Each protocol has specific validation rules
 - **Stamp ID**: Every valid stamp receives a unique sequential identifier
 - **Dual-Source Architecture**: Stamps can originate from direct Bitcoin transactions or Counterparty transactions (with SRC-20 Counterparty transactions discontinued after block 796000)
+
+## Protocol Activation Heights
+
+Every consensus boundary is a named constant in [`indexer/src/config.py`](../indexer/src/config.py).
+The table below is the single source of truth for this document — earlier prose that
+conflated the three distinct OLGA/P2WSH activations (stamps vs SRC-20 vs SRC-101) has
+been corrected to match these values.
+
+| Milestone | Constant (`config.py`) | Mainnet height |
+|-----------|------------------------|----------------|
+| Classic Stamp genesis (first stamp, on Counterparty) | `CP_STAMP_GENESIS_BLOCK` | 779652 |
+| SRC-20 genesis on Counterparty | `CP_SRC20_GENESIS_BLOCK` | 788041 |
+| SRC-721 genesis | `CP_SRC721_GENESIS_BLOCK` | 792370 |
+| SRC-20 genesis on direct Bitcoin (no CP encoding) | `BTC_SRC20_GENESIS_BLOCK` | 793068 |
+| Last block honoring Counterparty SRC-20 (CP SRC-20 ignored after) | `CP_SRC20_END_BLOCK` | 796000 |
+| Classic Stamps OLGA / P2WSH enabled | `CP_P2WSH_FEAT_BLOCK_START` | 833000 |
+| SRC-20 OLGA / P2WSH encoding | `BTC_SRC20_OLGA_BLOCK` | 865000 |
+| SRC-101 genesis | `BTC_SRC101_GENESIS_BLOCK` | 870652 |
+| SRC-101 image-optional | `BTC_SRC101_IMG_OPTIONAL_BLOCK` | 872200 |
+| SRC-101 OLGA / P2WSH encoding (~March 2026) | `BTC_SRC101_OLGA_BLOCK` | 940000 |
+
+> **OLGA is not a single height.** Classic Stamps adopted P2WSH/OLGA at block 833000
+> (`CP_P2WSH_FEAT_BLOCK_START`), SRC-20 at block 865000 (`BTC_SRC20_OLGA_BLOCK`), and
+> SRC-101 at block 940000 (`BTC_SRC101_OLGA_BLOCK`). Use the per-protocol constant — do
+> not assume one OLGA cutover applies to all protocols.
 
 ## Classic Stamps
 
@@ -266,7 +292,10 @@ Similar to SRC-721 but with additional code reference tracking.
 
 ## SRC-101 Domains
 
-SRC-101 is a domain name system native to Bitcoin Stamps.
+SRC-101 is a domain name system native to Bitcoin Stamps. It activates at block 870652
+(`BTC_SRC101_GENESIS_BLOCK`); images become optional at block 872200
+(`BTC_SRC101_IMG_OPTIONAL_BLOCK`); and it adopts P2WSH/OLGA encoding at block 940000
+(`BTC_SRC101_OLGA_BLOCK`, ~March 2026).
 
 ### Operations
 
@@ -342,9 +371,14 @@ OLGA uses P2WSH outputs to store data directly, as opposed to the older OP_MULTI
 4. Data is concatenated from all outputs
 5. PREFIX is identified in the concatenated data
 
-### Transition Point
+### Transition Points
 
-OLGA became the standard starting at block 833000.
+OLGA/P2WSH did not activate at one height for every protocol. Each protocol has its own
+constant in `config.py` (see [Protocol Activation Heights](#protocol-activation-heights)):
+
+- **Classic Stamps**: block 833000 (`CP_P2WSH_FEAT_BLOCK_START`)
+- **SRC-20**: block 865000 (`BTC_SRC20_OLGA_BLOCK`)
+- **SRC-101**: block 940000 (`BTC_SRC101_OLGA_BLOCK`, ~March 2026)
 
 ## Transaction Sources
 
@@ -401,111 +435,37 @@ The indexer maintains compatibility with both transaction types:
 
 ## Transaction Detection
 
-The indexer uses a multi-stage approach to detect protocol-relevant transactions:
+The indexer uses a multi-stage pipeline to detect protocol-relevant transactions.
+The pseudocode that previously lived here had drifted from the implementation; the
+authoritative entry points are listed below so this doc stays in sync with the code.
 
-### 1. Dual-Path Filtering
+### 1. Block-level filtering — `block_validation.filter_block_transactions`
 
-The indexer uses two different paths for transaction detection based on source:
+The first pass runs in
+[`indexer/src/index_core/block_validation.py`](../indexer/src/index_core/block_validation.py)
+(`filter_block_transactions`, imported and called from `blocks.py`). It walks the block's
+transactions and, when available, hands the raw hex to the high-performance Rust parser
+(`btc_stamps_parser`, wrapped by `index_core/fast_parser`) for pattern/prefix detection,
+falling back to the Python path when the Rust parser is unavailable.
 
-#### Direct Bitcoin Transaction Filtering (in blocks.py)
+### 2. Per-transaction decode — `transaction_utils.get_tx_info`
 
-```python
-# Pseudocode from filter_block_transactions
-for tx in block_data["tx"]:
-    # Try to filter with Rust parser first (for direct Bitcoin transactions)
-    if backend_instance._parser is not None:
-        parsed_txs = backend_instance._parser.batch_parse_transactions(tx_hexes)
-        # Process returned transactions (all should be included)
-    else:
-        # Use Python implementation
-        ctx = backend_instance.deserialize(tx["hex"])
-        filter_result = quick_filter_src20_transaction(ctx)
-        if filter_result:
-            raw_transactions[tx["txid"]] = tx["hex"]
-```
+The canonical decode/classification routine is
+[`get_tx_info(tx_hex, block_index=None, db=None, stamp_issuance=None)`](../indexer/src/index_core/transaction_utils.py)
+in `indexer/src/index_core/transaction_utils.py`. This is the real path that extracts
+source/destination, data payload, keyburn, and OLGA/OP_MULTISIG encoding from a raw
+transaction. Refer to that function (not pseudocode) for exact detection semantics, since
+the encoding rules are version- and block-height dependent.
 
-#### Counterparty Transaction Retrieval
+### 3. Counterparty source
 
-```python
-# Pseudocode for Counterparty transaction retrieval
-def fetch_xcp_block_async(block_index):
-    if block_index < CP_STAMP_GENESIS_BLOCK:
-        return None  # Skip blocks before Counterparty stamps existed
-    
-    # Make API call to retrieve pre-processed Counterparty data
-    cp_data = make_xcp_api_call(f"/blocks/{block_index}")
-    
-    # Process all transactions, but filter out SRC-20 after cutoff block
-    transactions = []
-    for tx in cp_data.get("transactions", []):
-        # For SRC-20, ignore CP transactions after cutoff block
-        if block_index > CP_SRC20_END_BLOCK and is_src20_transaction(tx):
-            continue
-        # Still process classic stamp transactions after cutoff
-        transactions.append(tx)
-        
-    return process_cp_transactions(transactions)
-```
+Counterparty-sourced stamps are retrieved via the Counterparty API and processed by the
+backend in [`indexer/src/index_core/backend.py`](../indexer/src/index_core/backend.py).
+SRC-20 issued through Counterparty is honored only up to `CP_SRC20_END_BLOCK` (796000);
+classic stamps via Counterparty remain supported.
 
-### 2. Rust Parser Detection (for Direct Bitcoin Transactions)
+### 4. Protocol dispatch
 
-The Rust parser evaluates Bitcoin transactions based on:
-
-```rust
-// Simplified detection logic
-let has_valid_pattern = check_for_p2wsh_pattern() || check_for_multisig_pattern();
-let has_valid_data = check_for_prefix_in_decrypted_data();
-let keyburn = detect_keyburn_in_transaction();
-
-// Final determination
-let should_include = (has_valid_pattern && has_valid_data) || 
-                     (has_valid_data && keyburn == 1);
-
-// Only return transactions that should be included
-if should_include {
-    results.push(tx_info.clone());
-}
-```
-
-### 3. Unified Protocol-Specific Processing
-
-After transaction filtering/retrieval, each transaction is processed by unified protocol handlers regardless of source:
-
-```python
-# In BlockProcessor.process_transaction_results
-if stamp_data.pval_src20:
-    _, src20_dict = parse_src20(self.db, prevalidated_src, self.processed_src20_in_block, self._lock)
-    with self._lock:
-        self.processed_src20_in_block.append(src20_dict)
-elif stamp_data.pval_src101:
-    _, src101_dict = parse_src101(
-        self.db, prevalidated_src, self.processed_src101_in_block, stamp_data.block_index, self._lock
-    )
-    with self._lock:
-        self.processed_src101_in_block.append(src101_dict)
-```
-
-### 4. Transaction Source Detection
-
-The system identifies transaction sources based on several factors:
-
-```python
-# Pseudocode for source detection
-def determine_transaction_source(tx_data, block_index):
-    # Check if it's a Counterparty transaction (has specific fields)
-    if "bindings" in tx_data and tx_data.get("status") == "valid":
-        # For SRC-20 after cutoff, reject Counterparty transactions
-        if block_index > CP_SRC20_END_BLOCK and is_src20_transaction(tx_data):
-            return None  # Reject CP SRC-20 after cutoff
-        return "counterparty"  # Accept CP classic stamps after cutoff
-        
-    # Check for OLGA P2WSH pattern (direct Bitcoin)
-    if has_p2wsh_pattern(tx_data) and block_index >= BTC_SRC20_OLGA_BLOCK:
-        return "direct_bitcoin"
-        
-    # Check for OP_MULTISIG pattern (direct Bitcoin)
-    if has_multisig_pattern(tx_data):
-        return "direct_bitcoin"
-        
-    return None  # Not a stamp transaction
-```
+Filtered/decoded transactions are dispatched to the protocol handlers
+(`stamp.py`, `src20.py`, `src721.py`, `src101.py`) by `BlockProcessor` in `blocks.py`.
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full component map and data flow.

--- a/indexer/docs/ci-workflows.md
+++ b/indexer/docs/ci-workflows.md
@@ -1,221 +1,134 @@
 # CI/CD Workflows
 
-This document describes the continuous integration and deployment workflows for the BTC Stamps Indexer.
+This document describes the GitHub Actions workflows for the BTC Stamps Indexer. It is
+generated from the actual files in [`.github/workflows/`](../../.github/workflows/) — keep
+it in sync when workflows change.
+
+> **Python versions:** the project supports **3.10 / 3.11 / 3.12** (`pyproject.toml`:
+> `python = "^3.10"`). The unit-test matrix runs all three; there is no Python 3.9.
+
+## Workflow Index
+
+| File | Name | Trigger(s) |
+|------|------|-----------|
+| `python-check.yml` | CI | `pull_request`, `workflow_dispatch` |
+| `reparse-validate.yml` | Reparse Consensus Validation | `pull_request` (consensus paths), `workflow_dispatch` |
+| `freeze-drift.yml` | Freeze Drift Check | `pull_request` (dep paths), `workflow_dispatch` |
+| `coverage.yml` | Coverage Analysis | `pull_request` + `push` to `main`/`dev`, `workflow_dispatch` |
+| `docker-auto-publish.yml` | Docker Auto-Publish | `push` to `main`/`dev` (indexer/docker paths) |
+| `docker-publish.yml` | Docker Build and Publish | `workflow_dispatch` (tag + environment) |
+| `version-check.yml` | Version Format Check | `push` + `pull_request` to `main`/`dev` |
+| `bump-version.yml` | Bump Version | `push` to `dev`/`main`, `pull_request` closed, `workflow_dispatch` |
+| `build-test.yml` | Build Tests | `workflow_call` (reusable) |
+| `setup-python.yml` | Setup Python Environment | `workflow_call` (reusable) |
+| `claude.yml` | Claude Code | comment/issue triggers |
+| `claude-code-review.yml` | Claude Code Review | `pull_request`, `workflow_dispatch` |
 
 ## Core Workflows
 
-### 1. Build Tests (`build-test.yml`)
-A reusable workflow that provides build and test verification.
+### `python-check.yml` — CI
 
-**Implementation:**
-- Triggered via workflow_call
-- Supports environment specification
-- Matrix testing across Python versions (3.9, 3.10, 3.11, 3.12)
+The primary PR gate. Runs on every pull request and via manual dispatch. Three jobs:
 
-**Process:**
-1. Sets up Python environment using setup-python.yml
-2. Creates Python module structure
-3. Runs build tests
-4. Executes Rust parser tests
+1. **Rust Checks** (`rust`) — `rustfmt`, `clippy`, and Rust parser checks (Python 3.11 to
+   drive the build, with the Rust toolchain + cache).
+2. **Code Quality & Unit Tests** (`code-quality`) — **matrix `['3.10', '3.11', '3.12']`**.
+   Verifies `poetry.lock` is in sync with `pyproject.toml`, checks for stray debug flags,
+   then runs code-quality checks and the unit-test suite (isort, black, flake8, mypy,
+   bandit, pytest via the `run_checks` / taskipy tasks).
+3. **Integration Tests** (`integration`) — builds the Rust parser and runs the integration
+   suite (excluding tests that require a live Bitcoin node).
 
-### 2. Docker Build and Publish (`docker-publish.yml`)
-Handles Docker image building and publishing.
+The README status badges (Code Quality, Rust Checks, Integration) point at the
+corresponding jobs of this single workflow.
 
-**Triggers:**
-- Manual trigger (workflow_dispatch)
-- Requires:
-  - Tag specification
-  - Environment selection (production/staging)
-  - Optional test skip flag
+### `reparse-validate.yml` — Reparse Consensus Validation
 
-**Process:**
-1. Build Tests (conditional)
-   - Uses reusable setup and build-test workflows
-   - Can be skipped with skip_tests flag
-2. Docker Build & Push
-   - Builds multi-arch image
-   - Tags with specified version
-   - Pushes to Docker Hub
-   - Applies metadata and labels
+Per-PR validation that the indexer's consensus surface still matches the checked-in
+baseline (`indexer/snapshots/ci_consensus_hashes.json`). Triggered on PRs that touch
+consensus-relevant paths (`index_core/**`, `rust_parser/**`, `config.py`, `pyproject.toml`,
+`poetry.lock`, the snapshots, `ci/**`). Runs on the **matrix `['3.10', '3.11', '3.12']`**
+and is **advisory** on first land (`continue-on-error: true`).
 
-### 3. Python Check (`python-check.yml`)
-Comprehensive code quality and testing workflow.
+Three validation tiers (all run across the matrix):
 
-**Triggers:**
-- Pull requests to `dev` and `main` branches
-- Manual workflow dispatch
+- **Tier 1** — Cross-check `CHECKPOINTS_MAINNET` against `reference_hashes.json` (pure-Python
+  AST parse; catches check.py / reference drift) for all baseline blocks.
+- **Tier 2** — Block-bytes hash verification: each baseline block is fetched from a
+  bitcoind RPC (or the public blockstream.info node) and its bytes verified against the
+  expected `block_hash`.
+- **Tier 3** — Full in-memory reparse (Rust parser + reparse pipeline) in a fresh
+  subprocess per block, comparing `txlist_hash` / `messages_hash` / `ledger_hash` to the
+  baseline. Tier 3 is DB-free, so blocks whose ledger depends on cross-block SRC-20 state
+  (`TIER3_CROSS_BLOCK_LEDGER`) are excluded by design — they remain covered by Tiers 1–2
+  and the periodic full stampsdev reindex (#775 / #778).
 
-**Matrix Testing:**
-Tests across Python versions:
-- Python 3.9
-- Python 3.10
-- Python 3.11
-- Python 3.12
+Also runs a **consensus package pin guard** (`ci/check_consensus_pkg_pins.py`) on each
+matrix Python, proving consensus-critical packages (regex, PyNaCl, pybase64) resolve
+identically on 3.10 / 3.11 / 3.12 (#759 / #803). Refresh the baseline with
+`./indexer/ci/refresh-consensus-hashes.sh`.
 
-**Quality Checks:**
+### `freeze-drift.yml` — Freeze Drift Check
 
-1. Debug Flag Verification
-   - Ensures production-safe debug settings
+Verifies that the resolved Python packages **inside the production indexer Docker image**
+match the checked-in baseline `indexer/ci/freeze.prod.lock` (built with `PYTHON_VERSION=3.12`).
+`poetry.lock` guarantees lockfile-internal consistency but not what pip actually realizes
+inside the prod image; this catches base-image/platform wheel drift (the regex / PyNaCl
+drift in PR #753). Update the baseline intentionally with `./indexer/ci/refresh-freeze.sh`.
 
-2. Code Style and Formatting
-   - isort for import ordering
-   - Black for code formatting
-   - Flake8 for PEP 8 compliance
-     * Complexity limit: 10
-     * Line length limit: 127 characters
+### `coverage.yml` — Coverage Analysis
 
-3. Rust-specific Checks
-   - Rust formatting verification
-   - Clippy linting
+Runs on PRs and pushes to `main`/`dev` (and manual dispatch). Executes the test suite under
+coverage on **Python 3.11** (single version, matching integration tests) and uploads to
+Codecov (`codecov.yml` / the codecov badge).
 
-4. Static Analysis
-   - Mypy type checking
-   - Bandit security scanning
+## Docker Workflows
 
-5. Test Suites
-   The following test suites are executed as part of the CI process:
+### `docker-auto-publish.yml` — Docker Auto-Publish
 
-   **Block Processing Tests:**
-   - test_block_rollback.py
-     * Tests rollback functionality for block processing
-     * Validates balance updates during rollbacks
-     * Ensures transaction integrity after rollbacks
+On every push to `main`/`dev` that touches `indexer/**`, `docker/**`, or the workflow
+itself, builds and pushes the indexer image (has `packages: write` permission). This is the
+automated path that produces the `dev` and release images.
 
-   **Integration Tests:**
-   - test_integration_block_processing.py
-     * End-to-end block processing validation
-     * Tests SRC-20 parsing and validation
-     * Verifies database interactions
+### `docker-publish.yml` — Docker Build and Publish
 
-   **Parser Tests:**
-   - test_parser_comparison.py
-     * Compares Python and Rust parser outputs
-     * Validates parsing consistency
-     * Tests deploy operations and numeric handling
+Manual (`workflow_dispatch`) build/publish with inputs: `tag` (required),
+`environment` (`production` / `staging` choice), and optional `skip_tests`. When tests are
+not skipped it runs the build/test jobs first, then builds a multi-arch image and pushes it.
 
-   **Rollback Tests:**
-   - test_rollback_transactions_stamptable.py
-     * Tests transaction table rollbacks
-     * Validates StampTableV4 rollbacks
-     * Ensures database consistency after rollbacks
+## Versioning Workflows
 
-   **SRC-20 Tests:**
-   - test_src20_balance.py
-     * Tests balance calculation accuracy
-     * Validates amount normalization
-     * Handles decimal place restrictions
+### `version-check.yml` — Version Format Check
 
-   - test_src20_update_valid.py
-     * Tests transfer operations
-     * Validates mint operations
-     * Verifies balance updates
-     * Tests cache management
+On pushes and PRs to `main`/`dev`, validates the version-string format for consistency.
 
-   - test_src20_validator.py
-     * Tests SRC-20 validation rules
-     * Validates numeric conversions
-     * Tests error handling
+### `bump-version.yml` — Bump Version
 
-### 4. Integration Test (`integration-test.yml`)
-Handles end-to-end integration testing.
+Automates version bumps. Triggers on pushes to `dev`/`main`, on closed PRs to those
+branches, and manual dispatch with a `versionType` input (`major`/`minor`/`patch`/`build`/
+`release`) and a `preRelease` flag. Uses Python 3.10.
 
-## Support Workflows
+## Reusable / Support Workflows
 
-### 1. Setup Python (`setup-python.yml`)
-A reusable workflow for consistent Python environment setup across other workflows.
-- Sets up Python environment
-- Configures Poetry and dependencies
-- Builds Rust parser
-- Caches dependencies for faster builds
+### `setup-python.yml` — Setup Python Environment
 
-## Environment Variables
+Reusable (`workflow_call`) workflow that installs Python, configures Poetry + dependencies,
+builds the Rust parser, and caches dependencies. Consumed by other workflows.
 
-Required environment variables for tests:
-- `USE_TEST_TX_HEX`
-- `PYTHONPATH`
-- `DOCKERHUB_TOKEN` (for Docker publishing)
+### `build-test.yml` — Build Tests
 
-## Security Notes
+Reusable (`workflow_call`) build + test verification (Python 3.10), invoked by the Docker
+publish flow.
 
-- Tests run in isolated containers
-- Sensitive credentials managed via GitHub Secrets
-- Docker Hub authentication required for pushes
-- Environment-specific deployments
+## Assistant Workflows
 
-## Manual Triggers
+- **`claude.yml` — Claude Code**: responds to issue/PR comment triggers to run the Claude
+  Code assistant against the repo.
+- **`claude-code-review.yml` — Claude Code Review**: runs an automated Claude review on pull
+  requests (and manual dispatch).
 
-The following workflows can be triggered manually:
-1. Build Tests: For development verification
-2. Docker Publish: For custom deployments
-   - Requires tag specification
-   - Environment selection
-   - Optional test skip for emergencies
-3. Python Check: For code quality verification
+## Notes
 
-## Best Practices
-
-1. Always run tests before merging to dev/main
-2. Use semantic versioning for tags
-3. Document significant workflow changes
-4. Review logs after automated runs
-5. Maintain test environment parity
-
-## Future Implementation Plans
-
-### 1. Version Management Workflows
-These workflows will improve version control and consistency:
-
-1. **test-publish.yml**
-   - Purpose: Automate package testing and publishing
-   - Triggers: Tag pushes (v*) and release creation
-   - Key Features:
-     * Package testing before publishing
-     * Version verification
-     * Automated package publishing
-     * Release notes generation
-
-2. **bump-version.yml**
-   - Purpose: Automate version management
-   - Implementation Plan:
-     * Analyze commit messages for version increment type
-     * Update version in pyproject.toml and other files
-     * Create and push version tags
-     * Generate changelog entries
-
-3. **version-check.yml**
-   - Purpose: Ensure version consistency
-   - Implementation Plan:
-     * Check version numbers across all files
-     * Validate semantic versioning compliance
-     * Block PRs with version inconsistencies
-
-### 2. Enhanced Security Features
-Future security enhancements:
-
-1. **Vulnerability Scanning**
-   - Add container vulnerability scanning
-   - Implement dependency security audits
-   - Add SBOM generation for compliance
-
-2. **Code Quality Gates**
-   - Add code coverage requirements
-   - Implement complexity limits
-   - Add security-focused linting rules
-
-### 3. Testing Improvements
-Planned test enhancements:
-
-1. **Performance Testing**
-   - Add benchmarking workflows
-   - Implement performance regression detection
-   - Add load testing for critical paths
-
-2. **Integration Testing**
-   - Expand end-to-end test coverage
-   - Add cross-version compatibility tests
-   - Implement network resilience tests
-
-3. **Documentation Testing**
-   - Add documentation link validation
-   - Implement example code testing
-   - Add API documentation verification
+- Consensus-critical changes are gated by `reparse-validate.yml` + `freeze-drift.yml` in
+  addition to the standard `python-check.yml` CI; see `indexer/ci/README.md`.
+- Sensitive credentials (Docker Hub, optional bitcoind RPC) are provided via GitHub Secrets.


### PR DESCRIPTION
Refreshes the five highest-value docs in the repo. Every correction was verified against the live code (`indexer/src/config.py`, `indexer/src/index_core/`, `indexer/table_schema.sql`, `.github/workflows/`) — no invented constants.

## Verified consensus constants (`indexer/src/config.py`)

| Constant | Value |
|----------|-------|
| `CP_STAMP_GENESIS_BLOCK` | 779652 |
| `CP_SRC20_GENESIS_BLOCK` | 788041 |
| `CP_SRC721_GENESIS_BLOCK` | 792370 |
| `BTC_SRC20_GENESIS_BLOCK` | 793068 |
| `CP_SRC20_END_BLOCK` | 796000 |
| `CP_P2WSH_FEAT_BLOCK_START` (Classic Stamps OLGA) | 833000 |
| `BTC_SRC20_OLGA_BLOCK` | 865000 |
| `BTC_SRC101_GENESIS_BLOCK` | 870652 |
| `BTC_SRC101_IMG_OPTIONAL_BLOCK` | 872200 |
| `BTC_SRC101_OLGA_BLOCK` | 940000 |

## Per-doc corrections

### `docs/PROTOCOLS.md`
- Added a single-source-of-truth **Protocol Activation Heights** table from `config.py`.
- De-conflated the three distinct OLGA/P2WSH cutovers: Classic Stamps **833000**, SRC-20 **865000**, SRC-101 **940000**.
- Added SRC-101 genesis / image-optional / OLGA heights.
- Replaced the fictional detection pseudocode (`fetch_xcp_block_async`, `determine_transaction_source`, …) with pointers to the real path: `transaction_utils.get_tx_info()` (transaction_utils.py:466) and `block_validation.filter_block_transactions()` (block_validation.py:141).

### `docs/ARCHITECTURE.md`
- Corrected the Transaction Filter location: `filter_block_transactions` lives in `block_validation.py`, not `blocks.py`.
- Documented the Rust parser era: PyO3 extension **`btc_stamps_parser`** (`#[pyo3(name = "btc_stamps_parser")]`) imported via the `index_core/fast_parser/` wrapper.
- Added the **backend injection seam**: `set_backend_override()` / `clear_backend_override()` + `BTC_STAMPS_BACKEND_OVERRIDE` env var (#800/#802).
- Added `src721.py` and expanded the component map (`reparse/`, market-data services, caching, `database_manager.ConnectionPool`, `block_validation.py`).

### `docs/DATABASE.md`
- Regenerated the full **30-table inventory** from `table_schema.sql` (one-line purpose each).
- Deleted the fictional `DatabaseManager` connection-pool snippet — the real API is `ConnectionPool` / `PooledConnection` in `database_manager.py`.
- Fixed the `owners` table column list (SRC-101 ownership: `index`/`id`/`p`/`deploy_hash`/…, not `name`/`exp_block`).
- Aligned rollback/reindex guidance with the real `database.py` functions (`purge_block_db`, `rebuild_balances`, `rebuild_owners`, `perform_complete_rollback`) and the `rollback` task.

### `indexer/docs/ci-workflows.md`
- Rewritten against the actual `.github/workflows/` files. Python matrix is **3.10/3.11/3.12** (not 3.9); removed the nonexistent `integration-test.yml` (integration is a job inside `python-check.yml`).
- Documented `python-check.yml` (rust / code-quality / integration), `reparse-validate.yml` (the 3 consensus tiers), `freeze-drift.yml`, `coverage.yml`, `docker-auto-publish.yml`, `docker-publish.yml`, version workflows, and reusable/assistant workflows.

### `README.md`
- Fixed `poetry run bandit` → **`poetry run task bandit`** (`bandit` is a `[tool.taskipy.tasks]` entry, not a poetry script).
- Clarified SRC-20 OLGA height **865000** vs Classic Stamps OLGA **833000** (the README's existing 833000 for Classic Stamps was correct and retained).

## Validation
Docs-only change. Confirmed markdown renders sanely and all internal relative links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
