### PR TITLE
fix(#842): join backend fetch-worker threads at test teardown (stop coverage-job SIGABRT)

### DIFF
--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import threading
 import time
+import weakref
 
 import config
 from index_core.backend import Backend
@@ -30,6 +31,15 @@ class CPBlocksPipeline:
 
     # Cleanup interval for stuck fetches (in seconds)
     CLEANUP_INTERVAL_SECONDS = 10
+
+    # Weak registry of all live pipeline instances. The background fetch worker
+    # runs as a daemon thread, so a pipeline that is started but never stopped
+    # (e.g. in a test) leaves that thread alive into interpreter shutdown, where
+    # it can do I/O on closed std streams and abort the process with SIGABRT
+    # (issue #842). This registry lets the test suite locate and stop any leaked
+    # pipelines at teardown. It is weak-referenced and never read in production,
+    # so it has no effect on indexing/consensus behavior.
+    _instances: "weakref.WeakSet" = weakref.WeakSet()
 
     def __init__(
         self,
@@ -139,6 +149,10 @@ class CPBlocksPipeline:
         self.last_health_check = 0  # Check every 30 seconds when in fallback
         self.health_check_interval = 30
 
+        # Track this instance so leaked background workers can be stopped at
+        # test teardown and never survive into interpreter shutdown (issue #842).
+        CPBlocksPipeline._instances.add(self)
+
     def start(self, start_block):
         """Start the background worker thread"""
         if start_block is None:
@@ -214,7 +228,7 @@ class CPBlocksPipeline:
         self.shutdown_flag.clear()
         self.initial_blocks_ready.clear()
 
-        self.worker_thread = threading.Thread(target=self._fetch_blocks_worker, daemon=True)
+        self.worker_thread = threading.Thread(target=self._fetch_blocks_worker, name="cp-blocks-fetch-worker", daemon=True)
         self.worker_thread.start()
         logger.debug(f"Started CP blocks pipeline from block {start_block}")
 

--- a/indexer/tests/conftest.py
+++ b/indexer/tests/conftest.py
@@ -183,6 +183,39 @@ def reset_coordinator():
 
 
 @pytest.fixture(autouse=True)
+def stop_leaked_pipelines():
+    """Stop any backend fetch-worker daemon threads left running by a test.
+
+    ``CPBlocksPipeline.start()`` launches its block-prefetch worker as a *daemon*
+    thread (plus a ``ThreadPoolExecutor``). A test that starts a pipeline but
+    never calls ``stop()`` leaves those daemon threads alive after the test. In
+    the coverage/CI environment there is no bitcoind backend, so the leaked loop
+    spins raising ``BackendRPCError`` and, at interpreter shutdown, does I/O on
+    already-closed std streams -> ``_enter_buffered_busy`` fatal error /
+    ``ValueError: I/O operation on closed file`` -> ``SIGABRT`` and a spurious
+    red coverage check (issue #842).
+
+    This autouse fixture stops every live pipeline at teardown so no fetch-worker
+    daemon thread can survive into interpreter shutdown.
+    """
+    yield
+
+    try:
+        from index_core.pipeline_utils import CPBlocksPipeline
+    except Exception:
+        return
+
+    for pipeline in list(CPBlocksPipeline._instances):
+        try:
+            worker = getattr(pipeline, "worker_thread", None)
+            if worker is not None and worker.is_alive():
+                pipeline.stop()
+        except Exception:
+            # Best-effort cleanup: a teardown hiccup must never fail the test.
+            pass
+
+
+@pytest.fixture(autouse=True)
 def reset_backend_override():
     """Guarantee no CI/test backend override leaks into the unit suite.
 

--- a/indexer/tests/test_pipeline_fallback_state_persistence.py
+++ b/indexer/tests/test_pipeline_fallback_state_persistence.py
@@ -164,20 +164,25 @@ def test_fallback_state_clear_after_rollback(temp_db, mock_backend, mock_node_he
         mock_node_health[1].return_value = ["http://healthy-node:4000"]  # mock_get returns healthy nodes
 
         # Simulate starting the pipeline (which should trigger rollback)
-        with patch("src.config.CP_STAMP_GENESIS_BLOCK", 0):
-            pipeline.start(12340)
+        try:
+            with patch("src.config.CP_STAMP_GENESIS_BLOCK", 0):
+                pipeline.start(12340)
 
-        # Verify rollback was called
-        mock_rollback.assert_called_once_with(12345)
+            # Verify rollback was called
+            mock_rollback.assert_called_once_with(12345)
 
-        # Verify state was cleared (should remain cleared since we have healthy nodes now)
-        assert pipeline.fallback_started_at is None
-        assert pipeline.failed_cp_blocks == set()
+            # Verify state was cleared (should remain cleared since we have healthy nodes now)
+            assert pipeline.fallback_started_at is None
+            assert pipeline.failed_cp_blocks == set()
 
-        # Verify state was cleared from SQLite
-        queue = ReprocessingQueue.get_instance()
-        loaded_state = queue.load_fallback_state(12345)
-        assert loaded_state is None
+            # Verify state was cleared from SQLite
+            queue = ReprocessingQueue.get_instance()
+            loaded_state = queue.load_fallback_state(12345)
+            assert loaded_state is None
+        finally:
+            # start() launches a daemon fetch-worker thread; stop it so it cannot
+            # survive into interpreter shutdown and crash the suite (issue #842).
+            pipeline.stop()
 
 
 def test_fallback_state_no_persistence_when_no_state_manager(mock_backend, mock_node_health):


### PR DESCRIPTION
## Root cause
`CPBlocksPipeline.start()` launches its block-prefetch worker as a **daemon thread** (plus a `ThreadPoolExecutor`). The test `test_fallback_state_clear_after_rollback` started a pipeline but never called `stop()`, leaking those daemon threads. In the coverage/CI environment there is no bitcoind backend, so the leaked worker loop spins raising `BackendRPCError` and, at interpreter shutdown, performs I/O on already-closed std streams → `_enter_buffered_busy` fatal error / `ValueError: I/O operation on closed file` → **SIGABRT (-6)**. This put a spurious red ❌ on the (informational, non-gating) Code Coverage Analysis job **even when the coverage target was met**.

## Fix (test/CI hygiene only)
- Add a **weak** instance registry `CPBlocksPipeline._instances` so the test suite can locate live pipelines. It is weak-referenced and **never read in production**, so it has no effect on indexing/consensus behavior.
- Add an autouse `conftest` fixture `stop_leaked_pipelines` that stops + joins any live pipeline worker at teardown, so no fetch-worker daemon thread can survive into interpreter shutdown.
- Stop the pipeline explicitly in the offending test via `try/finally`.
- Name the worker thread `cp-blocks-fetch-worker` for easier diagnosis.

## Verification
- Offending test file: **2 leaked daemon threads → 0** after the session.
- 59-test pipeline/backend slice passes with **0 leaked threads**.
- The real `pytest --cov=src -m 'not (requires_bitcoin_node)'` subprocess exits cleanly (**code 0**), no `_enter_buffered_busy` / `SIGABRT` / closed-file markers.
- `black` / `isort` clean.

**Consensus-None: test teardown only.**

Closes #842