### PR TITLE
chore(deps): isolate consensus-adjacent deps in Dependabot + add cargo ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@
 #
 # Ecosystems covered:
 #   - pip            Poetry-managed indexer/pyproject.toml
+#   - cargo          indexer/src/rust_parser (Rust parse core)
 #   - docker         indexer/Dockerfile (python base image)
 #   - github-actions .github/workflows/*
 #
@@ -10,6 +11,28 @@
 # after-publish compromised packages (npm shai-hulud / nx / @ctrl/tinycolor,
 # tj-actions/changed-files). Per Dependabot spec, security advisory updates
 # BYPASS cooldown, so CVE-driven bumps still flow through immediately.
+#
+# ============================================================================
+# CONSENSUS-ADJACENT DEPENDENCY POLICY (load-bearing — read before merging)
+# ============================================================================
+# A subset of deps sit on the decode/filter/parse path and can change the three
+# rolling consensus hashes (txlist_hash / ledger_hash / messages_hash):
+#   pip   : msgpack, cryptography, ecdsa, pycryptodome, pybase64,
+#           python-bitcoinlib, bitcoinlib
+#   cargo : the ENTIRE indexer/src/rust_parser tree (pyo3, rand, bitcoin, ...)
+#
+# These are isolated below into a dedicated `consensus-critical` group (pip) and
+# a separate cargo ecosystem entry, so their bumps land in their OWN PR rather
+# than mixed into routine dev/runtime batches.
+#
+# RULE: A consensus-adjacent bump MUST NOT be auto-merged. It must pass the
+# Reparse Consensus Validation gate (txlist + ledger identical) before merge —
+# see CONTRIBUTING.md "The consensus rule". Reviewers: add the `consensus` label
+# and hold the PR until the reparse gate is green. Any pip PR that changes
+# indexer/poetry.lock also needs the freeze baseline regenerated
+# (./indexer/ci/refresh-freeze.sh) or Freeze Drift CI fails; grouping keeps this
+# churn batched.
+# ============================================================================
 
 version: 2
 updates:
@@ -32,6 +55,20 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 7
     groups:
+      # Consensus-adjacent deps — see policy header. Listed FIRST so these
+      # packages are peeled into their OWN isolated PR (never mixed into the
+      # routine minor-and-patch batch). This PR must ride the Reparse Consensus
+      # gate before merge; do NOT auto-merge. Dependabot cannot set a per-group
+      # label, so reviewers add the `consensus` label manually on this PR.
+      consensus-critical:
+        patterns:
+          - "msgpack"
+          - "cryptography"
+          - "ecdsa"
+          - "pycryptodome*"
+          - "pybase64"
+          - "python-bitcoinlib"
+          - "bitcoinlib"
       # Group Python tooling updates together (black/flake8/mypy/bandit/pytest stack)
       python-tooling:
         patterns:
@@ -71,6 +108,41 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 7
+
+  # Cargo — the Rust parse core (indexer/src/rust_parser). EVERY dep here is
+  # consensus-adjacent: pyo3, rand and bitcoin can change parse output, so any
+  # bump must pass the Reparse Consensus gate before merge (do NOT auto-merge).
+  # The `consensus` label is applied so these PRs are obvious. Previously only
+  # grouped SECURITY updates (repo-level) reached cargo — e.g. the #729 rand
+  # bump; without this entry, routine cargo version updates were NOT tracked.
+  # All crates are grouped into a single PR to minimise reparse-gate cycles.
+  - package-ecosystem: "cargo"
+    directory: "/indexer/src/rust_parser"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "rust"
+      - "consensus"
+    commit-message:
+      prefix: "deps(cargo)"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7
+    groups:
+      rust-parser:
+        patterns:
+          - "*"
+    ignore:
+      # Major version bumps need manual review (breaking-change risk); pyo3
+      # majors especially require a reparse-gated migration.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions — tj-actions/changed-files compromise (March 2025) made this
   # a real supply-chain vector; cooldown is essential here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,17 @@ and proven by **Reparse Consensus Validation green (txlist + ledger identical)**
 `poetry run python ci/ci_reparse_subprocess.py --limit 5`. Cross-block SRC-20 `ledger_hash`
 is owned by the full from-genesis reindex (maintainer-triggered).
 
+**Consensus-adjacent dependency bumps.** Some dependencies sit on the parse path and
+can move the hashes: pip `msgpack` / `cryptography` / `ecdsa` / `pycryptodome` /
+`pybase64` / `python-bitcoinlib` / `bitcoinlib`, and the entire cargo `rust_parser`
+tree (`pyo3`, `rand`, `bitcoin`). Dependabot isolates these into their own PRs (the
+`consensus-critical` pip group and the `cargo` entry in
+[`.github/dependabot.yml`](.github/dependabot.yml)). **Do not auto-merge them** — they
+must pass the Reparse Consensus gate first, get the `consensus` label, and are never
+merged mid-release (they change release scope). A pip bump that touches
+`indexer/poetry.lock` also needs `./indexer/ci/refresh-freeze.sh` re-run, or Freeze
+Drift CI fails.
+
 ## Pull requests
 
 - **Branch off `dev`; PRs target `dev`** (not `main`). `v1.9.0` cuts via long-running


### PR DESCRIPTION
## What

Refinement pass on `.github/dependabot.yml` (config/docs only, consensus-neutral — no code or lockfile changes).

### 1. Isolate consensus-adjacent Python deps
New `consensus-critical` pip group, listed **first** so these packages are peeled into their **own** PR instead of being mixed into the routine `minor-and-patch` batch:
`msgpack`, `cryptography`, `ecdsa`, `pycryptodome*`, `pybase64`, `python-bitcoinlib`, `bitcoinlib`.

### 2. Add the missing `cargo` ecosystem
`indexer/src/rust_parser` (`pyo3`, `rand`, `bitcoin`) had **no** version-update tracking — only repo-level grouped *security* updates ever reached it (e.g. the #729 `rand` bump). New `cargo` entry: weekly, 7-day cooldown, majors ignored, all crates grouped into one PR, labelled `consensus`. Every crate here is consensus-adjacent.

### 3. Document the consensus-adjacent-dep policy
- A header block in `dependabot.yml`.
- A short note in `CONTRIBUTING.md` under the consensus rule.

Policy: consensus-adjacent bumps **must pass the Reparse Consensus gate**, get the `consensus` label, and are **never auto-merged or merged mid-release**. A pip bump that touches `indexer/poetry.lock` also needs `./indexer/ci/refresh-freeze.sh` re-run or Freeze Drift CI fails — grouping keeps that churn batched.

## Notes
- Dependabot can't set a *per-group* label, so the `consensus-critical` pip PRs rely on the group name + a comment instructing reviewers to add `consensus` manually. The whole cargo entry carries the `consensus` label directly.
- YAML validated with `yaml.safe_load`; ecosystems now: `pip`, `cargo`, `docker`, `github-actions`.

## Related alert triage (separate, not in this PR)
- Alert #104 `ecdsa` (Minerva P-256, GHSA-wj6h-64fc-37mp): **dismissed** as `tolerable_risk` — used only for `VerifyingKey` verification, no secret-scalar/signing path, no upstream fix.
- Alert #112 `pyo3 <0.29.0` (GHSA-36hh-v3qg-5jq4): has a fix but is a consensus-adjacent 0.24→0.29 migration — left for a **reparse-gated bump post-release**, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)