### PR TITLE
fix(#812): self-heal stale bitcoind RPC connections after backend restart (no manual restart)

### DIFF
--- a/indexer/src/index_core/backend.py
+++ b/indexer/src/index_core/backend.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import logging
 import os
+import threading
 import time
 from typing import Any, Dict, List, Optional
 
@@ -111,10 +112,54 @@ class Backend:
         # Initialize memory manager
         self.memory_manager = memory_manager
 
-        # Initialize optimized SSL session
+        # Initialize optimized SSL session.
+        # ``_session_lock`` guards rotation of the pooled session so that a
+        # bitcoind restart (which leaves stale CLOSE-WAIT sockets in the
+        # keep-alive pool) is healed by exactly one reconnect rather than every
+        # concurrent batch worker tearing the pool down at once.
+        self._session_lock = threading.Lock()
         self._session = self._create_optimized_session()
 
         self._initialized = True
+
+    @staticmethod
+    def _get_rpc_timeout():
+        """Return the (connect, read) timeout tuple for every bitcoind RPC call.
+
+        A bounded read timeout is what lets a wedged/half-open socket raise
+        instead of blocking the indexer indefinitely. Both bounds are
+        configurable via env (``RPC_CONNECT_TIMEOUT`` / ``RPC_TIMEOUT``) with the
+        previous hard-coded ``(5, 30)`` as the safe default.
+        """
+        connect_timeout = float(os.environ.get("RPC_CONNECT_TIMEOUT", 5))
+        read_timeout = float(os.environ.get("RPC_TIMEOUT", 30))
+        return (connect_timeout, read_timeout)
+
+    def _reset_session(self, stale_session=None):
+        """Drop the current RPC session and reconnect on a fresh connection pool.
+
+        After a bitcoind/backend restart the keep-alive pool can hold stale,
+        half-open (CLOSE-WAIT) sockets; reusing one makes the next RPC call hang.
+        Closing the session reaps those sockets and the replacement pool dials
+        brand-new connections, so the indexer self-heals without a manual
+        restart.
+
+        ``stale_session`` lets a caller pass the exact session it failed on so
+        that, under concurrent batch workers, only the first observer rotates the
+        pool and later threads (already holding the fresh session) skip the redundant reset.
+        """
+        with self._session_lock:
+            if stale_session is not None and stale_session is not self._session:
+                # Another worker already rotated the pool; nothing stale to drop.
+                return
+            old_session = getattr(self, "_session", None)
+            if old_session is not None:
+                try:
+                    old_session.close()
+                except Exception as e:
+                    logger.debug(f"Error closing stale RPC session: {e}")
+            self._session = self._create_optimized_session()
+            logger.warning("Reset bitcoind RPC session: dropped stale pooled connections and reconnecting.")
 
     def _should_collect_garbage(self, force_check: bool = False) -> bool:
         """
@@ -217,8 +262,9 @@ class Backend:
         else:
             session.ssl_context = ssl_context
 
-        # Configure session-wide timeout
-        session.request = functools.partial(session.request, timeout=(5, 30))
+        # Configure session-wide timeout (bounded so a stale socket raises
+        # instead of hanging the indexer forever)
+        session.request = functools.partial(session.request, timeout=self._get_rpc_timeout())
 
         logger.debug("Created optimized session handling both HTTP/HTTPS with connection pooling")
         return session
@@ -248,8 +294,14 @@ class Backend:
                 # Authentication is handled via API key in URL path
                 logger.debug(f"Attempt {i + 1}/{TRIES} to connect to {util.clean_url_for_log(url)}")
 
-                response = self._session.post(
-                    url, data=json.dumps(payload), headers=headers, timeout=(5, 30)  # Separate connect and read timeouts
+                # Capture the session used for this attempt so that, on a
+                # connection failure, we only rotate this exact (stale) pool.
+                session = self._session
+                response = session.post(
+                    url,
+                    data=json.dumps(payload),
+                    headers=headers,
+                    timeout=self._get_rpc_timeout(),  # Bounded connect/read timeouts
                 )
                 if response.status_code == 200:
                     if i > 0:
@@ -275,10 +327,15 @@ class Backend:
                         time.sleep(wait_time)
                         continue  # Retry on non-200 status codes
                     # Last attempt failed, will exit loop and handle error below
-            except (Timeout, ConnectionError) as e:
+            except (Timeout, ConnectionError, requests.exceptions.ChunkedEncodingError) as e:
                 logger.debug(
                     f"Could not connect to backend at `{util.clean_url_for_log(url)}`. Error: {str(e)} (Try {i + 1}/{TRIES})"
                 )
+                # A timeout / dropped or half-open (CLOSE-WAIT) connection means
+                # the pooled socket is unusable — e.g. after a bitcoind restart.
+                # Drop the stale pool and reconnect on a fresh session so the
+                # next attempt dials a brand-new socket and self-heals.
+                self._reset_session(stale_session=session)
                 # Exponential backoff for connection errors
                 wait_time = min(3 * (2**i), 30)  # Start at 3s, cap at 30s
                 time.sleep(wait_time)

--- a/indexer/tests/test_backend_rpc_reconnect.py
+++ b/indexer/tests/test_backend_rpc_reconnect.py
@@ -1,0 +1,120 @@
+"""Regression test for issue #812: stale bitcoind RPC connections after a backend restart.
+
+Root cause guarded here: after a ``bitcoind`` restart the keep-alive connection
+pool on the live indexer's ``requests.Session`` can hand back a half-open
+(CLOSE-WAIT) socket; a subsequent RPC call then blocks/hangs and the indexer
+wedges near tip until a manual restart.
+
+The fix (``Backend._reset_session``) drops the stale pool and reconnects on a
+fresh session inside the existing ``rpc_call`` retry loop, and every call applies
+a bounded ``(connect, read)`` timeout so a wedged socket raises instead of
+hanging forever. These tests assert that:
+
+  * a ``ConnectionError`` / ``Timeout`` raised once is retried on a brand-new
+    session (the stale session is closed) and ultimately succeeds, and
+  * the bounded timeout is passed to every ``session.post`` call.
+
+This is a connection-resilience guard only: RPC results / request payloads /
+parse path are unchanged (Consensus-None).
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import Timeout
+
+from index_core.backend import Backend
+
+
+def _ok_response(result):
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = {"result": result, "error": None}
+    return resp
+
+
+@patch("index_core.backend.config.RPC_URL", "http://user:pass@127.0.0.1:8332")
+@patch("index_core.backend.config.QUICKNODE_ENDPOINT", None)
+@patch("index_core.backend.config.QUICKNODE_API_KEY", None)
+class TestBackendRpcReconnect(unittest.TestCase):
+    """rpc_call must self-heal after a stale/dropped bitcoind connection."""
+
+    def setUp(self):
+        Backend._instance = None
+        Backend._override = None
+
+    def tearDown(self):
+        Backend._instance = None
+        Backend._override = None
+
+    def test_reconnects_on_connection_error_then_succeeds(self):
+        """A ConnectionError once -> stale pool dropped, retried on a fresh session, succeeds."""
+        stale_session = Mock(name="stale_session")
+        stale_session.post.side_effect = RequestsConnectionError("Connection reset by peer")
+        fresh_session = Mock(name="fresh_session")
+        fresh_session.post.return_value = _ok_response(840000)
+
+        # The session factory yields the initial (stale) pool, then the
+        # reconnect pool. Keep it patched for the whole call so the reconnect
+        # inside rpc_call gets the mock and never dials a real socket.
+        with patch(
+            "index_core.backend.Backend._create_optimized_session",
+            side_effect=[stale_session, fresh_session],
+        ), patch("index_core.backend.time.sleep"):
+            backend = Backend()
+            result = backend.rpc("getblockcount", [])
+
+        self.assertEqual(result, 840000)
+        # The stale pool was closed (sockets reaped) ...
+        stale_session.close.assert_called_once()
+        # ... and the retry went out on the brand-new session.
+        fresh_session.post.assert_called_once()
+        # The live session is now the fresh one.
+        self.assertIs(backend._session, fresh_session)
+
+    def test_reconnects_on_socket_timeout_then_succeeds(self):
+        """A read Timeout (wedged socket) is also healed via reconnect + retry."""
+        stale_session = Mock(name="stale_session")
+        stale_session.post.side_effect = Timeout("read timed out")
+        fresh_session = Mock(name="fresh_session")
+        fresh_session.post.return_value = _ok_response("deadbeef")
+
+        with patch(
+            "index_core.backend.Backend._create_optimized_session",
+            side_effect=[stale_session, fresh_session],
+        ), patch("index_core.backend.time.sleep"):
+            backend = Backend()
+            result = backend.rpc("getblockhash", [840000])
+
+        self.assertEqual(result, "deadbeef")
+        stale_session.close.assert_called_once()
+        fresh_session.post.assert_called_once()
+
+    def test_bounded_timeout_applied_to_every_call(self):
+        """Every RPC post must carry a bounded (connect, read) timeout."""
+        session = Mock(name="session")
+        session.post.return_value = _ok_response(1)
+
+        with patch(
+            "index_core.backend.Backend._create_optimized_session",
+            side_effect=[session],
+        ), patch("index_core.backend.time.sleep"):
+            backend = Backend()
+            backend.rpc("getblockcount", [])
+
+        _, kwargs = session.post.call_args
+        self.assertEqual(kwargs["timeout"], (5, 30))  # safe defaults
+        # Both bounds are finite/positive so a wedged socket cannot hang forever.
+        connect_timeout, read_timeout = kwargs["timeout"]
+        self.assertGreater(connect_timeout, 0)
+        self.assertGreater(read_timeout, 0)
+
+    def test_rpc_timeout_env_override(self):
+        """RPC_TIMEOUT / RPC_CONNECT_TIMEOUT env vars override the defaults."""
+        with patch.dict("os.environ", {"RPC_CONNECT_TIMEOUT": "3", "RPC_TIMEOUT": "45"}):
+            self.assertEqual(Backend._get_rpc_timeout(), (3.0, 45.0))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    unittest.main()


### PR DESCRIPTION
## Root cause

After a `bitcoind`/backend restart (node upgrade or crash-restart), the **live indexer's** keep-alive RPC connection pool in `indexer/src/index_core/backend.py` could hold stale, half-open (**CLOSE-WAIT**) sockets — the backend sent FIN but the client never reaped them. urllib3 then handed a half-closed pooled connection back to the next RPC call, which **blocked indefinitely** (main thread parked in `do_poll`, ~0% CPU). The indexer wedged near tip with no errors and no further block logs, recovering only on a manual `systemctl restart`.

This is the **live RPC pool** — distinct from the CI reparse `ci/public_backend.py` that PR #845 fixed. #845 does **not** fix this.

## The fix (connection resilience only)

- **Bounded timeout on every call** — `session.post` and the session-wide partial now use `Backend._get_rpc_timeout()`, configurable via `RPC_CONNECT_TIMEOUT` / `RPC_TIMEOUT` (safe defaults `(5, 30)`), so a wedged/half-open socket raises instead of hanging forever.
- **Drop-and-reconnect on connection failure** — on `Timeout` / `ConnectionError` / `ChunkedEncodingError`, `rpc_call` now calls `Backend._reset_session()` to close the stale pool (reaping the CLOSE-WAIT sockets) and reconnect on a fresh session inside the existing retry/backoff loop. So a backend restart self-heals without a manual indexer restart.
- **Concurrency-safe** — a lock + stale-session guard ensures concurrent `rpc_batch` workers rotate the pool exactly once rather than thrashing it.

## Consensus-None

Connection/session/retry handling only. RPC results, request payloads, method/params, ordering, response JSON parsing, caching, and the decode/parse path are all unchanged.

## Tests

`indexer/tests/test_backend_rpc_reconnect.py` (4 tests, all passing in the dev image) proves a transient `ConnectionError` / `Timeout` is retried on a brand-new session (the stale session is closed → pool self-heals), the bounded timeout is applied to every call, and `RPC_TIMEOUT`/`RPC_CONNECT_TIMEOUT` overrides take effect. Existing `tests/test_backend.py` (14 tests) still pass.

Closes #812