### PR TITLE
ci: add Python 3.13 to the test + reparse matrices (cross-version consensus confidence, refs #803)

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       USE_TEST_TX_HEX: '1'
       TESTING: '1'

--- a/.github/workflows/reparse-validate.yml
+++ b/.github/workflows/reparse-validate.yml
@@ -14,7 +14,7 @@ name: Reparse Consensus Validation
 # Without this, every Bucket A bump needs a manual 24-48h reindex for signal.
 # This gets us a per-PR signal at boundary blocks in <5 min on CI.
 #
-# What each tier validates (all run on the matrix 3.10/3.11/3.12):
+# What each tier validates (all run on the matrix 3.10/3.11/3.12/3.13):
 #   Tier 1  Cross-check CHECKPOINTS_MAINNET vs reference_hashes.json   (all baseline blocks)
 #   Tier 2  Block-bytes hash verification against the baseline          (all baseline blocks)
 #   Tier 3  Full in-memory reparse (txlist/messages/ledger hashes)      (self-contained blocks only)
@@ -61,8 +61,10 @@ jobs:
         # 3.10; the dev container runs 3.12. A code audit (#803) proved the
         # consensus hashes are version-invariant across this range *today* —
         # this matrix is the per-PR guard against a future code change
-        # reintroducing Python-version sensitivity.
-        python-version: ['3.10', '3.11', '3.12']
+        # reintroducing Python-version sensitivity. 3.13 is included so the
+        # planned final pre-release reparse has cross-version confidence (the
+        # Tier 3 reparse passed byte-identical on 3.13 — refs #803).
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Motivation

#803 documented that the indexer's consensus hashes depend on `str()`/`repr()` of containers, making them theoretically fragile across Python versions. The CI matrices currently cover only 3.10/3.11/3.12. Adding **3.13** empirically tests that the consensus surface (txlist_hash / messages_hash / ledger_hash) is byte-identical on 3.13 and lets the planned final pre-release reparse run on 3.13 for strong cross-version confidence.

## Changes

- `python-check.yml` — add `3.13` to the **Code Quality & Unit Tests** matrix.
- `reparse-validate.yml` — add `3.13` to the **Reparse Consensus Validation** matrix (+ comment updates).

(build-test.yml and coverage.yml run intentional single versions, not matrices — left unchanged.)

## 3.13 build/run verification

Built a 3.13 variant of the dev image (`docker build --target builder --build-arg PYTHON_VERSION=3.13 --build-arg INSTALL_DEV=true`, `python:3.13-slim`):

- `poetry install --with dev` resolved/installed cleanly on 3.13 (existing `poetry.lock`, no constraint changes needed). pyo3 `0.24` builds a version-specific `cp313` wheel — `btc_stamps_parser-0.1.0-cp313-cp313-manylinux_2_34_x86_64.whl` built and installed.
- `import btc_stamps_parser` and `import index_core` succeed on Python 3.13.14.
- Consensus unit slice (arc4 / base64 / check / consensus_error_handling / counterparty_detection): **47 passed, 3 skipped** (intentional).
- **Tier 3 subprocess reparse over the curated baseline: 61/61 passed, 0 failed** — consensus hashes byte-identical to the 3.10/3.12-generated baseline.

No dependency or toolchain blocked 3.13; `pyproject.toml` python constraint is already `^3.10`.

refs #803