### PR TITLE
ci: sign release images (keyless) + SBOM + digest + Docker Hub prune

### DIFF
--- a/.github/workflows/docker-auto-publish.yml
+++ b/.github/workflows/docker-auto-publish.yml
@@ -19,9 +19,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write so the release path can append the signed image digest
+      # + cosign verify instructions to the GitHub Release notes.
+      contents: write
       packages: write
-    
+      # id-token: write is REQUIRED for keyless (OIDC) cosign signing/attest on
+      # the release path. It is harmless on branch pushes (no signing runs there).
+      id-token: write
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
@@ -99,9 +104,9 @@ jobs:
             # Calculate how many to delete
             DELETE_COUNT=$((TAG_COUNT - 5))
             TAGS_TO_DELETE=$(echo "$TAGS" | head -n "$DELETE_COUNT")
-            
+
             echo "Found $TAG_COUNT SHA tags, deleting $DELETE_COUNT older tags"
-            
+
             # Delete old tags
             for TAG in $TAGS_TO_DELETE; do
               echo "Deleting tag: $TAG"
@@ -111,8 +116,50 @@ jobs:
           else
             echo "Only $TAG_COUNT SHA tags found, no pruning needed"
           fi
+
+          # Prune stale STAGING version tags, keeping the 10 most recently
+          # updated. Staging tags are the per-branch build markers:
+          #   dev  -> "<X.Y.Z>-canary.<N>-dev"   (e.g. 1.9.1-canary.5-dev)
+          #   main -> "<X.Y.Z>-main"             (edge builds)
+          # plus any legacy "*-edge" tags. These accumulate on every branch push.
+          #
+          # HARD SAFETY: this selection can NEVER touch a clean release tag
+          # (^X.Y.Z$), the moving pointers (latest / dev / edge), or SHA tags:
+          #   - clean releases are excluded by the semver `not` test,
+          #   - the bare pointers are excluded by explicit name != checks,
+          #   - only names matching a staging suffix/segment are considered.
+          # Sort is by last_updated (newest first) so we keep the freshest 10.
+          #
+          # NOTE: the retired ":1.9.0" release image predates this signing/SBOM
+          # pipeline. It is a clean X.Y.Z tag and is therefore intentionally NOT
+          # pruned here; it can be deleted manually from Docker Hub once the new
+          # signed 1.9.x release is verified.
+          echo "Listing staging tags to prune..."
+          STAGING_TAGS=$(curl -s -H "Authorization: Bearer $TOKEN" \
+                "https://hub.docker.com/v2/repositories/btcstamps/indexer/tags?page_size=100" | \
+                jq -r '.results[]
+                        | select(.name != "latest" and .name != "dev" and .name != "edge")
+                        | select((.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | not)
+                        | select(.name | test("-canary\\.|-dev$|-edge$|-main$"))
+                        | "\(.last_updated)\t\(.name)"' | \
+                sort -r | \
+                cut -f2)
+
+          STAGING_COUNT=$(echo "$STAGING_TAGS" | grep -c . || true)
+          if [ "$STAGING_COUNT" -gt 10 ]; then
+            STAGING_TO_DELETE=$(echo "$STAGING_TAGS" | tail -n +11)
+            echo "Found $STAGING_COUNT staging tags, deleting $((STAGING_COUNT - 10)) older ones (keeping newest 10)"
+            for TAG in $STAGING_TO_DELETE; do
+              echo "Deleting staging tag: $TAG"
+              curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+                "https://hub.docker.com/v2/repositories/btcstamps/indexer/tags/$TAG/"
+            done
+          else
+            echo "Only $STAGING_COUNT staging tags found, no staging pruning needed"
+          fi
       
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./indexer
@@ -123,7 +170,112 @@ jobs:
             btcstamps/indexer:${{ steps.set-tag.outputs.VERSION_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      
+
+      # ---- Release supply-chain integrity (RELEASE path only) ----------------
+      # Everything below is gated on IS_RELEASE == 'true', so branch pushes
+      # (:dev / :edge) are untouched. We pin the release image by its immutable
+      # digest (from the build step) for signing, SBOM and attestation so the
+      # exact bytes that were pushed are the exact bytes that get signed.
+
+      - name: Resolve release image digest
+        id: digest
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "$DIGEST" ]; then
+            echo "::error::No image digest available from build step; cannot sign release"
+            exit 1
+          fi
+          IMAGE_REF="btcstamps/indexer@${DIGEST}"
+          echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+          echo "Release image pinned by digest: ${IMAGE_REF}"
+
+      - name: Install cosign
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign release image (keyless / OIDC)
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
+        env:
+          # Keyless signing: identity comes from the GitHub Actions OIDC token
+          # (id-token: write). No private keys are stored anywhere. The signature
+          # is stored alongside the image on Docker Hub.
+          COSIGN_YES: "true"
+        run: |
+          cosign sign --yes "${{ steps.digest.outputs.IMAGE_REF }}"
+          echo "Signed ${{ steps.digest.outputs.IMAGE_REF }} (keyless)"
+
+      - name: Generate SBOM (SPDX JSON)
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.digest.outputs.IMAGE_REF }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          # Also publish the SBOM as a workflow artifact for auditors.
+          upload-artifact: true
+          artifact-name: sbom-${{ steps.set-tag.outputs.VERSION_TAG }}.spdx.json
+
+      - name: Attest SBOM to release image (keyless / OIDC)
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign attest --yes \
+            --predicate sbom.spdx.json \
+            --type spdxjson \
+            "${{ steps.digest.outputs.IMAGE_REF }}"
+          echo "Attached SPDX SBOM attestation to ${{ steps.digest.outputs.IMAGE_REF }}"
+
+      - name: Record signed image digest in GitHub Release
+        if: steps.set-tag.outputs.IS_RELEASE == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.set-tag.outputs.VERSION_TAG }}"
+          IMAGE_REF="${{ steps.digest.outputs.IMAGE_REF }}"
+
+          # release.yml's finalize job creates the "Release X.Y.Z" Release in
+          # parallel with this (much longer) build. Wait briefly for it to exist.
+          for _ in $(seq 1 24); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              break
+            fi
+            echo "Waiting for GitHub Release $TAG to be created..."
+            sleep 5
+          done
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::warning::GitHub Release $TAG not found after waiting; skipping digest note (image is still signed on Docker Hub)"
+            exit 0
+          fi
+
+          # Keyless verification identity is the signing workflow ref: this file
+          # running on the release tag. Consumers pass it to cosign verify.
+          IDENTITY="^https://github.com/${{ github.repository }}/.github/workflows/docker-auto-publish.yml@refs/tags/${TAG}\$"
+          ISSUER="https://token.actions.githubusercontent.com"
+
+          # Build the appended note with printf (avoids embedding an un-indented
+          # heredoc inside this YAML block scalar). 4-space indents => code blocks.
+          gh release view "$TAG" --json body --jq '.body' > current_notes.md || true
+          {
+            printf '\n---\n\n## Signed release image\n\n'
+            printf 'This release is published to Docker Hub as an immutable digest and signed\n'
+            printf 'keyless (Sigstore/cosign, GitHub Actions OIDC - no private keys):\n\n'
+            printf '    %s\n\n' "$IMAGE_REF"
+            printf '**Verify the signature:**\n\n'
+            printf '    cosign verify \\\n'
+            printf '      --certificate-identity-regexp %s \\\n' "'$IDENTITY'"
+            printf '      --certificate-oidc-issuer %s \\\n' "$ISSUER"
+            printf '      %s\n\n' "$IMAGE_REF"
+            printf '**Verify the SPDX SBOM attestation:**\n\n'
+            printf '    cosign verify-attestation --type spdxjson \\\n'
+            printf '      --certificate-identity-regexp %s \\\n' "'$IDENTITY'"
+            printf '      --certificate-oidc-issuer %s \\\n' "$ISSUER"
+            printf '      %s\n' "$IMAGE_REF"
+          } >> current_notes.md
+          gh release edit "$TAG" --notes-file current_notes.md
+          echo "Recorded ${IMAGE_REF} in GitHub Release $TAG"
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:


### PR DESCRIPTION
## What

Hardens the **release** path of `docker-auto-publish.yml` (which fires when `release.yml` finalize pushes an `X.Y.Z` tag) with Sigstore supply-chain integrity. All additions are gated on `IS_RELEASE == 'true'`, so branch pushes (`:dev` / `:edge`) are unaffected.

### 1. Keyless cosign signing
- Adds `id-token: write` (+ `contents: write`) to the `build_and_push` job.
- Installs cosign via `sigstore/cosign-installer@6f9f177...` (v4.1.2, pinned SHA).
- Captures the immutable build digest and runs `cosign sign --yes btcstamps/indexer@sha256:...` — keyless via GitHub Actions OIDC, **no private keys**. The signature is stored on Docker Hub.

### 2. SBOM
- Generates an SPDX-JSON SBOM with `anchore/sbom-action@e22c389...` (v0.24.0, pinned SHA) against the pinned digest.
- Uploads it as a workflow artifact **and** `cosign attest`s it (keyless) to the image.

### 3. Digest recorded in the GitHub Release
- After signing, appends the `btcstamps/indexer@sha256:...` digest plus copy-paste `cosign verify` / `cosign verify-attestation` commands to the Release notes (waits briefly for `release.yml` finalize to create the Release).

### 4. Docker Hub prune of stale staging tags
- Extends "Clean up old Docker images" to also delete stale `*-canary.*-dev` / `*-dev` / `*-edge` / `*-main` staging tags, keeping the newest ~10 by `last_updated`.
- **Never** deletes clean release tags (`X.Y.Z`), `:latest`, or the `:dev` / `:edge` moving pointers (explicit excludes + semver guard).
- Comment notes the retired `:1.9.0` image (a clean tag) is intentionally not pruned and can be removed manually once the new signed release is verified.

## How a consumer verifies a release

```bash
cosign verify \
  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  btcstamps/indexer@sha256:<digest>

# SBOM attestation:
cosign verify-attestation --type spdxjson \
  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  btcstamps/indexer@sha256:<digest>
```

The exact digest + commands are auto-appended to each GitHub Release.

## Validation
- `actionlint` (1.7.12) — clean on the changed workflow.
- `actionlint` + `shellcheck` (0.10.0) — no findings on any added `run:` step (only pre-existing SC2086/SC2193 on untouched steps remain).
- PyYAML `safe_load` — parses OK.

## Risks / notes
- Keyless signing **requires** the job's `id-token: write` OIDC permission (added here) and the OIDC issuer to be reachable — standard on GitHub-hosted runners.
- Signatures/attestations are stored on **Docker Hub** alongside the image; Docker Hub does support the OCI referrers/`.sig` tag storage cosign uses.
- The digest-in-Release step depends on `release.yml` finalize having created the Release; it waits up to ~2 min and degrades to a warning (image is still signed) if not found.
- All new action SHAs are pinned; no keys or new secrets introduced (reuses `DOCKERHUB_TOKEN`, `GITHUB_TOKEN`).

Draft — do not merge. Consensus infra; please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)