### PR TITLE
docs(sips): correct SIP-0005 fail-safe example in AUTHORING §5

### DIFF
--- a/docs/sips/AUTHORING.md
+++ b/docs/sips/AUTHORING.md
@@ -184,9 +184,11 @@ Copy into the SIP's **Activation** section:
 - **Participating indexers at activation**: stampchain (reference) + <other indexer(s)>.
 - **Fail-safe behavior (non-upgraded indexers)**: Describe exactly what an indexer that has NOT
   upgraded does when it encounters the new operation. It MUST fail safe — i.e., ignore the
-  operation and NOT mutate balances/state — never fail open (guess and diverge). Example
-  (SIP-0005): "Indexers that haven't upgraded will not recognize the `stamp:` prefix → the
-  transfer is ignored (tokens not debited). This is fail-safe, not fail-open."
+  operation and NOT mutate balances/state — never fail open (guess and diverge). Example: "A
+  pre-upgrade indexer does not treat the new op's marker as a valid operation, so it skips it —
+  the transfer is ignored, no tokens are debited, and no stamp number is assigned. This is
+  fail-safe, not fail-open." (If your op reuses the existing `stamp:` prefix rather than a new
+  marker, see the caveat below — that is *not* automatically fail-safe.)
 - **No-balance-divergence check**: State how an upgraded and a not-yet-upgraded indexer avoid
   diverging on *existing* stamps/tokens before the activation height. Confirm that below the
   activation block the new op is a no-op for all indexers.
@@ -197,6 +199,17 @@ Copy into the SIP's **Activation** section:
 **Fail-safe is the cardinal rule.** The classic safe pattern is a new prefix/marker or op-code that
 old indexers simply do not recognize and therefore skip. Avoid any design where a non-upgraded
 indexer would *partially* process the operation.
+
+**Verify the fail-safe claim against the reference indexer's real classification path, not intent.**
+A common trap: `stamp:` is the *universal* stamp-detection prefix (`config.PREFIX`), so an op that
+merely reuses it is **not** skipped by a pre-upgrade indexer. The prefix is recognized, the new
+(e.g. binary) body fails to parse as a known operation, and the payload falls through to being
+classified as an ordinary stamp (`ident = "STAMP"` in `index_core/models.py`) and assigned a stamp
+number. That diverges stamp numbering *and* the `txlist_hash` — which is fail-**open**, the opposite
+of the intended behavior. So a design that reuses `stamp:` for a new operation (e.g. a binary SRC-20
+encoding) must additionally prove that pre-upgrade indexers cleanly *reject* the new body — not
+render it as a stamp — below the activation height, or else use a distinct marker they ignore
+outright.
 
 ---
 


### PR DESCRIPTION
## Summary

Technical-accuracy correction to the merged SIP authoring guide (`docs/sips/AUTHORING.md`, from PR #891). **Docs-only — no consensus/indexer code changed.**

Post-merge review validated the guide against the real indexer (`index_core/models.py`, `check.py`, `config.py`) and SIP-0000 (#686). One §5 example is technically inaccurate; everything else validated clean (§3 security checklist, §4 cross-indexer coordination, §6 terminology, §8 SIP-0110 split, and the `economics.md` "data-embedding" edit).

## The inaccuracy (AUTHORING §5, Activation → Fail-safe behavior)

The example claimed:

> "Indexers that haven't upgraded will not recognize the `stamp:` prefix → the transfer is ignored (tokens not debited). This is fail-safe, not fail-open."

This is wrong on two counts:

1. **`stamp:` is the *universal* stamp-detection prefix** (`config.PREFIX = b"stamp:"`, `indexer/src/config.py`). A non-upgraded indexer absolutely *does* recognize it — it is how *all* stamps are detected. SIP-0005's own text (#688) confirms this, referring to "unrecognized `stamp:` prefixed" data that old indexers still see.
2. **A reused-prefix binary payload is not "ignored" — it is minted as an ordinary stamp.** Per `index_core/models.py`, a `stamp:`-prefixed non-JSON binary body flows `handle_bytes → handle_bytes_again` (or `handle_string`) and is classified `ident = "STAMP"`, so a pre-upgrade indexer assigns it a **stamp number** → divergence of stamp numbering and the `txlist_hash`. That is **fail-open**, and it directly contradicts the section's own cardinal rule ("a new prefix/marker … old indexers simply do not recognize and therefore skip").

## Changes

- Replace the false SIP-0005 example with an accurate, marker-agnostic fail-safe example.
- Add a caveat (next to the existing cardinal-rule paragraph) explaining that reusing the existing `stamp:` prefix for a new op is **not** automatically fail-safe — a pre-upgrade indexer renders the unparsed body as a numbered stamp (`ident="STAMP"`), diverging numbering + `txlist_hash` — so such a design must prove old indexers cleanly *reject* the new body, or use a distinct marker.

1 file changed, 16 insertions(+), 3 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)