### PR TITLE
docs(sips): reconcile SIP registry — resolve SIP-0009 collision, add 0007/0009/0010/0011

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,16 @@ Protocol evolution is governed through community-driven SIPs. See [SIP-0000](htt
 | SIP | Title | Status |
 |-----|-------|--------|
 | [0001](https://github.com/stampchain-io/btc_stamps/issues/685) | SRC-20 Conditional Transfers (Hashlock/Timelock) | Draft |
+| [0002](https://github.com/stampchain-io/btc_stamps/issues/484) | SRC-20 UTXO Binding & Transfer Format v2.0 | Superseded (by 0001) |
 | [0003](https://github.com/stampchain-io/btc_stamps/issues/485) | SRC-20 Cross-Chain Bridge Specification | Draft |
 | [0004](https://github.com/stampchain-io/btc_stamps/issues/687) | Shielded SRC-20 — Privacy Extension (Phased) | Draft |
 | [0005](https://github.com/stampchain-io/btc_stamps/issues/688) | Binary Transfer Format for SRC-20 | Draft |
 | [0006](https://github.com/stampchain-io/btc_stamps/issues/689) | Native SRC-20 AMM (Automated Market Maker) | Draft |
+| [0007](https://github.com/stampchain-io/btc_stamps/issues/735) | Probabilistic Atomic Swaps for SRC-20 | Draft |
 | [0008](https://github.com/stampchain-io/btc_stamps/issues/692) | Dual Transaction Parsing | Draft |
+| [0009](https://github.com/stampchain-io/btc_stamps/issues/725) | On-Demand SRC-20 SVG Generation | Draft |
+| [0010](https://github.com/stampchain-io/btc_stamps/issues/726) | Decentralised Stamp Relay Network | Draft |
+| [0011](https://github.com/stampchain-io/btc_stamps/issues/736) | Batch Operations & State Channels for SRC-20 | Draft |
 
 Full roadmap and gating criteria: [bitcoinstamps.xyz/en/protocols/sips](https://bitcoinstamps.xyz/en/protocols/sips) | Whitepaper details: [docs/whitepaper/improvement-proposals.md](docs/whitepaper/improvement-proposals.md)
 

--- a/docs/whitepaper/improvement-proposals.md
+++ b/docs/whitepaper/improvement-proposals.md
@@ -571,7 +571,11 @@ Transaction outputs:
 | **0004** | Shielded SRC-20 — Privacy Extension | Draft | [#687](https://github.com/stampchain-io/btc_stamps/issues/687) | 2027+ (phased) |
 | **0005** | Binary Transfer Format for SRC-20 | Draft | [#688](https://github.com/stampchain-io/btc_stamps/issues/688) | TBD |
 | **0006** | Native SRC-20 AMM (Automated Market Maker) | Draft | [#689](https://github.com/stampchain-io/btc_stamps/issues/689) | TBD |
+| **0007** | Probabilistic Atomic Swaps for SRC-20 | Draft | [#735](https://github.com/stampchain-io/btc_stamps/issues/735) | TBD |
 | **0008** | Dual Transaction Parsing | Draft | [#692](https://github.com/stampchain-io/btc_stamps/issues/692) | TBD |
+| **0009** | On-Demand SRC-20 SVG Generation | Draft | [#725](https://github.com/stampchain-io/btc_stamps/issues/725) | TBD |
+| **0010** | Decentralised Stamp Relay Network | Draft | [#726](https://github.com/stampchain-io/btc_stamps/issues/726) | TBD |
+| **0011** | Batch Operations & State Channels for SRC-20 | Draft | [#736](https://github.com/stampchain-io/btc_stamps/issues/736) | TBD |
 
 ---
 

--- a/docs/whitepaper/improvement-proposals.md
+++ b/docs/whitepaper/improvement-proposals.md
@@ -349,7 +349,7 @@ Example (0.3% fee tier):
 
 **Phased Rollout**:
 - **Phase 1**: SRC-20/SRC-20 pools (fully trustless, no external dependencies)
-- **Phase 2**: wBTC pools (requires SIP-0007 wrapped asset standard)
+- **Phase 2**: wBTC pools (requires the future wrapped asset standard — not yet drafted or numbered)
 - **Phase 3**: Stablecoin pools (requires SIP-0003 bridge for USDT/USDC)
 
 **Benefits**:


### PR DESCRIPTION
## Summary

Reconciles the SIP registry across all in-repo surfaces so every SIP number is unique and every proposal is cross-linked, following BIP-style unique/permanent number assignment (per SIP-0000 / #686).

### Root issue: duplicate SIP-0009
Two open issues both claimed **SIP-0009**:
- #725 — On-Demand SRC-20 SVG Generation (babalicious-io, opened **2026-03-31**)
- #736 — Batch Operations & State Channels (reinamora137, opened **2026-05-09**)

**Resolution (first-come, per BIP convention):** #725 keeps **SIP-0009**; #736 renumbered to **SIP-0011** (next free number — 0000–0010 were all assigned). The #736 issue title + in-body self-references were updated live, with explanatory comments on both #725 and #736.

### Files changed
- `README.md` — SIP table now lists 0001–0011 (added 0002-superseded, 0007, 0009, 0010, 0011).
- `docs/whitepaper/improvement-proposals.md` — summary table extended to 0011; corrected stale "SIP-0007 wrapped asset standard" reference (the wrapped-asset standard is now unnumbered/undrafted).

### Canonical registry (post-reconciliation)
| SIP | Issue | Title |
|-----|-------|-------|
| 0007 | #735 | Probabilistic Atomic Swaps |
| 0008 | #692 | Dual Transaction Parsing |
| 0009 | #725 | On-Demand SRC-20 SVG Generation |
| 0010 | #726 | Decentralised Stamp Relay Network |
| 0011 | #736 | Batch Operations & State Channels |

### Also updated (outside this repo)
- **SIP-0000 body (#686)** — registry table completed (0000–0011), stale roadmap prose disambiguated (legacy "SIP-0008 = Wrapped Asset Standard" → unnumbered), New-SIP checklist + doc-locations table corrected (repo org `btc-stamps`, site domain `bitcoinstamps.xyz`, whitepaper mirror + regen step).
- **bitcoinstamps.xyz** — companion PR updates `sip-registry.yaml` + regenerates the whitepaper artifacts.

Docs-only; no consensus-path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)