### PR TITLE
build: parameterize Dockerfile site-packages path by PYTHON_VERSION (enables 3.13 image)

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -61,6 +61,8 @@ RUN pip install target/wheels/*.whl
 FROM python:${PYTHON_VERSION}-slim
 
 ARG POETRY_VERSION=2.1.1
+# Re-declare in the runtime stage so ${PYTHON_VERSION} is usable in COPY paths below
+ARG PYTHON_VERSION=3.12
 
 ENV PYTHONPATH=/app:/app/src \
     POETRY_VERSION=${POETRY_VERSION} \
@@ -105,7 +107,7 @@ RUN useradd -m indexer && \
     chown -R indexer:indexer /app
 
 # Copy installed Python dependencies from builder
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages /usr/local/lib/python${PYTHON_VERSION}/site-packages
 
 # ✅ Copy installed CLI tools and entry points (like `indexer`)
 COPY --from=builder /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
The runtime stage of `indexer/Dockerfile` hardcoded `/usr/local/lib/python3.12/site-packages` in its `COPY --from=builder`. Building with `--build-arg PYTHON_VERSION=3.13` would copy from a non-existent path (the 3.13 builder installs under `python3.13/`), producing a broken image with no site-packages.

**Fix:** re-declare `ARG PYTHON_VERSION` in the runtime stage and parameterize the COPY path to `python${PYTHON_VERSION}`. Default remains `3.12` — output-identical for the default build; unblocks a full-3.13 runtime/reparse image.

**Why now:** required prerequisite for the v1.9.0 final certifying reparse, which we're running on 3.13 for #803 cross-version confidence.

Consensus-neutral (build plumbing only). Locally validated by building the image with `PYTHON_VERSION=3.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)