### PR TITLE
perf(tools): harden update_bg.py for the WebP background S3 refresh (#846)

### DIFF
--- a/indexer/tools/update_bg.py
+++ b/indexer/tools/update_bg.py
@@ -1,91 +1,148 @@
+#!/usr/bin/env python3
+"""Regenerate stored SRC-20 stamp SVGs for given ticks and re-upload them to S3.
+
+Use this after changing a token's background in ``srcbackground`` (e.g. the WebP
+re-encode in tools/convert_backgrounds_to_webp.py) to refresh the already-rendered
+``{tx_hash}.svg`` files on S3 **without** a full chain reindex. For each matching
+``SRC20Valid`` row it rebuilds the SVG from the current background, uploads it
+(overwriting the same S3 key), and updates ``StampTableV4.file_hash`` /
+``file_size_bytes``.
+
+Connection uses the standard ``RDS_*`` env vars, so run this on the host whose env
+points at the target database (the prod deployment's env points ``RDS_*`` at Aurora).
+S3 upload only happens when ``STORE_FILES`` + ``AWS_S3_*`` are configured (see config.py);
+with storage disabled it updates the DB only -- so a dev run never touches S3.
+
+CDN note: stamp objects are served by Cloudflare as ``immutable, max-age=31536000``.
+Overwriting S3 alone leaves clients on the stale cached copy, so this writes a purge
+manifest (one stamp URL per regenerated file) for a follow-up Cloudflare cache purge.
+
+Usage:
+    poetry run python tools/update_bg.py KEVIN STAMP            # specific ticks
+    poetry run python tools/update_bg.py --all-webp            # every tick now WebP-backed
+    poetry run python tools/update_bg.py --all-webp --dry-run  # report only, no upload/DB write
+"""
+
 import argparse
 import os
 import sys
 
 import pymysql as mysql
-
-if os.getcwd().endswith("/indexer"):
-    sys.path.append(os.getcwd())
-    dotenv_path = os.path.join(os.getcwd(), ".env")
-else:
-    sys.path.append(os.path.join(os.getcwd(), "indexer"))
-    dotenv_path = os.path.join(os.getcwd(), "indexer/.env")
-
 from dotenv import load_dotenv
 
-load_dotenv(dotenv_path=dotenv_path, override=True)
+_INDEXER_DIR = os.getcwd() if os.getcwd().endswith("/indexer") else os.path.join(os.getcwd(), "indexer")
+sys.path.append(_INDEXER_DIR)
+# config in this stack reads .env.local; fall back to .env. Neither overrides a real env var.
+for _name in (".env.local", ".env"):
+    load_dotenv(dotenv_path=os.path.join(_INDEXER_DIR, _name))
 
-import config
-from index_core.aws import get_s3_objects
-from index_core.src20 import build_src20_svg_string
-from index_core.stamp import store_files
+import config  # noqa: E402
+from index_core.aws import get_s3_objects  # noqa: E402
+from index_core.src20 import build_src20_svg_string  # noqa: E402
+from index_core.stamp import store_files  # noqa: E402
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "ticks_to_update",
-    nargs="+",
-    help=f"""
-    Provide a list of tick values to update.
-    Use double backslash for unicode chars.
-    Example: `python {os.path.basename(__file__)} kevin stamp bear\\\\u0001f43b`""",
-)
-args = parser.parse_args()
-
-ticks_to_update = args.ticks_to_update
-
-# we are specifying specific vars here instead of using defaults in config.py
-# so we can update to production or dev db's specifically
-rds_host = os.environ.get("ST3_HOSTNAME")
-rds_user = os.environ.get("ST3_USER")
-rds_password = os.environ.get("ST3_PASSWORD")
-rds_database = os.environ.get("RDS_DATABASE")
-rds_port = int(os.environ.get("RDS_PORT", 3306))
-
-db = mysql.connect(
-    host=rds_host,
-    user=rds_user,
-    password=rds_password,
-    port=rds_port,
-    database=rds_database,
-)
+STAMP_MIMETYPE = "image/svg+xml"
 
 
-print("connecting to database", rds_host)
-config.S3_OBJECTS = get_s3_objects(db, config.AWS_S3_BUCKETNAME, config.AWS_S3_CLIENT)
-
-
-stamp_mimetype = "image/svg+xml"
-cursor = db.cursor()
-
-for tick_to_update in ticks_to_update:
-    print(f"Updating {tick_to_update}...")
-
-    cursor.execute(
-        "SELECT tx_hash, p, op, tick, amt, lim, max FROM SRC20Valid WHERE tick = %s",
-        (tick_to_update,),
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument(
+        "ticks",
+        nargs="*",
+        help="tick values to regenerate (use double backslash for unicode, e.g. bear\\\\u0001f43b)",
     )
-    src_20_dict = cursor.fetchall()
+    p.add_argument(
+        "--all-webp",
+        action="store_true",
+        help="regenerate every tick whose srcbackground is now image/webp (the converted set)",
+    )
+    p.add_argument("--dry-run", action="store_true", help="report counts/sizes only; no S3 upload, no DB write")
+    p.add_argument(
+        "--manifest",
+        default="update_bg_purge_urls.txt",
+        help="file to write regenerated stamp URLs for the Cloudflare purge step",
+    )
+    return p.parse_args()
 
-    for row in src_20_dict:
-        tx_hash, p, op, tick, amt, lim, max = row
-        # convert the decimal value of amt to an int
-        if amt:
-            amt = int(amt)
-        p = p.upper()
-        tick = tick.upper()
-        op = op.upper()
-        svg_string = build_src20_svg_string(db, {"p": p, "op": op, "tick": tick, "amt": amt, "lim": lim, "max": max})
 
-        file_suffix = "svg"
-        if type(svg_string) is str:
-            svg_string = svg_string.encode("utf-8")
-        filename = f"{tx_hash}.{file_suffix}"
-        file_obj_md5 = store_files(db, filename, svg_string, stamp_mimetype)
+def connect():
+    return mysql.connect(
+        host=os.environ.get("RDS_HOSTNAME"),
+        user=os.environ.get("RDS_USER"),
+        password=os.environ.get("RDS_PASSWORD"),
+        port=int(os.environ.get("RDS_PORT", 3306)),
+        database=os.environ.get("RDS_DATABASE"),
+    )
 
+
+def resolve_ticks(cursor, args):
+    if args.all_webp:
+        cursor.execute("SELECT tick FROM srcbackground WHERE base64 LIKE 'image/webp%' AND p = 'SRC-20'")
+        return [r[0] for r in cursor.fetchall()]
+    return args.ticks
+
+
+def main():
+    args = parse_args()
+    db = connect()
+    cursor = db.cursor()
+    print(f"connected to {os.environ.get('RDS_HOSTNAME')} / {os.environ.get('RDS_DATABASE')}  dry_run={args.dry_run}")
+
+    s3_enabled = bool(config.AWS_S3_ENABLED)
+    if not args.dry_run and not s3_enabled:
+        print("WARNING: S3 storage is disabled (STORE_FILES/AWS_S3_* unset) -- will update DB only, no upload.")
+    if not args.dry_run and s3_enabled:
+        config.S3_OBJECTS = get_s3_objects(db, config.AWS_S3_BUCKETNAME, config.AWS_S3_CLIENT)
+
+    ticks = resolve_ticks(cursor, args)
+    if not ticks:
+        print("no ticks to process (pass ticks or --all-webp)")
+        return
+    print(f"processing {len(ticks)} tick(s)")
+
+    regenerated = 0
+    manifest = []
+    for tick in ticks:
         cursor.execute(
-            "UPDATE StampTableV4 SET file_hash = %s WHERE tx_hash = %s",
-            (file_obj_md5, tx_hash),
+            "SELECT tx_hash, p, op, tick, amt, lim, max FROM SRC20Valid WHERE tick = %s",
+            (tick,),
         )
+        rows = cursor.fetchall()
+        for tx_hash, p, op, row_tick, amt, lim, mx in rows:
+            svg = build_src20_svg_string(
+                db,
+                {
+                    "p": p.upper(),
+                    "op": op.upper(),
+                    "tick": row_tick.upper(),
+                    "amt": int(amt) if amt else amt,
+                    "lim": lim,
+                    "max": mx,
+                },
+            )
+            if isinstance(svg, str):
+                svg = svg.encode("utf-8")
+            filename = f"{tx_hash}.svg"
+            manifest.append(f"https://{config.DOMAINNAME}/stamps/{filename}")
+            if not args.dry_run:
+                file_obj_md5, _ = store_files(db, filename, svg, STAMP_MIMETYPE)
+                cursor.execute(
+                    "UPDATE StampTableV4 SET file_hash = %s, file_size_bytes = %s WHERE tx_hash = %s",
+                    (file_obj_md5, len(svg), tx_hash),
+                )
+            regenerated += 1
+        print(f"  {tick}: {len(rows)} stamp(s)")
 
-db.commit()
-db.close()
+    if not args.dry_run:
+        db.commit()
+    with open(args.manifest, "w") as f:
+        f.write("\n".join(manifest) + ("\n" if manifest else ""))
+    db.close()
+    action = "would regenerate" if args.dry_run else "regenerated"
+    print(f"{action} {regenerated} SVG(s); wrote {len(manifest)} URLs to {args.manifest}")
+    if not args.dry_run and s3_enabled:
+        print("NEXT: purge these URLs (or the /stamps/ path) from Cloudflare so clients drop the immutable cache.")
+
+
+if __name__ == "__main__":
+    main()

--- a/indexer/tools/update_bg.py
+++ b/indexer/tools/update_bg.py
@@ -110,52 +110,55 @@ def main():
         return
     print(f"processing {len(ticks)} tick(s)")
 
+    # Flush async uploads per tick: the unbounded upload queue would otherwise buffer the
+    # whole run (~1.2M SVGs) in memory. Per-tick commit also checkpoints progress.
+    flush_async = (not args.dry_run) and s3_enabled and config.USE_ASYNC_UPLOADS
     regenerated = 0
-    manifest = []
-    for tick in ticks:
-        cursor.execute(
-            "SELECT tx_hash, p, op, tick, amt, lim, max FROM SRC20Valid WHERE tick = %s",
-            (tick,),
-        )
-        rows = cursor.fetchall()
-        for tx_hash, p, op, row_tick, amt, lim, mx in rows:
-            svg = build_src20_svg_string(
-                db,
-                {
-                    "p": p.upper(),
-                    "op": op.upper(),
-                    "tick": row_tick.upper(),
-                    "amt": int(amt) if amt else amt,
-                    "lim": lim,
-                    "max": mx,
-                },
+    manifest_count = 0
+    manifest_f = open(args.manifest, "w")
+    try:
+        for i, tick in enumerate(ticks, 1):
+            cursor.execute(
+                "SELECT tx_hash, p, op, tick, amt, lim, max FROM SRC20Valid WHERE tick = %s",
+                (tick,),
             )
-            if isinstance(svg, str):
-                svg = svg.encode("utf-8")
-            filename = f"{tx_hash}.svg"
-            manifest.append(f"https://{config.DOMAINNAME}/stamps/{filename}")
-            if not args.dry_run:
-                file_obj_md5, _ = store_files(db, filename, svg, STAMP_MIMETYPE)
-                cursor.execute(
-                    "UPDATE StampTableV4 SET file_hash = %s, file_size_bytes = %s WHERE tx_hash = %s",
-                    (file_obj_md5, len(svg), tx_hash),
+            rows = cursor.fetchall()
+            for tx_hash, p, op, row_tick, amt, lim, mx in rows:
+                svg = build_src20_svg_string(
+                    db,
+                    {
+                        "p": p.upper(),
+                        "op": op.upper(),
+                        "tick": row_tick.upper(),
+                        "amt": int(amt) if amt else amt,
+                        "lim": lim,
+                        "max": mx,
+                    },
                 )
-            regenerated += 1
-        print(f"  {tick}: {len(rows)} stamp(s)")
-
-    if not args.dry_run:
-        db.commit()
-        # store_files queues async uploads on a background worker; flush them before exit,
-        # otherwise the process ends with uploads (and their s3objects updates) still pending.
-        if s3_enabled and config.USE_ASYNC_UPLOADS:
-            print("flushing async uploads...")
-            wait_for_uploads()
+                if isinstance(svg, str):
+                    svg = svg.encode("utf-8")
+                filename = f"{tx_hash}.svg"
+                manifest_f.write(f"https://{config.DOMAINNAME}/stamps/{filename}\n")
+                manifest_count += 1
+                if not args.dry_run:
+                    file_obj_md5, _ = store_files(db, filename, svg, STAMP_MIMETYPE)
+                    cursor.execute(
+                        "UPDATE StampTableV4 SET file_hash = %s, file_size_bytes = %s WHERE tx_hash = %s",
+                        (file_obj_md5, len(svg), tx_hash),
+                    )
+                regenerated += 1
+            if not args.dry_run:
+                db.commit()
+                if flush_async:
+                    wait_for_uploads()  # drain this tick's uploads before the next -> bounded memory
+            print(f"  [{i}/{len(ticks)}] {tick}: {len(rows)} stamp(s)  (total {regenerated})")
+    finally:
+        manifest_f.close()
+        if flush_async:
             stop_upload_worker()
-    with open(args.manifest, "w") as f:
-        f.write("\n".join(manifest) + ("\n" if manifest else ""))
-    db.close()
+        db.close()
     action = "would regenerate" if args.dry_run else "regenerated"
-    print(f"{action} {regenerated} SVG(s); wrote {len(manifest)} URLs to {args.manifest}")
+    print(f"{action} {regenerated} SVG(s); wrote {manifest_count} URLs to {args.manifest}")
     if not args.dry_run and s3_enabled:
         print("NEXT: purge these URLs (or the /stamps/ path) from Cloudflare so clients drop the immutable cache.")
 

--- a/indexer/tools/update_bg.py
+++ b/indexer/tools/update_bg.py
@@ -37,6 +37,7 @@ for _name in (".env.local", ".env"):
     load_dotenv(dotenv_path=os.path.join(_INDEXER_DIR, _name))
 
 import config  # noqa: E402
+from index_core.async_upload import stop_upload_worker, wait_for_uploads  # noqa: E402
 from index_core.aws import get_s3_objects  # noqa: E402
 from index_core.src20 import build_src20_svg_string  # noqa: E402
 from index_core.stamp import store_files  # noqa: E402
@@ -57,6 +58,12 @@ def parse_args():
         help="regenerate every tick whose srcbackground is now image/webp (the converted set)",
     )
     p.add_argument("--dry-run", action="store_true", help="report counts/sizes only; no S3 upload, no DB write")
+    p.add_argument(
+        "--no-s3-dedup",
+        action="store_true",
+        help="skip enumerating existing S3 objects; treat every file as new (overwrite). "
+        "Use when every targeted file changed (e.g. --all-webp) to avoid a full-bucket list.",
+    )
     p.add_argument(
         "--manifest",
         default="update_bg_purge_urls.txt",
@@ -92,7 +99,10 @@ def main():
     if not args.dry_run and not s3_enabled:
         print("WARNING: S3 storage is disabled (STORE_FILES/AWS_S3_* unset) -- will update DB only, no upload.")
     if not args.dry_run and s3_enabled:
-        config.S3_OBJECTS = get_s3_objects(db, config.AWS_S3_BUCKETNAME, config.AWS_S3_CLIENT)
+        if args.no_s3_dedup:
+            config.S3_OBJECTS = {}  # every upload treated as new -> overwrite; no bucket enumeration
+        else:
+            config.S3_OBJECTS = get_s3_objects(db, config.AWS_S3_BUCKETNAME, config.AWS_S3_CLIENT)
 
     ticks = resolve_ticks(cursor, args)
     if not ticks:
@@ -135,6 +145,12 @@ def main():
 
     if not args.dry_run:
         db.commit()
+        # store_files queues async uploads on a background worker; flush them before exit,
+        # otherwise the process ends with uploads (and their s3objects updates) still pending.
+        if s3_enabled and config.USE_ASYNC_UPLOADS:
+            print("flushing async uploads...")
+            wait_for_uploads()
+            stop_upload_worker()
     with open(args.manifest, "w") as f:
         f.write("\n".join(manifest) + ("\n" if manifest else ""))
     db.close()


### PR DESCRIPTION
Hardens `tools/update_bg.py` — the tool that regenerates stored SRC-20 SVGs per tick and re-uploads to S3 **without a full reindex**, i.e. the rollout path for the WebP background conversion (#846 / #851).

## Changes
- **Bug fix:** it wrote the `store_files()` return **tuple** into `StampTableV4.file_hash`; now unpacks `(md5, filename)` and stores the md5.
- Also refreshes **`file_size_bytes`** alongside `file_hash`.
- **`--all-webp`**: auto-selects every tick whose `srcbackground` is now `image/webp` (the converted set) — no need to list hundreds of ticks by hand.
- **`--dry-run`**: report counts only; no S3 upload, no DB write (safe pre-flight).
- **Cloudflare purge manifest**: writes one stamp URL per regenerated file. Objects are served `immutable, max-age=31536000`, so overwriting S3 alone leaves clients stale — the manifest feeds the purge step (no CF creds on the indexer host).
- Connects via standard **`RDS_*`** (run on the target deployment's host) instead of the `ST3_`/`RDS_` hybrid. S3 upload stays gated by `STORE_FILES`/`AWS_S3_*`, so a **dev run is DB-only and never touches S3**.

## Verified
Lint clean. `--dry-run` against the dev DB regenerates WebP-backed SVGs for the given ticks and emits the manifest with correct `https://stampchain.io/stamps/{tx_hash}.svg` URLs — no writes.

## Rollout (operator, on the target host)
1. Update prod `srcbackground` from the regenerated CSV (#851).
2. `poetry run python tools/update_bg.py --all-webp --dry-run` → review counts.
3. `poetry run python tools/update_bg.py --all-webp` → regenerate + re-upload + write manifest.
4. Cloudflare purge the manifest URLs (or the `/stamps/` path) — separate agent on a CF-access host.

Refs #846. Follow-on to #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)