### PR TITLE
fix(validation): close pooled connection in _read_block_hashes (leak → pool exhaustion)

### DIFF
--- a/indexer/src/index_core/block_validation.py
+++ b/indexer/src/index_core/block_validation.py
@@ -217,12 +217,19 @@ def _read_block_hashes(block_index: int) -> Optional[Dict[str, Optional[str]]]:
     from index_core.database import db_manager
 
     db = db_manager.connect()
-    with db.cursor() as cursor:
-        cursor.execute(
-            "SELECT block_hash, ledger_hash, txlist_hash, messages_hash FROM blocks WHERE block_index = %s",
-            (block_index,),
-        )
-        row = cursor.fetchone()
+    try:
+        with db.cursor() as cursor:
+            cursor.execute(
+                "SELECT block_hash, ledger_hash, txlist_hash, messages_hash FROM blocks WHERE block_index = %s",
+                (block_index,),
+            )
+            row = cursor.fetchone()
+    finally:
+        # Return the pooled connection. Without this the connection leaks on
+        # every call; validate_block_against_reference runs this once per 1000
+        # blocks, so the pool (max 10) exhausts after ~10 checkpoints and the
+        # main loop stalls waiting for a connection that never frees.
+        db.close()
     if row is None:
         return None
     return {

--- a/indexer/tests/test_reference_validation.py
+++ b/indexer/tests/test_reference_validation.py
@@ -117,3 +117,29 @@ def test_dispatcher_both_mode_ands_results():
     finally:
         config.VALIDATION_MODE = original_mode
         config.DEBUG_VALIDATION = False
+
+
+def test_read_block_hashes_returns_connection_to_pool():
+    """Regression: _read_block_hashes must return (close) its pooled connection.
+
+    Without db.close() every call leaks a connection. This runs once per 1000
+    blocks under VALIDATION_MODE=reference, so the pool (max 10) exhausts after
+    ~10 checkpoints and the indexer's main loop stalls waiting for a connection
+    that never frees. The connection must be closed even when a row is found.
+    """
+    from unittest.mock import MagicMock
+
+    mock_db = MagicMock()
+    cursor = mock_db.cursor.return_value.__enter__.return_value
+    cursor.fetchone.return_value = ("bh", "lh", "tlh", "mh")
+
+    mock_mgr = MagicMock()
+    mock_mgr.connect.return_value = mock_db
+
+    # _read_block_hashes lazily does `from index_core.database import db_manager`
+    with patch("index_core.database.db_manager", mock_mgr):
+        result = block_validation._read_block_hashes(5000)
+
+    assert result == {"block_hash": "bh", "ledger_hash": "lh", "txlist_hash": "tlh", "messages_hash": "mh"}
+    mock_mgr.connect.assert_called_once()
+    mock_db.close.assert_called_once()  # <-- the leak guard: connection returned to the pool


### PR DESCRIPTION
## Problem

After the RLock deadlock fix (#868), the v1.9.0 certifying reparse got further but **stalled again at ~30 min** with `Connection pool exhausted` retrying in the node-health version-persist path.

## Root cause (confirmed via py-spy + `SHOW PROCESSLIST`)

`_read_block_hashes` (the `VALIDATION_MODE=reference` inline check) acquired a pooled connection but only context-managed the **cursor** — the **connection was never returned**:
```python
db = db_manager.connect()
with db.cursor() as cursor:   # closes cursor, not the connection
    ...
```
It runs once per 1000 blocks, so it leaked one connection per checkpoint. MySQL showed **10 idle `Sleep` connections** staggered ~3 min apart; the pool (max 10) exhausted after ~10 checkpoints and the main loop stalled.

## Fix

`try/finally: db.close()` to return the connection. This is a **dev-validation-only path** (`DEBUG_VALIDATION`), so **prod is unaffected**; consensus-neutral (no change to computed/persisted data — rides the reparse gate). Adds a regression test that asserts the connection is closed (fails if the leak returns).

## Note

This was masked by the earlier self-deadlock (#868), which halted the run before the pool could fully exhaust. With both fixed, the reference-validation path is now leak-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)