### PR TITLE
fix(pipeline): reentrant locks (RLock) to fix connection-pool self-deadlock

### DIFF
--- a/indexer/src/index_core/database_manager.py
+++ b/indexer/src/index_core/database_manager.py
@@ -74,7 +74,12 @@ class ConnectionPool:
 
         self._pool = queue.Queue(maxsize=self.max_connections)
         self._active_connections: Dict[int, Connection] = {}
-        self._lock = threading.Lock()
+        # RLock (reentrant): get_connection() holds this lock while calling
+        # _create_connection(), which re-acquires it to register the new
+        # connection. With a plain Lock that self-re-acquisition deadlocks the
+        # borrower permanently (0% CPU, silent) whenever the pool is empty and
+        # a fresh connection must be created under load.
+        self._lock = threading.RLock()
         self._shutting_down = False
         self._initialize_pool()
 

--- a/indexer/src/index_core/pipeline_utils.py
+++ b/indexer/src/index_core/pipeline_utils.py
@@ -62,7 +62,10 @@ class CPBlocksPipeline:
             fallback_mode (bool): If True, continue processing without CP data when nodes fail.
         """
         self.queue = {}  # Block data by index
-        self._lock = threading.Lock()
+        # RLock (reentrant): several paths re-enter this lock on the same thread
+        # (e.g. _process_completed_futures holds it, then _enter_fallback_mode
+        # re-acquires it near tip). A plain Lock self-deadlocks in those cases.
+        self._lock = threading.RLock()
         self.worker_thread = None
         self.shutdown_flag = threading.Event()
         self.initial_blocks_ready = threading.Event()

--- a/indexer/tests/test_database_manager.py
+++ b/indexer/tests/test_database_manager.py
@@ -133,6 +133,52 @@ class TestConnectionPool:
             pool.get_connection()
 
     @patch("index_core.database_manager.pymysql.connect")
+    def test_get_connection_reentrant_create_no_deadlock(self, mock_connect):
+        """Regression (#868): when the pool is empty but still under
+        max_connections, get_connection() acquires self._lock and then calls
+        _create_connection(), which re-acquires self._lock. With a non-reentrant
+        threading.Lock this self-deadlocks the borrower permanently (0% CPU,
+        silent) — the exact hang that wedged a from-genesis reindex. The lock
+        must be reentrant (RLock).
+
+        The borrow runs in a worker thread joined with a timeout so a regression
+        (RLock -> Lock) FAILS this test instead of hanging CI forever.
+        """
+
+        def make_conn(**kwargs):
+            c = Mock()
+            c.ping.return_value = None
+            return c
+
+        mock_connect.side_effect = make_conn
+
+        # min < max so the empty-pool path creates a new connection *under the
+        # lock* (the deadlock path); short timeout so queue.Empty fires quickly.
+        pool = ConnectionPool(
+            host="localhost", user="test", password="test", database="test", min_connections=1, max_connections=3, timeout=0.2
+        )
+
+        # Drain the single pooled connection: pool queue now empty while
+        # active (1) < max (3) — exactly the create-under-lock condition.
+        first = pool.get_connection()
+        assert isinstance(first, PooledConnection)
+
+        result = {}
+
+        def borrow():
+            result["conn"] = pool.get_connection()
+
+        t = threading.Thread(target=borrow, name="reentrant-borrow", daemon=True)
+        t.start()
+        t.join(timeout=5.0)
+
+        assert not t.is_alive(), (
+            "get_connection() deadlocked creating a connection while holding "
+            "self._lock — ConnectionPool._lock must be a reentrant RLock (#868)"
+        )
+        assert isinstance(result.get("conn"), PooledConnection)
+
+    @patch("index_core.database_manager.pymysql.connect")
     def test_return_connection_to_pool(self, mock_connect):
         """Test returning a connection to the pool"""
         mock_connection = Mock()


### PR DESCRIPTION
## Problem

A from-genesis reindex (Python 3.13, CP_SKIP=true) **deadlocked** during early sync — process alive, CPU ~0%, backends healthy, zero log output, progress watchdog tripped. A restart cleared it (confirming a deadlock, not a crash).

## Root cause (confirmed via py-spy)

`ConnectionPool` uses a non-reentrant `threading.Lock` but re-acquires it on the same thread:
- `get_connection()` holds `self._lock` (`database_manager.py:121`) when the pool is empty, then calls `_create_connection()` (`:123`)
- `_create_connection()` re-acquires `self._lock` (`:93`) to register the new connection → **self-deadlock**

py-spy thread dump of the hung process:
```
MainThread:
  _create_connection (database_manager.py:93)   <- blocked re-acquiring self._lock
  get_connection (database_manager.py:123)       <- already holds self._lock (:121)
  connect (database_manager.py:351)
  persist_bitcoin_core_version (node_health.py:923)
  persist_all_versions (node_health.py:983)
  follow (blocks.py:1218)
```
Only triggers when the pool empties under load (queue.Empty → create-under-lock path), which is why it's intermittent.

`CPBlocksPipeline._lock` has the same latent reentrancy hazard (`_process_completed_futures` → `_enter_fallback_mode` re-acquire near tip).

## Fix

Both `self._lock` → `threading.RLock()`. Pure reentrancy fix — no change to what is computed or persisted, so **consensus-neutral** (rides the Reparse Consensus Validation gate to prove it). Version-agnostic bug; Python 3.13's GIL hand-off just makes the pool-empty race more frequent, which is how it surfaced on the v1.9.0 certifying reparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)