### PR TITLE
feat: optional file-based inline validation mode (reference_hashes.json vs heavy compare_tables)

### DIFF
--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -98,6 +98,12 @@ DEBUG_SKIP_REBUILD_BALANCES = os.getenv("DEBUG_SKIP_REBUILD_BALANCES", "false").
 DEBUG_PROFILING = os.getenv("DEBUG_PROFILING", "false").lower() == "true"
 DISABLE_RUST_PARSER = os.environ.get("DISABLE_RUST_PARSER", "False").lower() == "true"
 DEBUG_VALIDATION = os.getenv("DEBUG_VALIDATION", "false").lower() == "true"
+# Mode for the every-1000-block inline consensus check (consensus-neutral; validation tooling only).
+# Only consulted when DEBUG_VALIDATION is enabled.
+#   "db"        -> heavy dev-vs-prod DB diff via tools/compare_tables.py (DEFAULT; preserves prior behavior)
+#   "reference" -> lightweight file-based check against snapshots/reference_hashes.json (no prod-DB dependency)
+#   "both"      -> run both paths and require BOTH to pass
+VALIDATION_MODE = os.getenv("VALIDATION_MODE", "db").lower()
 
 # Structured per-block performance logging (off by default, consensus-neutral).
 # When enabled, the follow() loop appends one JSON object per block to

--- a/indexer/src/index_core/block_validation.py
+++ b/indexer/src/index_core/block_validation.py
@@ -10,11 +10,12 @@ Functions:
     filter_block_transactions(): Filter transactions based on genesis status and patterns
 """
 
+import json
 import logging
 import os
 import subprocess
 import sys
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import config
 import index_core.check as check
@@ -86,10 +87,29 @@ def create_check_hashes(
 
 
 def validate_block_against_production(block_index: int) -> bool:
-    """Run the compare_tables script to validate against production."""
+    """Dispatch the every-1000-block inline consensus check per VALIDATION_MODE.
+
+    Consensus-NEUTRAL: validation tooling only; does NOT change indexer
+    output/decode/hashes. Kept under the original name so the blocks.py call
+    site is unchanged. Halt-on-False semantics are preserved for every mode:
+      * "db"        -> compare_tables dev-vs-prod DB diff (DEFAULT; unchanged)
+      * "reference" -> lightweight file-based reference_hashes.json check
+      * "both"      -> run both paths and require BOTH to pass (logical AND)
+    Any unrecognized value falls back to the default "db" path.
+    """
     if not config.DEBUG_VALIDATION:
         return True
 
+    mode = getattr(config, "VALIDATION_MODE", "db")
+    if mode == "reference":
+        return validate_block_against_reference(block_index)
+    if mode == "both":
+        return _validate_block_against_production_db(block_index) and validate_block_against_reference(block_index)
+    return _validate_block_against_production_db(block_index)
+
+
+def _validate_block_against_production_db(block_index: int) -> bool:
+    """Run the compare_tables script to validate against production."""
     block_logger = logging.getLogger("validate_block")
     block_logger.info(f"Validating block {block_index} against production database...")
 
@@ -136,6 +156,127 @@ def validate_block_against_production(block_index: int) -> bool:
     except Exception as e:
         block_logger.error(f"Error running validation: {str(e)}")
         return True
+
+
+# ---------------------------------------------------------------------------
+# Optional file-based inline validation (consensus-NEUTRAL — validation tooling
+# only; does NOT change indexer output/decode/hashes).
+#
+# A lightweight alternative to the heavy dev-vs-prod compare_tables.py DB diff:
+# the every-1000-block check can instead compare the indexer's stored block
+# hashes against the ``snapshots/reference_hashes.json`` checkpoint file (the
+# same source validate_hashes.py uses), removing the prod-DB dependency so
+# validation can run off-host. Selected via ``config.VALIDATION_MODE``
+# (default "db" preserves the prior compare_tables behavior).
+# ---------------------------------------------------------------------------
+
+# Module-level cache for the parsed reference_hashes.json so it is read at most
+# once per process (mirrors the cheapness requirement of the 1000-block check).
+_REFERENCE_HASHES_CACHE: Optional[Dict[str, Dict[str, str]]] = None
+
+
+def _reference_hashes_path() -> str:
+    """Resolve snapshots/reference_hashes.json relative to the indexer root.
+
+    block_validation.py lives at ``indexer/src/index_core/`` so three dirname()
+    hops reach the indexer root — the same hop count compare_tables resolution
+    uses to find ``tools/``.
+    """
+    indexer_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    return os.path.join(indexer_root, "snapshots", "reference_hashes.json")
+
+
+def _load_reference_hashes() -> Dict[str, Dict[str, str]]:
+    """Load and cache the ``hashes`` map from reference_hashes.json (once)."""
+    global _REFERENCE_HASHES_CACHE
+    if _REFERENCE_HASHES_CACHE is None:
+        path = _reference_hashes_path()
+        with open(path, "r") as f:
+            data = json.load(f)
+        _REFERENCE_HASHES_CACHE = data.get("hashes", {})
+    return _REFERENCE_HASHES_CACHE
+
+
+def _read_block_hashes(block_index: int) -> Optional[Dict[str, Optional[str]]]:
+    """Read the stored consensus hashes for ``block_index`` from the dev DB.
+
+    Reuses the indexer's configured connection pool (no extra credentials) and
+    returns the same columns validate_hashes.py compares, or None if the block
+    row is absent.
+    """
+    # Lazy import to avoid any import-time coupling to the database pool.
+    from index_core.database import db_manager
+
+    db = db_manager.connect()
+    with db.cursor() as cursor:
+        cursor.execute(
+            "SELECT block_hash, ledger_hash, txlist_hash, messages_hash FROM blocks WHERE block_index = %s",
+            (block_index,),
+        )
+        row = cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "block_hash": row[0],
+        "ledger_hash": row[1],
+        "txlist_hash": row[2],
+        "messages_hash": row[3],
+    }
+
+
+def validate_block_against_reference(block_index: int) -> bool:
+    """Validate a block's stored hashes against snapshots/reference_hashes.json.
+
+    Mirrors validate_hashes.py field handling (ledger_hash may be ""). Returns:
+      * True  on a full match,
+      * True  (non-fatal) when the block is absent from the reference file
+              (i.e. the tail beyond the snapshot) or absent from the dev DB,
+              logging a warning so the tail never false-halts,
+      * False on a real hash mismatch.
+    """
+    block_logger = logging.getLogger("validate_block")
+    block_logger.info(f"Validating block {block_index} against reference_hashes.json...")
+
+    try:
+        ref_hashes = _load_reference_hashes()
+    except Exception as e:
+        # Tooling failure must never false-halt a consensus reindex.
+        block_logger.warning(f"Could not load reference_hashes.json ({e}); skipping reference validation")
+        return True
+
+    expected = ref_hashes.get(str(block_index))
+    if expected is None:
+        block_logger.warning(
+            f"Block {block_index} not present in reference_hashes.json "
+            f"(beyond snapshot tail); skipping reference validation"
+        )
+        return True
+
+    actual = _read_block_hashes(block_index)
+    if actual is None:
+        block_logger.warning(f"Block {block_index} not found in dev blocks table; skipping reference validation")
+        return True
+
+    mismatches: List[Tuple[str, Optional[str], Optional[str]]] = []
+    # txlist_hash / messages_hash / block_hash are always present in the file;
+    # ledger_hash may be "" (genesis-era blocks) — only compared when non-empty.
+    for field in ("txlist_hash", "messages_hash", "block_hash"):
+        exp = expected.get(field)
+        if exp and exp != actual.get(field):
+            mismatches.append((field, exp, actual.get(field)))
+
+    exp_ledger = expected.get("ledger_hash")
+    if exp_ledger and exp_ledger != (actual.get("ledger_hash") or ""):
+        mismatches.append(("ledger_hash", exp_ledger, actual.get("ledger_hash")))
+
+    if mismatches:
+        block_logger.error(f"Reference validation failed at block {block_index}")
+        for field, exp, act in mismatches:
+            block_logger.error(f"  {field} mismatch: expected={exp} actual={act}")
+        return False
+
+    block_logger.info(f"Block {block_index} reference validation successful")
+    return True
 
 
 def filter_block_transactions(block_data, stamp_issuances=None):

--- a/indexer/tests/test_reference_validation.py
+++ b/indexer/tests/test_reference_validation.py
@@ -1,0 +1,119 @@
+"""Tests for the optional file-based inline validation mode (reference_hashes.json).
+
+Consensus-NEUTRAL: exercises validation tooling only; it does NOT touch the
+indexer's decode/parse/hash logic. All DB access is mocked — no real DB or
+network is used.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import config
+from index_core import block_validation
+
+# Small in-memory reference map mirroring snapshots/reference_hashes.json's
+# "hashes" shape. ledger_hash is "" for the genesis-era style entry.
+REFERENCE = {
+    "1000": {
+        "block_hash": "bh1000",
+        "ledger_hash": "",
+        "messages_hash": "mh1000",
+        "txlist_hash": "th1000",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _seed_reference_cache():
+    """Seed the module-level reference cache so no file is read, and restore it."""
+    original = block_validation._REFERENCE_HASHES_CACHE
+    block_validation._REFERENCE_HASHES_CACHE = dict(REFERENCE)
+    yield
+    block_validation._REFERENCE_HASHES_CACHE = original
+
+
+def _row(**overrides):
+    base = {
+        "block_hash": "bh1000",
+        "ledger_hash": "",
+        "txlist_hash": "th1000",
+        "messages_hash": "mh1000",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_match_returns_true():
+    with patch.object(block_validation, "_read_block_hashes", return_value=_row()):
+        assert block_validation.validate_block_against_reference(1000) is True
+
+
+def test_mismatch_returns_false():
+    with patch.object(block_validation, "_read_block_hashes", return_value=_row(txlist_hash="WRONG")):
+        assert block_validation.validate_block_against_reference(1000) is False
+
+
+def test_missing_block_returns_true_with_warning(caplog):
+    # Block 2000 is not present in the reference file -> non-fatal True + warning,
+    # and the DB is never queried (short-circuits before _read_block_hashes).
+    with patch.object(block_validation, "_read_block_hashes") as read_mock:
+        with caplog.at_level("WARNING", logger="validate_block"):
+            result = block_validation.validate_block_against_reference(2000)
+    assert result is True
+    read_mock.assert_not_called()
+    assert any("not present in reference_hashes.json" in r.message for r in caplog.records)
+
+
+def test_block_absent_from_db_returns_true():
+    # Block is in the reference file but missing from the dev DB -> non-fatal True.
+    with patch.object(block_validation, "_read_block_hashes", return_value=None):
+        assert block_validation.validate_block_against_reference(1000) is True
+
+
+def test_dispatcher_default_mode_uses_db_unchanged():
+    """Default VALIDATION_MODE 'db' must call ONLY the compare_tables path."""
+    original_mode = getattr(config, "VALIDATION_MODE", "db")
+    config.VALIDATION_MODE = "db"
+    config.DEBUG_VALIDATION = True
+    try:
+        with patch.object(block_validation, "_validate_block_against_production_db", return_value=True) as db_mock:
+            with patch.object(block_validation, "validate_block_against_reference") as ref_mock:
+                assert block_validation.validate_block_against_production(5000) is True
+        db_mock.assert_called_once_with(5000)
+        ref_mock.assert_not_called()
+    finally:
+        config.VALIDATION_MODE = original_mode
+        config.DEBUG_VALIDATION = False
+
+
+def test_dispatcher_reference_mode_uses_reference_only():
+    original_mode = getattr(config, "VALIDATION_MODE", "db")
+    config.VALIDATION_MODE = "reference"
+    config.DEBUG_VALIDATION = True
+    try:
+        with patch.object(block_validation, "_validate_block_against_production_db") as db_mock:
+            with patch.object(block_validation, "validate_block_against_reference", return_value=True) as ref_mock:
+                assert block_validation.validate_block_against_production(5000) is True
+        db_mock.assert_not_called()
+        ref_mock.assert_called_once_with(5000)
+    finally:
+        config.VALIDATION_MODE = original_mode
+        config.DEBUG_VALIDATION = False
+
+
+def test_dispatcher_both_mode_ands_results():
+    original_mode = getattr(config, "VALIDATION_MODE", "db")
+    config.VALIDATION_MODE = "both"
+    config.DEBUG_VALIDATION = True
+    try:
+        with patch.object(block_validation, "_validate_block_against_production_db", return_value=True):
+            with patch.object(block_validation, "validate_block_against_reference", return_value=False):
+                assert block_validation.validate_block_against_production(5000) is False
+    finally:
+        config.VALIDATION_MODE = original_mode
+        config.DEBUG_VALIDATION = False


### PR DESCRIPTION
## Motivation

The every-1000-block inline consensus check (gated by `DEBUG_VALIDATION`) currently shells out to `tools/compare_tables.py`, a heavy dev-vs-prod **DB** table diff that requires a live prod-DB connection. This PR adds a lighter, file-based alternative so the periodic check can validate against the `snapshots/reference_hashes.json` checkpoint file instead — removing the prod-DB dependency and enabling validation off-host / on sparky.

## New flag: `VALIDATION_MODE`

Only consulted when `DEBUG_VALIDATION` is enabled. Values:

- `db` (**DEFAULT**) — existing `compare_tables.py` dev-vs-prod DB diff; behavior is **unchanged**, so the running reindex and existing runs are unaffected.
- `reference` — lightweight file-based check against `snapshots/reference_hashes.json` (no prod-DB dependency).
- `both` — run both paths and require **both** to pass (logical AND).

## How the reference path works

- Loads `reference_hashes.json` once into a module-level cache (no per-call reload).
- Reads the dev DB `blocks` row for the block via the indexer's existing connection pool.
- Compares `txlist_hash` / `ledger_hash` / `messages_hash` / `block_hash`, mirroring `validate_hashes.py` field handling (`ledger_hash` may be `""`).
- Missing block — in the file (tail beyond the snapshot) or in the DB — is **non-fatal** (logs a warning, returns True) so the tail never false-halts. A real hash mismatch returns False, preserving the existing halt-on-False semantics.

## Tests

Focused, fully mocked unit tests (no real DB/network): match → True, mismatch → False, missing-block → True + warning, block-absent-from-DB → True, plus dispatcher coverage for `db` (default, unchanged), `reference`, and `both` (AND).

## Consensus

**Consensus-None:** validation tooling only; does not touch decode/parse/hashes. The default mode preserves the exact prior `compare_tables` behavior.