### PR TITLE
ci(release): hands-off PR-then-tag release + docker/version-check fixes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -100,42 +100,12 @@ jobs:
         id: get_commit
         run: printf 'hash=%s\n' "$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-      - name: Handle PR merge to main
-        if: env.SKIP == 'false' && github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == 'main'
-        run: |
-          # Get the PR title
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          
-          # Get the version from the PR branch
-          PR_VERSION=$(cat VERSION)
-          
-          # If version is in canary format, convert to prod
-          if [[ "$PR_VERSION" == *"+canary"* ]]; then
-            # First remove the build number
-            TEMP_VERSION=${PR_VERSION%.*}
-            # Then convert to prod format
-            NEW_VERSION=${TEMP_VERSION%+*}
-            # --no-tag: this strip lands on the PREVIOUS release version
-            # (e.g. 1.8.26+canary.N -> 1.8.26), whose tag already exists.
-            # Tagging here would collide (fatal: tag 'X' already exists) and
-            # abort the whole release. The real new-version tag is created by
-            # the [major|minor|patch] bump immediately below. This mirrors the
-            # --no-tag already used in the "Handle PR merge to dev" step.
-            bump2version --new-version "${NEW_VERSION}" --allow-dirty --no-tag release
-          fi
-          
-          # Handle version bumping based on PR title
-          if [[ "$PR_TITLE" == *"[major]"* ]]; then
-            bump2version major --verbose --allow-dirty
-          elif [[ "$PR_TITLE" == *"[minor]"* ]]; then
-            bump2version minor --verbose --allow-dirty
-          else
-            # Default behavior: bump patch version
-            bump2version patch --verbose --allow-dirty
-          fi
-          
-          # Store the new version
-          printf 'NEW_VERSION=%s\n' "$(cat VERSION)" >> $GITHUB_ENV
+      # NOTE: Cutting a production release (prod version bump on main, tag,
+      # GitHub Release, and version-only sync-back to dev) is owned by the
+      # dedicated release.yml "Cut Release" workflow, which releases via a PR to
+      # main + tag (never a direct push to main, which the `main-req` ruleset
+      # rejects with GH013). This workflow now only manages canary versions on
+      # dev. See release.yml for the release runbook.
 
       - name: Handle PR merge to dev
         if: env.SKIP == 'false' && github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == 'dev'
@@ -165,61 +135,14 @@ jobs:
       - name: Commit and push changes if new version
         if: env.SKIP == 'false' && env.NEW_VERSION
         run: |
+          # Canary bumps only ever land on dev here; the release path (main tag +
+          # Release + sync-back) lives in release.yml. Never push tags from this
+          # step — production tags are pushed by release.yml using the PAT.
           if [ "$(git rev-parse HEAD)" != "${{ env.hash }}" ]; then
             git push origin HEAD:${{ github.ref }}
-            # Only push tags for production releases (main branch)
-            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-              git push origin --tags
-            fi
           else
             echo "No new commit created, so no push."
           fi
-
-      - name: Create Release
-        if: env.SKIP == 'false' && env.NEW_VERSION && github.ref == 'refs/heads/main'
-        id: create_release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.NEW_VERSION }}
-          name: Release ${{ env.NEW_VERSION }}
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-
-      - name: Sync version back to dev
-        if: env.SKIP == 'false' && env.NEW_VERSION && github.event_name == 'pull_request' && github.base_ref == 'main'
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
-        run: |
-          # Version-only sync-back. This repo squash-merges dev->main, so main is
-          # a single squashed commit while dev keeps full history: a `main -> dev`
-          # PR phantom-conflicts on every squashed commit and can never merge.
-          # dev already contains all of main's CODE, so we only need to advance
-          # its version. Branch off dev, set the new canary version, PR to dev.
-          CANARY_VERSION="${NEW_VERSION}+canary.1"
-          SYNC_BRANCH="chore/sync-${NEW_VERSION}-canary"
-          EXISTING_PR=$(gh pr list --base dev --head "${SYNC_BRANCH}" --json number --jq '.[0].number' 2>/dev/null || echo "")
-          if [[ -n "$EXISTING_PR" ]]; then
-            echo "Sync PR #${EXISTING_PR} already exists, skipping creation"
-            exit 0
-          fi
-          git fetch origin dev
-          git checkout -B "${SYNC_BRANCH}" origin/dev
-          # bump2version (commit=True in .bumpversion.cfg) commits the version
-          # files itself; --no-tag because canary versions are never tagged.
-          bump2version --new-version "${CANARY_VERSION}" --no-tag --allow-dirty release
-          git push origin "${SYNC_BRANCH}"
-          # [skip-version] in the PR title => the dev-push bump step skips, leaving
-          # dev exactly at canary.1 (the next real dev push increments to canary.2).
-          PR_URL=$(gh pr create \
-            --base dev \
-            --head "${SYNC_BRANCH}" \
-            --title "chore: sync dev to ${CANARY_VERSION} after v${NEW_VERSION} release [skip-version]" \
-            --body "Automated post-release version sync. dev already has all of main's code (main is a squash of dev), so this updates only the version number to \`${CANARY_VERSION}\`, resuming canary development on the v${NEW_VERSION} line.")
-          echo "Created sync PR: $PR_URL"
-          gh pr merge "$PR_URL" --squash --auto 2>/dev/null || echo "Auto-merge unavailable — merge ${PR_URL} manually to restore canary versioning on dev"
 
   manual-versioning:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-auto-publish.yml
+++ b/.github/workflows/docker-auto-publish.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - dev
+    # Release version tags (X.Y.Z, no v-prefix, no +canary). A release commit
+    # always bumps indexer/pyproject.toml (indexer/**), so the paths filter below
+    # is satisfied for the tagged commit and the release build runs.
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
     paths:
       - 'indexer/**'
       - 'docker/**'
@@ -39,22 +44,31 @@ jobs:
       - name: Set Docker tag
         id: set-tag
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "TAG=latest" >> $GITHUB_OUTPUT
-          else
-            echo "TAG=dev" >> $GITHUB_OUTPUT
-          fi
           echo "SHA_TAG=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-          # Set branch name for tag
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          # Sanitize version for Docker tag (replace + with -)
-          SANITIZED_VERSION=$(echo "${{ steps.get-version.outputs.VERSION }}" | sed 's/+/-/g')
-          
-          if [[ "$BRANCH_NAME" != "main" ]]; then
-            # For non-main branches, add branch name to version
-            echo "VERSION_TAG=${SANITIZED_VERSION}-${BRANCH_NAME}" >> $GITHUB_OUTPUT
+
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # Release build (triggered by an X.Y.Z tag push): this is the ONLY
+            # path that publishes the moving :latest pointer and the clean
+            # :X.Y.Z release image, and the only path that rewrites the Docker
+            # Hub description. A plain push to main must never overwrite these.
+            RELEASE_VERSION="${GITHUB_REF#refs/tags/}"
+            echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+            echo "TAG=latest" >> $GITHUB_OUTPUT
+            echo "VERSION_TAG=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           else
-            echo "VERSION_TAG=${SANITIZED_VERSION}" >> $GITHUB_OUTPUT
+            # Branch push: publish a staging pointer only (never :latest, never a
+            # clean X.Y.Z tag). main -> :edge, dev -> :dev.
+            BRANCH_NAME=${GITHUB_REF#refs/heads/}
+            echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+            if [[ "$BRANCH_NAME" == "main" ]]; then
+              echo "TAG=edge" >> $GITHUB_OUTPUT
+            else
+              echo "TAG=dev" >> $GITHUB_OUTPUT
+            fi
+            # Sanitize version for Docker tag (replace + with -). Branch versions
+            # carry +canary, so this can never collide with a clean X.Y.Z tag.
+            SANITIZED_VERSION=$(echo "${{ steps.get-version.outputs.VERSION }}" | sed 's/+/-/g')
+            echo "VERSION_TAG=${SANITIZED_VERSION}-${BRANCH_NAME}" >> $GITHUB_OUTPUT
           fi
       
       - name: Log in to Docker Hub
@@ -121,7 +135,7 @@ jobs:
 
       - name: Update Docker Hub Description
         uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4
-        if: github.ref == 'refs/heads/main'
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
         with:
           username: btcstamps
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,220 @@
+name: Cut Release
+
+# Hands-off production release for btc_stamps.
+#
+# The `main-req` ruleset requires 5 status checks on refs/heads/main with an
+# empty bypass list, so a direct `git push origin HEAD:main` of a version-bump
+# commit is rejected (GH013). Those checks CAN pass on a pull request, so this
+# workflow releases via a PR to main + a tag, never a direct push:
+#
+#   prepare  (manual "Cut Release", input: bump=major|minor|patch)
+#     -> compute clean X.Y.Z from main's current version + bump level
+#     -> create release/vX.Y.Z off main with the 4 version files set to X.Y.Z
+#     -> open a [skip-version] PR to main and enable squash auto-merge
+#        (merges once the 5 required checks are green)
+#
+#   finalize (release/* PR merged into main)
+#     -> tag X.Y.Z (no v-prefix) on the merge commit, pushed with the PAT so
+#        tag-triggered workflows (docker-auto-publish) fire
+#     -> create the "Release X.Y.Z" GitHub Release
+#     -> open a version-only [skip-version] sync-back PR setting dev to
+#        X.Y.Z+canary.1 and enable squash auto-merge
+#
+# Tags are pushed with secrets.PAT on purpose: tags pushed with GITHUB_TOKEN do
+# not trigger downstream Actions. Rulesets target refs/heads/main, not tags, so
+# the tag push is not ruleset-blocked. Auto-merge is enabled with the PAT so the
+# eventual merge emits a pull_request event that triggers the finalize job.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Release version bump level'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+env:
+  GIT_USER_NAME: GitHub Action
+  GIT_USER_EMAIL: action@github.com
+
+jobs:
+  # Manual trigger: open the release PR to main and let it auto-merge.
+  prepare:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install bump2version
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          git remote set-url origin https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}.git
+
+      - name: Compute release version and create release branch
+        id: version
+        run: |
+          # main carries a clean prod version (X.Y.Z). bump2version reads the
+          # current version from .bumpversion.cfg and, because the `release` part
+          # has optional_value = prod, serializes back to a clean X.Y.Z. Bumping
+          # commits the 4 version files (commit = True) onto the new branch.
+          git checkout -B release/staging main
+          bump2version "${{ github.event.inputs.bump }}" \
+            --no-tag --allow-dirty --verbose \
+            --message 'chore: release {new_version} [skip-version]'
+          NEW_VERSION=$(cat VERSION)
+          if [[ "$NEW_VERSION" == *"+canary"* ]]; then
+            echo "::error::Refusing to release a canary version ($NEW_VERSION); main must carry a clean X.Y.Z version"
+            exit 1
+          fi
+          RELEASE_BRANCH="release/v${NEW_VERSION}"
+          git branch -m "release/staging" "${RELEASE_BRANCH}"
+          git push origin "${RELEASE_BRANCH}"
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
+
+      - name: Open release PR to main and enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.NEW_VERSION }}"
+          RELEASE_BRANCH="${{ steps.version.outputs.RELEASE_BRANCH }}"
+          # [skip-version] keeps bump-version.yml from re-bumping when the squash
+          # commit lands on main.
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${RELEASE_BRANCH}" \
+            --title "chore: release ${NEW_VERSION} [skip-version]" \
+            --body "Automated production release cut by the Cut Release workflow.
+
+          Sets the version files to \`${NEW_VERSION}\` (prod). Once the required checks pass and this squash-merges, the finalize job tags \`${NEW_VERSION}\` on main, publishes the GitHub Release, and opens the version-only sync-back PR restoring canary versioning on dev.")
+          echo "Opened release PR: $PR_URL"
+          gh pr merge "$PR_URL" --squash --auto \
+            || echo "Auto-merge unavailable — merge ${PR_URL} manually (admin) once checks are green"
+
+  # Runs when a release/* PR is merged into main: tag, release, sync back to dev.
+  finalize:
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && github.event.pull_request.base.ref == 'main'
+      && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install bump2version
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          git remote set-url origin https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}.git
+
+      - name: Tag release
+        id: tag
+        run: |
+          NEW_VERSION=$(cat VERSION)
+          if [[ "$NEW_VERSION" == *"+canary"* ]]; then
+            echo "::error::main is at a canary version ($NEW_VERSION); refusing to tag"
+            exit 1
+          fi
+          # No v-prefix (matches .bumpversion.cfg tag_name = {new_version}).
+          # Pushed with the PAT so tag-triggered workflows (docker-auto-publish)
+          # fire; rulesets target refs/heads/main only, so tag pushes are allowed.
+          if git ls-remote --exit-code --tags origin "refs/tags/${NEW_VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${NEW_VERSION} already exists on origin, skipping tag push"
+          else
+            git tag "${NEW_VERSION}" "${{ github.event.pull_request.merge_commit_sha }}"
+            git push origin "${NEW_VERSION}"
+          fi
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.NEW_VERSION }}
+          name: Release ${{ steps.tag.outputs.NEW_VERSION }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+
+      - name: Sync version back to dev
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          NEW_VERSION="${{ steps.tag.outputs.NEW_VERSION }}"
+          # Version-only sync-back. This repo squash-merges dev->main, so main is
+          # a single squashed commit while dev keeps full history: a `main -> dev`
+          # PR phantom-conflicts on every squashed commit and can never merge.
+          # dev already contains all of main's CODE, so we only advance its
+          # version. Branch off dev, set the new canary version, PR to dev.
+          CANARY_VERSION="${NEW_VERSION}+canary.1"
+          SYNC_BRANCH="chore/sync-${NEW_VERSION}-canary"
+          EXISTING_PR=$(gh pr list --base dev --head "${SYNC_BRANCH}" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Sync PR #${EXISTING_PR} already exists, skipping creation"
+            exit 0
+          fi
+          git fetch origin dev
+          git checkout -B "${SYNC_BRANCH}" origin/dev
+          # bump2version (commit = True) commits the version files itself;
+          # --no-tag because canary versions are never tagged.
+          bump2version --new-version "${CANARY_VERSION}" --no-tag --allow-dirty release
+          git push origin "${SYNC_BRANCH}"
+          # [skip-version] in the PR title => the dev-push bump step in
+          # bump-version.yml skips, leaving dev exactly at canary.1 (the next real
+          # dev push increments to canary.2).
+          PR_URL=$(gh pr create \
+            --base dev \
+            --head "${SYNC_BRANCH}" \
+            --title "chore: sync dev to ${CANARY_VERSION} after ${NEW_VERSION} release [skip-version]" \
+            --body "Automated post-release version sync. dev already has all of main's code (main is a squash of dev), so this updates only the version number to \`${CANARY_VERSION}\`, resuming canary development on the ${NEW_VERSION} line.")
+          echo "Created sync PR: $PR_URL"
+          gh pr merge "$PR_URL" --squash --auto \
+            || echo "Auto-merge unavailable — merge ${PR_URL} manually to restore canary versioning on dev"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -19,7 +19,15 @@ jobs:
 
       - name: Validate version format
         run: |
-          BRANCH=${GITHUB_REF#refs/heads/}
+          # On pull_request events GITHUB_REF is refs/pull/N/merge, which matches
+          # neither "dev" nor "main" and made this check a silent no-op on PRs.
+          # Use the PR's base branch for pull_request events so dev PRs are
+          # validated as canary and main PRs as prod; keep push behavior as-is.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BRANCH="${{ github.base_ref }}"
+          else
+            BRANCH=${GITHUB_REF#refs/heads/}
+          fi
           VERSION=$(cat VERSION)
           
           if [[ "$BRANCH" == "dev" && "$VERSION" != *"+canary"* ]]; then


### PR DESCRIPTION
## What & why

Makes production releases **hands-off** and fixes two release-related latent bugs, **without changing the branch model** (dev-primary, `X.Y.Z+canary.N` canaries, Dependabot→`dev`, no-`v`-prefix tags).

Root cause: the release path pushed a version-bump commit **directly to `main`**, which the `main-req` ruleset rejects (`GH013`, 5/5 required checks expected, empty bypass list). Both 1.9.0 and 1.9.1 needed manual recovery. The 5 checks in `python-check.yml` (`name: CI`) are `pull_request`-triggered and gated on `base_ref == dev|main`, so they **do** pass on a PR to `main` — so we release via **PR-then-tag**, never a direct push.

## Per-file changes

**`.github/workflows/release.yml` (new — "Cut Release")**
- `workflow_dispatch` input `bump = major|minor|patch`. `prepare` job: checks out `main`, `bump2version` computes the clean `X.Y.Z` (the `release` part's `optional_value = prod` serializes to clean form), creates `release/vX.Y.Z` with the 4 version files set, commit tagged `[skip-version]`, pushes, opens a PR to `main`, enables **squash auto-merge** (merges when the 5 checks go green).
- `finalize` job (trigger: `pull_request` `closed`, base `main`, head `release/*`, merged): tags `X.Y.Z` (**no `v`-prefix**) on `merge_commit_sha`, **pushes the tag with `secrets.PAT`** (GITHUB_TOKEN-pushed tags don't trigger downstream Actions; rulesets target `refs/heads/main`, not tags, so the tag push is allowed), creates the `Release X.Y.Z` GitHub Release, then opens the **version-only** sync-back PR to `dev` at `X.Y.Z+canary.1` (`[skip-version]`, auto-merge).
- Auto-merge and the release PR both use the **PAT** so the eventual merge emits a `pull_request` event that triggers `finalize`. Idempotence guards: skips tagging if the tag already exists; skips the sync PR if one already exists.

**`.github/workflows/bump-version.yml`**
- Removes the broken/dead push-to-main release steps (`Handle PR merge to main`, main `Create Release`, `Sync version back to dev`) and the tag push inside `Commit and push`. This workflow now **only** manages dev canary versions. (`Handle PR merge to dev` and `manual-versioning` left untouched.)

**`.github/workflows/docker-auto-publish.yml`**
- Adds an `X.Y.Z` **tag** trigger. `:latest` + the clean `:X.Y.Z` image + the Docker Hub description rewrite now happen **only on a release tag push**. Branch pushes publish a **staging pointer only** (`main → :edge`, `dev → :dev`) plus the SHA tag and a `+canary`-suffixed version tag — so a stray `main` push can no longer overwrite the released `:latest`/`:X.Y.Z`.

**`.github/workflows/version-check.yml`**
- Uses `github.base_ref` on `pull_request` events (was `GITHUB_REF#refs/heads/` → `refs/pull/N/merge`, matching neither `dev` nor `main`, so the check was a silent no-op on PRs). Push behavior unchanged. Now dev PRs are validated as canary, main PRs as prod.

## Release runbook (new)

1. **Actions → "Cut Release" → Run workflow** on `dev` (or any ref), pick `bump` = `major|minor|patch`.
2. It opens `release/vX.Y.Z → main` and enables auto-merge. Review; it squash-merges once the 5 required checks pass. *(If org auto-merge is disabled, admin-merge the PR — the finalize job still runs on merge.)*
3. On merge, finalize auto-tags `X.Y.Z`, publishes the GitHub Release, and the tag push triggers `docker-auto-publish` → `:latest` + `:X.Y.Z` + description.
4. Finalize opens the `X.Y.Z+canary.1` sync-back PR to `dev` (auto-merges). Done.

## Verification
- YAML parsed with PyYAML — all 4 files valid.
- `actionlint 1.7.12` — **no findings** on `release.yml`, `docker-auto-publish.yml`, `version-check.yml`. The only 2 warnings are **pre-existing** script-injection notes on untouched lines in `bump-version.yml` (`check-skip` PR title, `Handle PR merge to dev` `head_ref`).

## Risks / follow-ups
- **Requires org setting "Allow auto-merge"** for hands-off merging; without it, admin-merge — finalize still fires (guarded with a graceful fallback message).
- **Tag + `paths` interaction:** `docker-auto-publish` keeps its `indexer/**` paths filter; a release commit always bumps `indexer/pyproject.toml`, so the tagged commit satisfies it. If a reviewer prefers belt-and-suspenders, drop `paths`.
- Pre-existing `bump-version.yml` script-injection warnings and the `manual-versioning` job's direct-push (rejected if ever run on `main`) are **out of scope** — left as follow-ups.

Draft — please review; do not merge without maintainer sign-off. This is release infra for a consensus indexer.
