### PR TITLE
fix(ci): retry socket timeouts in reparse public_backend (fixes flaky Reparse Consensus Validation)

### DIFF
--- a/indexer/ci/public_backend.py
+++ b/indexer/ci/public_backend.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import socket
 import time
 import urllib.error
 import urllib.request
@@ -47,7 +48,7 @@ _MIN_INTERVAL = float(os.environ.get("CI_BLOCKSTREAM_MIN_INTERVAL", "0.6"))
 _last_request_at = [0.0]
 
 
-def _http_get(url: str, timeout: int = 30, retries: int = 10) -> bytes:
+def _http_get(url: str, timeout: int = 60, retries: int = 10) -> bytes:
     # blockstream.info rate-limits (HTTP 429). Two-pronged resilience: (1) a
     # global min-interval throttle to avoid provoking 429 in the first place,
     # and (2) capped exponential backoff that retries transient 429/503 hard so
@@ -68,6 +69,15 @@ def _http_get(url: str, timeout: int = 30, retries: int = 10) -> bytes:
             if e.code not in (429, 503):
                 raise
             time.sleep(min(45, 3 * (attempt + 1)))
+        except (socket.timeout, TimeoutError, ConnectionError) as e:
+            # On py>=3.10 a socket read timeout raises bare TimeoutError
+            # (== socket.timeout), which is NOT a urllib URLError/HTTPError, so
+            # without this branch a transient read timeout would escape the
+            # retry loop and fail the whole reparse job (the recurring flaky
+            # "Reparse Consensus Validation" timeout). Retry it with the same
+            # capped exponential backoff as other transient network errors.
+            last_err = e
+            time.sleep(min(30, 2**attempt))
         except urllib.error.URLError as e:  # type: ignore[attr-defined]
             last_err = e
             time.sleep(min(30, 2**attempt))

--- a/indexer/tests/test_public_backend_timeout_retry.py
+++ b/indexer/tests/test_public_backend_timeout_retry.py
@@ -1,0 +1,88 @@
+"""Focused regression test for ci/public_backend._http_get socket-timeout retry.
+
+Root cause guarded here: on py>=3.10 a socket read timeout raises a bare
+``TimeoutError`` (== ``socket.timeout``), which is NEITHER ``urllib.error.HTTPError``
+nor ``urllib.error.URLError``. Before the fix it escaped the retry loop and failed
+the whole reparse job (the recurring flaky "Reparse Consensus Validation" timeout).
+The fix retries it with the existing capped exponential backoff; this test asserts
+``_http_get`` retries past a transient ``TimeoutError`` and ultimately succeeds.
+
+The ci/ module is CI infrastructure (not a package on the import path), so we load
+it by file path rather than importing it as a normal module.
+"""
+
+import importlib.util
+import os
+import socket
+from pathlib import Path
+from unittest import mock
+
+_MODULE_PATH = Path(__file__).resolve().parent.parent / "ci" / "public_backend.py"
+
+
+def _load_public_backend():
+    spec = importlib.util.spec_from_file_location("ci_public_backend", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_http_get_retries_socket_timeout_then_succeeds():
+    pb = _load_public_backend()
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b"block-bytes"
+
+    # First call: socket read timeout (bare TimeoutError on py>=3.10). Second
+    # call: a valid response. The retry branch must absorb the timeout so the
+    # second attempt runs and returns the bytes.
+    calls = {"n": 0}
+
+    def _fake_urlopen(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError("timed out")
+        return _FakeResp()
+
+    # socket.timeout is an alias of TimeoutError on py>=3.10 — assert the
+    # premise so the test stays honest about what it is guarding.
+    assert socket.timeout is TimeoutError or issubclass(socket.timeout, OSError)
+
+    with mock.patch.object(pb.urllib.request, "urlopen", _fake_urlopen), mock.patch.object(
+        pb.time, "sleep", lambda *_a, **_k: None
+    ):
+        result = pb._http_get("https://example.invalid/block/abc/raw")
+
+    assert result == b"block-bytes"
+    assert calls["n"] == 2, "expected exactly one retry after the transient timeout"
+
+
+def test_http_get_raises_after_exhausting_retries_on_timeout():
+    pb = _load_public_backend()
+
+    def _always_timeout(req, timeout=None):
+        raise socket.timeout("timed out")
+
+    with mock.patch.object(pb.urllib.request, "urlopen", _always_timeout), mock.patch.object(
+        pb.time, "sleep", lambda *_a, **_k: None
+    ):
+        try:
+            pb._http_get("https://example.invalid/block/abc/raw", retries=3)
+        except RuntimeError as e:
+            assert "failed after 3 attempts" in str(e)
+        else:  # pragma: no cover - guard
+            raise AssertionError("expected RuntimeError after exhausting retries")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    os.environ.setdefault("CI_BLOCKSTREAM_MIN_INTERVAL", "0")
+    test_http_get_retries_socket_timeout_then_succeeds()
+    test_http_get_raises_after_exhausting_retries_on_timeout()
+    print("ok")


### PR DESCRIPTION
## Root cause

The reparse-validate CI workflow's `indexer/ci/public_backend.py::_http_get` retry loop only caught `urllib.error.HTTPError` and `urllib.error.URLError`. On py>=3.10 a socket **read timeout** raises a bare `TimeoutError` (== `socket.timeout`), which is **neither** of those — so it escaped the retry/backoff loop entirely and failed the whole job. This is the recurring flaky **Reparse Consensus Validation** timeout (e.g. block 868008 on #843).

## Fix

- Add `socket.timeout` / `TimeoutError` / `ConnectionError` to the retried exception set, using the **existing** capped exponential backoff — a transient read timeout is now retried instead of raised immediately.
- Bump the `urlopen` timeout for the large `/block/{hash}/raw` fetch from `30s` → `60s` (single conservative bump).
- Adds a focused unit test (`tests/test_public_backend_timeout_retry.py`) that mocks `urllib.request.urlopen` to raise `TimeoutError` once then return a valid response, asserting `_http_get` retries and ultimately succeeds (plus a retry-exhaustion case).

No refactor of the backoff; no change to non-timeout behavior; no other file touched.

## Diff (exception handling)

```python
        except (socket.timeout, TimeoutError, ConnectionError) as e:
            last_err = e
            time.sleep(min(30, 2**attempt))
        except urllib.error.URLError as e:  # unchanged
            last_err = e
            time.sleep(min(30, 2**attempt))
```

Timeout constant: `_http_get(..., timeout: int = 30, ...)` → `timeout: int = 60`.

## Scope

**consensus-None (CI tooling only)** — `indexer/ci/` is test/CI infrastructure, not the production indexer code path. Block bytes are still hash-verified by the caller, so trust is unchanged.

Refs #844