### PR TITLE
docs(#749): correct misleading P2WSH/MULTISIG comment in transaction_utils.py

### DIFF
--- a/indexer/src/index_core/transaction_utils.py
+++ b/indexer/src/index_core/transaction_utils.py
@@ -566,7 +566,10 @@ def get_tx_info(tx_hex, block_index=None, db=None, stamp_issuance=None):
         # SRC-20 via MULTISIG
         # This prioritizes P2WSH over CHECKMULTISIG in a mixed transaction
         # To be deprecated in a future block height over P2WSH for all SRC-20 transactions
-        # Important: Continue to process MULTISIG data even if P2WSH data is present but invalid
+        # NOTE: this is `elif`, so once a P2WSH data chunk is present the MULTISIG branch is
+        # intentionally NOT attempted -- even when the P2WSH data fails its length check. That
+        # exclusion is consensus-load-bearing (matches the stampscan reference implementation);
+        # adding a MULTISIG fallback here would fork consensus. See issue #749 (WONTFIX).
         elif pubkeys_compiled:
             chunk = b"".join(pubkey[1:-1] for pubkey in pubkeys_compiled)
             try:


### PR DESCRIPTION
## Summary
Doc-only fix. The comment at `transaction_utils.py:569` said "Continue to process MULTISIG data even if P2WSH data is present but invalid" — but the `elif` does the **opposite**: once a P2WSH data chunk is present, the MULTISIG branch is skipped even when the P2WSH data fails its length check. Rewrites the comment to document the actual, **consensus-load-bearing** behavior (P2WSH-priority + no MULTISIG fallback, matching the stampscan reference implementation) and references #749.

Closes the only remaining follow-up from #749 (closed WONTFIX — consensus-correct exclusion).

## Consensus impact
- [x] **None** — comment-only; no change to the decode/filter/parse path or the rolling hashes.

## Validation
- Comment-only change; line length within the 127 limit. No code/tests affected.