### PR TITLE
fix(ops): stop progress-watchdog false positives at tip (idle-at-tip tick + configurable threshold)

### DIFF
--- a/indexer/src/index_core/blocks.py
+++ b/indexer/src/index_core/blocks.py
@@ -2134,6 +2134,10 @@ def follow(
                             zmq_wait_time = 5  # seconds, shorter timeout for more frequent shutdown checks
 
                             while not server.shutdown_flag.is_set():
+                                # Idle-at-tip liveness (watchdog false-positive fix): tick while
+                                # healthily waiting for the next block so ProgressWatchdog only
+                                # trips on a genuine stall, not on normal Bitcoin inter-block gaps.
+                                progress_watchdog.tick(label=f"at tip {block_index}, waiting for next block (zmq)")
                                 # Send keepalive if needed
                                 if time.time() - last_keepalive > KEEPALIVE_INTERVAL:
                                     if not send_keepalive(db):
@@ -2215,6 +2219,9 @@ def follow(
                         while slept_time < config.BACKEND_POLL_INTERVAL and not server.shutdown_flag.is_set():
                             time.sleep(poll_sleep_interval)
                             slept_time += poll_sleep_interval
+                            # Idle-at-tip liveness (watchdog false-positive fix): tick while
+                            # healthily polling for the next block; a genuine hang stops ticking.
+                            progress_watchdog.tick(label=f"at tip {block_index}, waiting for next block (poll)")
                             if server.shutdown_flag.is_set():
                                 logger.info("Shutdown flag detected during poll sleep, breaking...")
                                 break

--- a/indexer/src/index_core/ops_alerter.py
+++ b/indexer/src/index_core/ops_alerter.py
@@ -157,8 +157,13 @@ class ProgressWatchdog:
     24 hours.
     """
 
-    def __init__(self, stall_threshold_sec: int = 1800, check_interval_sec: int = 60):
-        self.stall_threshold_sec = stall_threshold_sec
+    def __init__(self, stall_threshold_sec: Optional[int] = None, check_interval_sec: int = 60):
+        # Threshold is configurable via OPS_ALERT_STALL_SEC (default 1800s) so it
+        # can be tuned per-deployment without a code change. An explicit arg still
+        # wins (used by tests).
+        self.stall_threshold_sec = (
+            stall_threshold_sec if stall_threshold_sec is not None else int(os.environ.get("OPS_ALERT_STALL_SEC", "1800"))
+        )
         self.check_interval_sec = check_interval_sec
         self._last_tick = time.monotonic()
         self._last_tick_label = "startup"

--- a/indexer/tests/test_ops_alerter.py
+++ b/indexer/tests/test_ops_alerter.py
@@ -127,3 +127,49 @@ def test_get_sns_client_handles_missing_boto3(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     assert ops_alerter._get_sns_client() is None
+
+
+def test_watchdog_threshold_from_env(monkeypatch):
+    """OPS_ALERT_STALL_SEC configures the stall threshold; explicit arg still wins."""
+    monkeypatch.delenv("OPS_ALERT_STALL_SEC", raising=False)
+    assert ops_alerter.ProgressWatchdog().stall_threshold_sec == 1800  # default
+
+    monkeypatch.setenv("OPS_ALERT_STALL_SEC", "3600")
+    assert ops_alerter.ProgressWatchdog().stall_threshold_sec == 3600  # env honored
+
+    # An explicit constructor arg overrides the env (used by tests/callers).
+    assert ops_alerter.ProgressWatchdog(stall_threshold_sec=42).stall_threshold_sec == 42
+
+
+def test_watchdog_tick_resets_stall_timer():
+    """Idle-at-tip fix: ticking during a healthy wait clears the stall timer so the
+    watchdog does NOT trip; without a tick the timer keeps aging toward the trip.
+
+    This models the blocks.py idle-at-tip wait loops, which now tick every poll/zmq
+    iteration so normal Bitcoin inter-block gaps no longer false-trip the watchdog.
+    """
+    wd = ops_alerter.ProgressWatchdog(stall_threshold_sec=100)
+
+    # Simulate a long wait with no progress -> the trip condition is met.
+    wd._last_tick = time.monotonic() - 200
+    assert (time.monotonic() - wd._last_tick) >= wd.stall_threshold_sec
+
+    # A single idle-at-tip tick clears the stall -> would NOT trip.
+    wd.tick(label="at tip 956514, waiting for next block (poll)")
+    assert (time.monotonic() - wd._last_tick) < wd.stall_threshold_sec
+    assert wd._last_tick_label == "at tip 956514, waiting for next block (poll)"
+
+
+def test_watchdog_fires_when_no_tick_past_threshold(monkeypatch):
+    """When the main loop genuinely stops ticking past the threshold, the watchdog
+    still fires a critical alert (the real-hang case must survive the idle-at-tip fix)."""
+    fired = []
+    monkeypatch.setattr(ops_alerter, "notify", lambda *a, **kw: fired.append(kw.get("dedup_key")))
+
+    # threshold 0 -> any elapsed time counts as stalled; fast check interval.
+    wd = ops_alerter.ProgressWatchdog(stall_threshold_sec=0, check_interval_sec=0.01)
+    wd.start()
+    time.sleep(0.1)
+    wd.stop()
+
+    assert "progress-watchdog" in fired


### PR DESCRIPTION
## Problem

Prod (`prod2`) frequently emits a **critical** `progress-watchdog` alert ("No main-loop progress for 1803s … Process may be hung") even though it's **healthy and following tip**. Root cause: `ProgressWatchdog.tick()` is only called on real block processing (`blocks.py:1685`), never during the caught-up wait-for-next-block loops. So any Bitcoin inter-block gap >30 min (normal Poisson mining variance) false-trips it. (Confirmed by the prod investigation: block height keeps advancing between alerts; the "Last progress label" number increases — i.e. not a real hang.)

## Fix

- **blocks.py**: tick the watchdog each iteration of both idle-at-tip wait paths (ZMQ `wait_for_notification` loop and the polling sleep loop), labelled `at tip N, waiting…`. A healthy tip-wait keeps the watchdog fed; a genuine hang stops ticking and **still trips it**.
- **ops_alerter.py**: `ProgressWatchdog` threshold now reads **`OPS_ALERT_STALL_SEC`** (default 1800) — tunable per deployment without a code change; an explicit constructor arg still wins.
- **tests**: env-threshold honored, tick resets the stall timer (idle-at-tip), and the watchdog still fires on a real stall past threshold.

## Notes

- **Consensus-neutral** — the watchdog is an alerter; it does not touch block processing or any hash (rides the reparse gate to confirm).
- Reaches prod via the normal v1.9.0 deploy (no prod hot-patch). Also silences the current benign prod false positives once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)