### PR TITLE
ci: make codecov advisory (non-blocking) + fix stale target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,11 +10,11 @@ coverage:
     # Overall project coverage
     project:
       default:
-        target: 55%           # Target coverage for the project (realistic baseline)
+        target: 54%           # Informational baseline (matches tools/run_coverage.py)
         threshold: 5%         # Allow 5% drop in coverage
         base: auto           # Compare against base branch
         if_ci_failed: error  # Fail if CI fails
-        informational: false # Make this check required
+        informational: true  # Advisory only — coverage is NOT a merge gate (job is flaky)
         only_pulls: false    # Run on all commits
     
     # Coverage for changed files in PR
@@ -24,7 +24,7 @@ coverage:
         threshold: 10%        # Allow some flexibility
         base: auto
         if_ci_failed: error
-        informational: false
+        informational: true   # Advisory only — patch coverage does not block merges
         only_pulls: true      # Only on PRs
 
 # Comment configuration


### PR DESCRIPTION
## What
- `codecov.yml`: set **project** and **patch** statuses to `informational: true` (advisory only — they no longer block/redden PRs).
- Correct the stale project target **55% → 54%** to match `tools/run_coverage.py`.

## Why
The codecov statuses were configured as hard gates (`informational: false`, targets 55%/70%) with `if_ci_failed: error` — which contradicts how the team actually treats coverage (the `Code Coverage Analysis` job is flaky and non-blocking, per CLAUDE.md). That mismatch produces red-noise on PRs. Making them advisory keeps the coverage signal (comments still post) without gating merges.

## Scope / note
Config-only; no code change; consensus-neutral. **Separate item:** the recurring red on the **`Code Coverage Analysis` GH Actions job** itself (live-backend RPC + shutdown SIGABRT in `coverage.yml`) is a job-level flake not addressed here — flag if you want that fixed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)