### PR TITLE
perf: de-dup per-block consensus-hash DB query + drop no-op str-join (check.py)

### DIFF
--- a/indexer/src/index_core/block_validation.py
+++ b/indexer/src/index_core/block_validation.py
@@ -56,22 +56,31 @@ def create_check_hashes(
     Returns:
         tuple: A tuple containing the new ledger hash, transaction list hash, and messages hash.
     """
+    # Fetch the block row once and share it across the 3 per-block consensus_hash
+    # calls below. consensus_hash only reads found_hash (per-field) from this row;
+    # the per-call UPDATEs touch a different column than each call reads, so the row
+    # is byte-identical whether fetched once up front or 3x inline. Output-neutral.
+    cursor = db.cursor()
+    cursor.execute("""SELECT * FROM blocks WHERE block_index = %s""", (block_index,))
+    block_results = cursor.fetchall()
+    block_row = block_results[0] if block_results else None
+
     # Filter out None values before sorting
     filtered_stamps = [stamp for stamp in valid_stamps_in_block if stamp is not None]
     sorted_valid_stamps = sorted(filtered_stamps, key=lambda x: x.get("stamp_number", 0))
     txlist_content = str(sorted_valid_stamps)
     new_txlist_hash, found_txlist_hash = check.consensus_hash(
-        db, block_index, "txlist_hash", previous_txlist_hash, txlist_content
+        db, block_index, "txlist_hash", previous_txlist_hash, txlist_content, block_row=block_row
     )
 
     ledger_content = str(processed_src20_in_block)
     new_ledger_hash, found_ledger_hash = check.consensus_hash(
-        db, block_index, "ledger_hash", previous_ledger_hash, ledger_content
+        db, block_index, "ledger_hash", previous_ledger_hash, ledger_content, block_row=block_row
     )
 
     messages_content = str(txhash_list)
     new_messages_hash, found_messages_hash = check.consensus_hash(
-        db, block_index, "messages_hash", previous_messages_hash, messages_content
+        db, block_index, "messages_hash", previous_messages_hash, messages_content, block_row=block_row
     )
 
     try:

--- a/indexer/src/index_core/check.py
+++ b/indexer/src/index_core/check.py
@@ -231,7 +231,12 @@ def handle_consensus_error(error_msg: str) -> None:
         raise ConsensusError(error_msg)
 
 
-def consensus_hash(db, block_index, field, previous_consensus_hash, content):
+# Sentinel distinguishing "block_row not provided" (self-fetch) from an
+# explicitly-passed row that may legitimately be None (block not in db).
+_BLOCK_ROW_NOT_PROVIDED = object()
+
+
+def consensus_hash(db, block_index, field, previous_consensus_hash, content, block_row=_BLOCK_ROW_NOT_PROVIDED):
     field_position = config.BLOCK_FIELDS_POSITION
     cursor = db.cursor()
 
@@ -296,13 +301,18 @@ def consensus_hash(db, block_index, field, previous_consensus_hash, content):
         calculated_hash = ""
     else:
         # For other hashes (messages, txlist), use the previous consensus hash in calculation
-        calculated_hash = util.dhash_string(previous_consensus_hash + "{}{}".format(consensus_hash_version, "".join(content)))
+        # content is always a string on the consensus path (#803), so "".join(content) == content.
+        calculated_hash = util.dhash_string(previous_consensus_hash + "{}{}".format(consensus_hash_version, content))
 
     # Verify hash (if already in database) or save hash (if not).
-    cursor.execute("""SELECT * FROM blocks WHERE block_index = %s""", (block_index,))
-    results = cursor.fetchall()
-    if results:
-        found_hash = results[0][config.BLOCK_FIELDS_POSITION[field]]
+    # The block row is identical across the 3 per-block calls (txlist/ledger/messages),
+    # so callers may fetch it once and pass it in via block_row to avoid 3x SELECTs.
+    if block_row is _BLOCK_ROW_NOT_PROVIDED:
+        cursor.execute("""SELECT * FROM blocks WHERE block_index = %s""", (block_index,))
+        results = cursor.fetchall()
+        block_row = results[0] if results else None
+    if block_row is not None:
+        found_hash = block_row[config.BLOCK_FIELDS_POSITION[field]]
     else:
         found_hash = None
     if found_hash and field != "messages_hash":

--- a/indexer/tests/test_block_validation.py
+++ b/indexer/tests/test_block_validation.py
@@ -78,6 +78,12 @@ class TestBlockValidation:
         from index_core.block_validation import create_check_hashes
 
         mock_db = Mock()
+        # create_check_hashes fetches the block row once and shares it across the
+        # 3 consensus_hash calls; give the cursor a subscriptable row (>=9 cols to
+        # cover config.BLOCK_FIELDS_POSITION) so block_results[0] does not raise.
+        mock_cursor = Mock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [(None,) * 10]
 
         with patch("index_core.check.consensus_hash") as mock_consensus_hash, patch(
             "index_core.block_validation.update_block_hashes"
@@ -100,6 +106,12 @@ class TestBlockValidation:
         from index_core.exceptions import BlockUpdateError
 
         mock_db = Mock()
+        # create_check_hashes fetches the block row once before the (mocked)
+        # consensus_hash calls; give the cursor a subscriptable row so
+        # block_results[0] does not raise before update_block_hashes errors.
+        mock_cursor = Mock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [(None,) * 10]
 
         with patch("index_core.check.consensus_hash") as mock_consensus_hash, patch(
             "index_core.block_validation.update_block_hashes"
@@ -123,6 +135,12 @@ class TestBlockValidation:
         from index_core.block_validation import create_check_hashes
 
         mock_db = Mock()
+        # create_check_hashes fetches the block row once and shares it across the
+        # 3 consensus_hash calls; give the cursor a subscriptable row so
+        # block_results[0] does not raise.
+        mock_cursor = Mock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [(None,) * 10]
 
         # Create stamps in non-sorted order
         valid_stamps = [
@@ -469,6 +487,12 @@ class TestBlockValidationEdgeCases:
         from index_core.block_validation import create_check_hashes
 
         mock_db = Mock()
+        # create_check_hashes fetches the block row once and shares it across the
+        # 3 consensus_hash calls; give the cursor a subscriptable row so
+        # block_results[0] does not raise.
+        mock_cursor = Mock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [(None,) * 10]
 
         # Include None in the list (should be filtered out)
         valid_stamps = [
@@ -541,6 +565,12 @@ class TestBlockValidationEdgeCases:
         from index_core.block_validation import create_check_hashes
 
         mock_db = Mock()
+        # create_check_hashes fetches the block row once and shares it across the
+        # 3 consensus_hash calls; give the cursor a subscriptable row so
+        # block_results[0] does not raise.
+        mock_cursor = Mock()
+        mock_db.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [(None,) * 10]
 
         # Create stamps with missing stamp_number fields
         valid_stamps = [

--- a/indexer/tests/test_check.py
+++ b/indexer/tests/test_check.py
@@ -5,10 +5,12 @@ import warnings
 from unittest.mock import MagicMock, Mock, patch
 
 import config
+import index_core.util as util
 from index_core.check import (
     CHECKPOINTS_MAINNET,
     CHECKPOINTS_REGTEST,
     CHECKPOINTS_TESTNET,
+    CONSENSUS_HASH_VERSION_MAINNET,
     ConsensusError,
     VersionError,
     VersionUpdateRequiredError,
@@ -225,6 +227,98 @@ class TestConsensusHash(unittest.TestCase):
         calculated, found = consensus_hash(self.db, 800000, "ledger_hash", "previous_hash", "")
 
         self.assertEqual(calculated, "")
+
+
+class TestConsensusHashPerfOptimizations(unittest.TestCase):
+    """Output-neutrality tests for the consensus-hash perf optimizations (Refs #817).
+
+    Covers (a) dropping the no-op "".join(content), (b) the optional block_row
+    de-dup of the per-block blocks SELECT, and (c) create_check_hashes fetching
+    the block row once for all 3 per-block consensus_hash calls.
+    """
+
+    def setUp(self):
+        self.db = Mock()
+        self.cursor = Mock()
+        self.db.cursor.return_value = self.cursor
+
+    @patch("index_core.check.config.TESTNET", False)
+    @patch("index_core.check.config.REGTEST", False)
+    @patch("index_core.check.config.BLOCK_FIELDS_POSITION", {"txlist_hash": 5})
+    @patch("index_core.check.CHECKPOINTS_MAINNET", {})
+    def test_join_noop_is_byte_identical_for_string_content(self):
+        """(a) For string content (the only kind on the consensus path, #803),
+        "".join(content) == content, so the calculated hash is unchanged."""
+        content = str([{"stamp_number": 1}, {"stamp_number": 2}])
+        previous = "a" * 64
+        version = CONSENSUS_HASH_VERSION_MAINNET
+
+        # The exact pre-change vs post-change expression, with REAL hashing.
+        old_form = util.dhash_string(previous + "{}{}".format(version, "".join(content)))
+        new_form = util.dhash_string(previous + "{}{}".format(version, content))
+        self.assertEqual(old_form, new_form)
+
+        # And the function itself now produces that identical value.
+        self.cursor.fetchall.return_value = []  # no existing row -> save path
+        calculated, found = consensus_hash(self.db, 850000, "txlist_hash", previous, content)
+        self.assertEqual(calculated, new_form)
+        self.assertEqual(calculated, old_form)
+        self.assertIsNone(found)
+
+    @patch("index_core.check.config.TESTNET", False)
+    @patch("index_core.check.config.REGTEST", False)
+    @patch("index_core.check.config.BLOCK_FIELDS_POSITION", {"messages_hash": 6})
+    def test_block_row_matches_self_fetch_and_skips_select(self):
+        """(b) A passed block_row yields the same found_hash as the self-fetch
+        path and issues no blocks SELECT."""
+        row = [None] * 10
+        row[6] = "existing_messages_hash"
+        row = tuple(row)
+
+        with patch("index_core.check.util.dhash_string", return_value="calc"):
+            # Self-fetch path (backward-compatible: no block_row passed).
+            self.cursor.fetchall.return_value = [row]
+            _, found_self = consensus_hash(self.db, 800000, "messages_hash", "prev", "content")
+
+            # Passed-row path on a fresh cursor that returns nothing if queried.
+            cursor2 = Mock()
+            db2 = Mock()
+            db2.cursor.return_value = cursor2
+            _, found_passed = consensus_hash(db2, 800000, "messages_hash", "prev", "content", block_row=row)
+
+        self.assertEqual(found_self, "existing_messages_hash")
+        self.assertEqual(found_passed, found_self)
+
+        # No blocks SELECT issued when block_row is provided.
+        blocks_selects = [
+            c for c in cursor2.execute.call_args_list if "SELECT" in str(c) and "blocks" in str(c)
+        ]
+        self.assertEqual(blocks_selects, [])
+
+    def test_create_check_hashes_fetches_block_row_once(self):
+        """(c) create_check_hashes fetches the block row exactly once and shares
+        it across all 3 per-block consensus_hash calls."""
+        from index_core import block_validation
+
+        db = Mock()
+        cursor = Mock()
+        db.cursor.return_value = cursor
+        row = ("r",) * 10
+        cursor.fetchall.return_value = [row]
+
+        with patch.object(block_validation.check, "consensus_hash", return_value=("new", "found")) as mock_ch, patch.object(
+            block_validation, "update_block_hashes"
+        ):
+            block_validation.create_check_hashes(db, 800000, [], [], ["txhash"])
+
+        # Exactly one blocks SELECT for the whole block.
+        blocks_selects = [c for c in cursor.execute.call_args_list if "SELECT" in str(c) and "blocks" in str(c)]
+        self.assertEqual(len(blocks_selects), 1)
+
+        # All 3 calls share the same fetched row via block_row.
+        self.assertEqual(mock_ch.call_count, 3)
+        for call in mock_ch.call_args_list:
+            self.assertEqual(call.kwargs.get("block_row"), row)
 
 
 class TestCheckpoints(unittest.TestCase):

--- a/indexer/tests/test_check.py
+++ b/indexer/tests/test_check.py
@@ -290,9 +290,7 @@ class TestConsensusHashPerfOptimizations(unittest.TestCase):
         self.assertEqual(found_passed, found_self)
 
         # No blocks SELECT issued when block_row is provided.
-        blocks_selects = [
-            c for c in cursor2.execute.call_args_list if "SELECT" in str(c) and "blocks" in str(c)
-        ]
+        blocks_selects = [c for c in cursor2.execute.call_args_list if "SELECT" in str(c) and "blocks" in str(c)]
         self.assertEqual(blocks_selects, [])
 
     def test_create_check_hashes_fetches_block_row_once(self):


### PR DESCRIPTION
## What

Two output-neutral perf optimizations on the per-block consensus-hash path in `check.py` / `block_validation.py`, surfaced by #817:

1. **Drop the no-op `"".join(content)`** in `consensus_hash` (check.py). `content` is always a string on the consensus path — `create_check_hashes` passes `str(sorted_valid_stamps)` / `str(processed_src20_in_block)` / `str(txhash_list)` (the #803 str-coupling). Since `"".join(<string>) == <string>`, the calculated hash is byte-identical. Replaced `"{}{}".format(version, "".join(content))` with `"{}{}".format(version, content)`.

2. **De-dup the per-block `SELECT * FROM blocks`.** `create_check_hashes` calls `consensus_hash` 3x per block (txlist / ledger / messages), each re-fetching the same block row. The row is now fetched **once** in `create_check_hashes` and passed in via a new optional `block_row` param. When omitted, `consensus_hash` self-fetches exactly as before (sentinel default), so all other callers (`reparse/snapshot.py`, existing tests) are unaffected. Each call reads a different per-field column than any prior call updates, so `found_hash` is identical whether the row is fetched once up front or 3x inline.

## Why

The per-block consensus-hash path runs for every block during sync/reparse; the duplicate `SELECT * FROM blocks` (3x/block) and the redundant `"".join` over an already-joined string are pure overhead.

## Output-neutral / #803-safe

Preserves byte-identical hash content; `"".join(str) == str`; the SELECT only reads `found_hash`, not `calculated_hash`. **Reparse Consensus Validation (txlist+ledger identical) is the proof.** No change to `calculated_hash`, the save/update path, `handle_consensus_error`, field positions, or the str()-coupling (#803).

## Tests

Added a focused unit test class (`TestConsensusHashPerfOptimizations`, mocked db cursor, pure-unit) proving:
- (a) for string content the calculated hash is unchanged vs the old `"".join` form (both computed with real hashing, asserted equal);
- (b) `consensus_hash` with a passed `block_row` yields the same `found_hash` as the self-fetch path and issues no blocks SELECT;
- (c) `create_check_hashes` fetches the block row once and shares it across all 3 calls.

Local reparse skipped to protect the running from-genesis VALIDATION reindex, so **CI's Reparse Consensus Validation is authoritative**.

Refs #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)
