### PR TITLE
docs: document the Cut Release workflow + governance (second reviewer)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,11 @@
-*	@reinamora137
+# Code owners for btc_stamps.
+#
+# Every PR requests review from BOTH owners below (two-reviewer governance).
+#
+# @reinamora137  - repo maintainer / admin.
+# @btcopenstamp  - required *second reviewer* only. This adds a governance
+#                  second-set-of-eyes on every change; it does NOT grant
+#                  admin/maintainer rights. For CODEOWNERS review to be
+#                  requestable, @btcopenstamp needs at least write (collaborator)
+#                  access to the repo, but should NOT be made an org/repo admin.
+*	@reinamora137 @btcopenstamp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,11 @@ Drift CI fails.
 
 ## Pull requests
 
-- **Branch off `dev`; PRs target `dev`** (not `main`). `v1.9.0` cuts via long-running
-  PR #495 (dev→main).
+- **Branch off `dev`; PRs target `dev`** (not `main`). Every PR is reviewed by two
+  code owners (see [`.github/CODEOWNERS`](.github/CODEOWNERS)). **Releases are cut by
+  maintainers** via the automated **Cut Release** workflow (PR-then-tag → signed
+  `X.Y.Z` Docker image + GitHub Release → version-only sync-back to `dev`); do not
+  open release PRs to `main` yourself. See [`docs/dev/versioning.md`](docs/dev/versioning.md).
 - Title convention: `type(#NNN): summary` (e.g. `fix(#812): ...`, `chore: ...`).
 - Set a **milestone** (e.g. `v1.9.0`) and **labels**
   (`consensus` / `ci` / `perf` / `supply-chain` / `documentation`).

--- a/README.md
+++ b/README.md
@@ -105,9 +105,31 @@ Full roadmap and gating criteria: [bitcoinstamps.xyz/en/protocols/sips](https://
 
 ## 🤝 Contributions
 
-The Bitcoin Stamps protocol is open source and community-driven. 
+The Bitcoin Stamps protocol is open source and community-driven.
 If you have ideas, improvements, or bug fixes, please submit
 a pull request or open an issue.
+
+**Branch off `dev` and open PRs against `dev`** (not `main`). Every PR is
+reviewed by two code owners. Releases are cut by maintainers via the automated
+**Cut Release** workflow. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full
+workflow and [`docs/dev/versioning.md`](docs/dev/versioning.md) for versioning
+and the release process.
+
+## 🔏 Signed Releases
+
+Release images published to Docker Hub (`btcstamps/indexer`) are **signed
+keyless with [Sigstore/cosign](https://www.sigstore.dev/)** (GitHub Actions OIDC —
+no private keys) and carry an SPDX SBOM attestation. Each
+[GitHub Release](https://github.com/stampchain-io/btc_stamps/releases) records the
+exact `btcstamps/indexer@sha256:…` digest and the `cosign verify` command. To
+verify provenance before running an image:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+```
 
 ## 💎 Donate
 

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -1,305 +1,147 @@
-# Bitcoin Stamps Versioning Guide
+# Bitcoin Stamps Versioning & Release Guide
 
-This document outlines the versioning processes for the Bitcoin Stamps project, particularly focusing on managing versions between development (dev) and production (main) branches.
+This document describes how versions and releases work for the Bitcoin Stamps
+indexer. **`dev` is the primary branch**; `main` carries the current production
+release. Releases are **tag-driven** and cut by maintainers with a single manual
+workflow — you should almost never touch versions by hand.
 
 ## Version Format
 
-- Main branch: `MAJOR.MINOR.PATCH` (e.g., `1.8.26`)
-- Dev branch: `MAJOR.MINOR.PATCH+canary.BUILD` (e.g., `1.8.26+canary.1`)
+- **Main branch (production):** `MAJOR.MINOR.PATCH` — e.g. `1.9.0`
+  (**no `v` prefix**; git tags are also `1.9.0`, not `v1.9.0`).
+- **Dev branch (canary):** `MAJOR.MINOR.PATCH+canary.BUILD` — e.g. `1.9.0+canary.1`
 
-## Command Breakdown
+Version Format Check CI enforces this: `dev` must be `+canary`, `main` must not.
 
-### bump2version Command Format
+## Golden rules
+
+1. **Branch off `dev`; PRs target `dev`** (not `main`).
+2. **Never** hand-edit `VERSION` / `indexer/pyproject.toml` /
+   `indexer/src/config.py` — bumps are automated via `.bumpversion.cfg`.
+3. **Never** push a bump commit directly to `main`, **never** rebase/force-push
+   `dev` onto `main`, and **never** open a `main → dev` PR. (Why: this repo
+   squash-merges `dev → main`, so `main` is a single squashed commit while `dev`
+   keeps full history — a `main → dev` merge phantom-conflicts on every squashed
+   commit and can never merge, and a rebase would rewrite `dev`'s protected
+   history and break every open PR and clone.)
+4. **Releases are cut only by maintainers** via the **Cut Release** workflow
+   (below). Tags have **no `v` prefix**.
+
+## Dev canary versioning (automated)
+
+`bump-version.yml` runs on pushes/merges to `dev` and keeps the canary build
+number moving. You don't run anything:
+
+```
+1.9.0+canary.1 → 1.9.0+canary.2 → 1.9.0+canary.3 …
+```
+
+### `[skip-version]` — opting a change out of a bump
+
+- **On a PR merged to `dev`:** put `[skip-version]` in the **PR title** to skip
+  the canary bump for that merge.
+- **On a direct push to `dev`:** put `[skip-version]` in the **commit message**
+  to skip the bump for that commit.
+
+Only the PR title is inspected for PR merges (commit messages inside the PR are
+ignored); only the commit message is inspected for direct pushes. No git tags or
+GitHub Releases are created for dev/canary builds.
+
+## Cutting a release (the **Cut Release** workflow)
+
+Releases are produced entirely by the `release.yml` **"Cut Release"** workflow —
+a PR-then-tag flow that satisfies branch protection on `main` (a direct
+version-bump push to `main` is rejected by the required-checks ruleset). A
+maintainer triggers it manually:
+
+> **Actions → Cut Release → Run workflow → choose bump = `major` | `minor` | `patch`**
+
+What happens, hands-off, from there:
+
+1. **`prepare`** — computes the clean `X.Y.Z` from `main`'s current version and
+   the chosen bump, creates `release/vX.Y.Z` off `main` with the version files
+   set to `X.Y.Z` (prod), opens a `[skip-version]` PR to `main`, and enables
+   squash auto-merge. It merges once the required checks are green.
+2. **`finalize`** (runs when that release PR squash-merges into `main`):
+   - **tags `X.Y.Z`** (no `v` prefix) on the merge commit, pushed with the `PAT`
+     so tag-triggered workflows fire;
+   - creates the **`Release X.Y.Z`** GitHub Release (auto-generated notes);
+   - opens a **version-only sync-back PR** to `dev` setting it to
+     `X.Y.Z+canary.1` (`[skip-version]` in the title) and auto-merges it, so
+     canary development resumes on the new line. Only the version number syncs —
+     `dev` already contains all of `main`'s code.
+3. **`docker-auto-publish.yml`** — the `X.Y.Z` tag push triggers the release
+   image build, which publishes `btcstamps/indexer:latest` + the clean
+   `:X.Y.Z` tag to Docker Hub, then **signs the image and attaches an SBOM**
+   (see below).
+
+Example: a `minor` bump from `1.9.0` produces tag `1.10.0`, Release `1.10.0`,
+Docker `btcstamps/indexer:1.10.0` + `:latest`, and syncs `dev` to
+`1.10.0+canary.1`.
+
+There is **no** manual "push a bump to main", "rebase dev onto main", or
+"force-push" step — those legacy rituals are gone.
+
+## Verifying a signed release image
+
+Release images are signed **keyless** (Sigstore/cosign via GitHub Actions OIDC —
+no private keys) and carry an SPDX SBOM attestation. Each GitHub Release records
+the exact `btcstamps/indexer@sha256:…` digest and the commands to verify it:
+
+```bash
+# Verify the signature (substitute the digest from the Release notes):
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+
+# Verify the SPDX SBOM attestation:
+cosign verify-attestation --type spdxjson \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+```
+
+## Files the automation updates
+
+- `VERSION`
+- `indexer/pyproject.toml`
+- `indexer/src/config.py`
+
+## `bump2version` reference (for maintainers / manual recovery only)
+
 ```bash
 bump2version [part] [options]
 
-# Common parts:
-# - release: Switch between prod/canary formats
-# - minor: Increment minor version (1.8.26 → 1.9.0)
-# - patch: Increment patch version (1.8.26 → 1.8.27)
-# - major: Increment major version (1.8.26 → 2.0.0)
-# - build: Increment canary build (1.8.26+canary.1 → 1.8.26+canary.2)
+# Parts:
+#   major   1.9.0 → 2.0.0
+#   minor   1.9.0 → 1.10.0
+#   patch   1.9.0 → 1.9.1
+#   build   1.9.0+canary.1 → 1.9.0+canary.2
+#   release switch prod <-> canary serialization
 
-# Common options:
-# --new-version: Specify exact version or format (prod/canary)
-# --allow-dirty: Allow uncommitted changes in working directory
+# Options:
+#   --new-version   set an exact version (e.g. 1.9.0+canary.1)
+#   --no-tag        do NOT create a git tag (required for canary + strip steps)
+#   --allow-dirty   allow uncommitted changes in the working tree
 ```
 
-## Branch Synchronization Workflows
-
-### 1. Starting New Development Work (Main → Dev)
-
-To sync dev with main's latest changes:
-
-```bash
-# 1. Create a PR from main to dev
-# You can do this via GitHub UI or command line:
-git checkout main
-git pull origin main
-git checkout dev
-git pull origin main
-git push origin dev
-# Then create PR from main to dev via GitHub UI
-```
-
-The GitHub Action will automatically:
-1. Detect that it's a PR from main to dev
-2. Convert the version to canary format
-3. Update all version files
-4. Create appropriate tags
-
-Example:
-- Starting version: `1.8.26`
-- After PR merge: `1.8.26+canary.1`
-
-Note: No need to manually run any version commands - the workflow handles everything!
-
-### 2. Making Dev Changes
-
-The GitHub Action will automatically:
-1. Check if version is in canary format
-2. If in canary format, increment the build number
-3. Update all version files and create tags
-
-Example progression:
-```
-1.8.26+canary.1 → 1.8.26+canary.2 → 1.8.26+canary.3
-```
-
-### 3. Creating PR to Main
-
-When creating a PR from dev to main:
-
-#### Default Behavior (Automatic Patch Bump)
-By default, when merging to main:
-1. Keep the version in canary format
-2. The GitHub Action will automatically:
-   - Convert canary version to prod format
-   - Bump the patch version
-   - Update version files
-   - Create appropriate tags
-
-Example:
-- PR version: `1.8.26+canary.5`
-- After merge: `1.8.27`
-
-#### Version Control via PR Title
-You can control version bumping using keywords in the PR title:
-- `[minor]`: Will bump minor version instead of patch
-- `[major]`: Will bump major version instead of patch
-- `[skip-version]`: Will skip version bump entirely
-
-Example PR titles:
-- "feat: add new feature [minor]" → `1.8.26+canary.5` → `1.9.0`
-- "fix: bug fix" → `1.8.26+canary.5` → `1.8.27` (default patch bump)
-- "feat: breaking change [major]" → `1.8.26+canary.5` → `2.0.0`
-- "chore: update deps [skip-version]" → `1.8.26+canary.5` → `1.8.26`
-
-### 4. Manual Version Updates
-
-For cases requiring manual version control:
-
-```bash
-# Using workflow_dispatch:
-# Go to Actions → Bump Version → Run workflow
-# Select version type: major, minor, patch, build, or release
-# Optionally mark as pre-release
-
-# Or using command line:
-bump2version [type] --allow-dirty
-git push origin HEAD --tags
-```
-
-Note: When using manual version control, add `[skip-version]` to your PR title to prevent automatic version bumping.
-
-### 5. Syncing Dev After Main Update (automated)
-
-After a release lands on main, dev must advance to the new canary line
-(e.g. `1.9.0` → `1.9.0+canary.1`). **This is fully automated** by the
-`Sync version back to dev` step in `bump-version.yml` — you normally do nothing.
-
-**Do NOT rebase/force-push dev onto main, and do NOT open a `main → dev` PR.**
-This repo **squash-merges** dev → main (merge commits are disabled repo-wide), so
-main is a single squashed commit while dev keeps full history. A `main → dev`
-merge therefore phantom-conflicts on *every* squashed commit (hundreds of files)
-and can never merge; a `git rebase origin/main` + force-push would rewrite dev's
-protected history and break every open PR and clone.
-
-Because dev already contains **all of main's code** (main was squashed *from*
-dev), only the **version number** needs to sync. The workflow does exactly that:
-
-1. Branches off `dev` (`chore/sync-<version>-canary`).
-2. Sets the version files to `<version>+canary.1` (`bump2version ... --no-tag`).
-3. Opens a small PR to `dev` (title contains `[skip-version]`) and auto-merges it.
-
-Example:
-- Release version on main: `1.9.0`
-- dev after sync: `1.9.0+canary.1` (next dev push → `+canary.2`)
-
-If auto-merge is unavailable, just merge that one-file sync PR by hand.
-
-## GitHub Actions Workflow Behavior
-
-The workflow (`bump-version.yml`) handles:
-
-1. PR Merge to Main:
-   - Converts canary version to prod format
-   - Applies version bump based on PR title
-   - Updates version files
-   - Creates appropriate tags
-
-2. PR Merge to Dev:
-   - Converts to canary format if merging from main
-   - Creates appropriate tags
-   - Updates version files
-
-3. Dev Branch Commits:
-   - Increments build number if in canary format
-   - Updates version files
-   - Creates appropriate tags
-
-4. Manual Version Updates:
-   - Supports manual version bumping via workflow_dispatch
-   - Allows specifying version type (major, minor, patch, build, release)
-
-## Files Updated
-
-The workflow automatically updates these files:
-- VERSION
-- indexer/pyproject.toml
-- indexer/src/config.py
-
-## Best Practices
-
-1. Let the GitHub Action handle format conversions
-2. Use PR title keywords to control version bumping
-3. Use `[skip-version]` when manual control is needed
-4. Always ensure changes are committed before version updates
-
-## Common Issues and Solutions
-
-1. **Version Format Mismatch**
-   - The workflow automatically handles format conversions
-   - No need to manually convert between prod/canary formats
-
-2. **Failed CI Workflows**
-   - Ensure all changes are committed
-   - Use `--allow-dirty` flag for manual updates
-
-3. **Sync Issues**
-   - Let the workflow handle version conversions during syncs
-   - Manual intervention only needed for special cases
-
-4. **Release aborts with `fatal: tag 'X.Y.Z' already exists`**
-   - Cause: the canary-strip on merge-to-main (`X.Y.Z+canary.N → X.Y.Z`) lands on
-     the *previous* release version, whose tag already exists. If that
-     `bump2version release` runs without `--no-tag` it re-creates that tag and
-     aborts the whole release (main left on canary, no new tag/Release, wrong
-     Docker publish).
-   - Invariant: the canary-strip **must** use `--no-tag`; only the title-driven
-     `[major|minor|patch]` bump creates the new tag. Do not remove it.
-   - Recovery if it ever aborts again: branch off main → set the four version
-     files to the intended `X.Y.Z` → PR to main with `[skip-version]` → merge →
-     `git tag X.Y.Z <sha> && git push origin X.Y.Z` → create the GitHub Release →
-     confirm Docker published `X.Y.Z`/`latest` → let the sync-back PR restore
-     canary on dev.
-
-Note on cleanup: canary **git tags** and **GitHub Releases** are no longer
-created for dev builds (the dev-push bump uses `--no-tag`; the Release step is
-gated to `main`). Any pre-existing `X.Y.Z+canary.N` tags/Releases are legacy
-cruft and safe to delete — real release tags (`X.Y.Z`) must be kept.
-
-## Version Control Keywords
-
-### PR Title Keywords
-When creating a Pull Request, use these keywords in the PR title to control version bumping:
-- `[minor]` - Bumps minor version
-- `[major]` - Bumps major version
-- `[skip-version]` - Skips version update for this PR
-
-Note: For PRs, only the PR title is checked for keywords. Commit messages within the PR are ignored.
-
-### Commit Message Keywords
-For direct commits to branches (not through PRs):
-- `[skip-version]` - Skips version update for this specific commit
-
-Example:
-```bash
-# Direct commit to dev - will skip version bump
-git commit -m "chore: update deps [skip-version]"
-
-# PR to main - will bump minor version regardless of commit messages
-git commit -m "feat: new feature [skip-version]"  # [skip-version] is ignored
-git push origin dev
-# Create PR with title: "feat: new feature [minor]"
-```
-
-## Process Flows
-
-### 1. Normal PR to Main
-```bash
-# Create PR with title based on change type:
-"feat: new feature"              # Will bump patch
-"feat: new feature [minor]"      # Will bump minor
-"feat: new feature [major]"      # Will bump major
-"chore: update [skip-version]"   # Won't bump version
-
-# Result:
-# - Workflow checks PR title only
-# - Ignores commit messages within PR
-# - Applies version bump based on PR title
-```
-
-### 2. Direct Commits to Dev
-```bash
-# Regular commit - will bump canary build
-git commit -m "feat: your changes"
-git push origin dev
-
-# Skip version bump
-git commit -m "chore: quick fix [skip-version]"
-git push origin dev
-
-# Result:
-# - Workflow checks commit message
-# - Skips version bump if [skip-version] is present
-```
-
-## Important Notes
-
-1. **PR Version Control**
-   - Only PR titles control version bumping
-   - Commit messages within PRs are ignored
-   - PR title keywords: `[major]`, `[minor]`, `[skip-version]`
-
-2. **Direct Commit Version Control**
-   - Only affects direct pushes to branches
-   - Only `[skip-version]` is checked
-   - Applies to that specific commit only
-
-3. **Process Safety**
-   - PR merges always use PR title for version control
-   - Direct commits can be skipped individually
-   - No mixing of PR and commit message controls
-
-4. **Best Practices**
-   - Use PR titles to control major/minor version bumps
-   - Use commit `[skip-version]` for maintenance commits
-   - Keep version control intent clear in PR titles
-
-### Version Format Validation
-
-The CI pipeline automatically validates version formats through a dedicated workflow:
-
-- Dev branch: Must use canary format (e.g., `1.0.0+canary.1`)
-- Main branch: Must use production format (e.g., `1.0.0`)
-
-The validation runs:
-1. On every push to dev/main
-2. On every pull request targeting dev/main
-
-If you see version format errors:
-1. For dev branch: Run `bump2version release --new-version canary`
-2. For main branch: Run `bump2version release --new-version prod`
-
-The validation workflow must pass before the version bumping workflow can run.
+**Invariant:** any `bump2version release` that lands on an already-released
+`X.Y.Z` **must** use `--no-tag`, or it re-creates that tag and aborts. The Cut
+Release workflow already does this; only override it during manual recovery.
+
+## Troubleshooting
+
+- **Version format error in CI.** `dev` must be `X.Y.Z+canary.N`, `main` must be
+  clean `X.Y.Z`. The automation normally keeps these correct; if a branch is
+  wrong, open a small `[skip-version]` PR that sets the version files correctly.
+- **Sync-back PR didn't auto-merge.** If auto-merge is unavailable, just merge
+  the one-file `chore: sync dev to X.Y.Z+canary.1 …` PR by hand to restore
+  canary versioning on `dev`.
+- **Release aborted with `tag 'X.Y.Z' already exists`.** Manual recovery: branch
+  off `main` → set the version files to the intended `X.Y.Z` → open a
+  `[skip-version]` PR to `main` → merge → `git tag X.Y.Z <sha> && git push origin
+  X.Y.Z` → create the GitHub Release → confirm Docker published `X.Y.Z` / `latest`
+  → let the sync-back PR restore canary on `dev`.
+- **Legacy canary tags/Releases.** Old `X.Y.Z+canary.N` git tags or Releases are
+  cruft and safe to delete; real release tags (`X.Y.Z`) must be kept.

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -6,10 +6,35 @@ Official Docker image for the Bitcoin Stamps Indexer - the reference implementat
 
 ## Available Tags
 
-- `latest` - Built automatically from the `main` branch
-- `dev` - Built automatically from the `dev` branch
+- `latest` - The most recent stable release (published on an `X.Y.Z` release tag)
+- `X.Y.Z` - Stable release versions (no `v` prefix), e.g. `1.9.0`
+- `dev` - Built automatically from the `dev` branch (canary / unstable)
 - `<sha>` - Built from specific commits (first 7 characters of commit hash)
-- `vX.Y.Z` - Stable release versions
+
+Only clean `X.Y.Z` release tags and `latest` are signed (see below). `dev`,
+`<sha>`, and staging tags are development builds and are not signed.
+
+## Verifying this image
+
+Release images are **signed keyless** with [Sigstore/cosign](https://www.sigstore.dev/)
+(GitHub Actions OIDC — no private keys) and carry an SPDX SBOM attestation. The
+matching [GitHub Release](https://github.com/stampchain-io/btc_stamps/releases)
+records the exact `btcstamps/indexer@sha256:…` digest. Verify provenance before
+running:
+
+```bash
+# Verify the signature (substitute the release version and digest):
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+
+# Verify the SPDX SBOM attestation:
+cosign verify-attestation --type spdxjson \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+```
 
 ## Quick Start
 


### PR DESCRIPTION
## What

Documentation + governance updates so contributors and Docker Hub users understand the **new tag-driven release process** and can verify signed images. Pairs with #900 (which implements the signing/SBOM/prune).

### Per-file
- **`.github/CODEOWNERS`** — add `@btcopenstamp` as a required **second reviewer** alongside `@reinamora137` (`* @reinamora137 @btcopenstamp`). Comment clarifies `btcopenstamp` needs at least write/collaborator access for CODEOWNERS review to be requestable, but is **not** a repo admin/maintainer. Both handles verified to exist.
- **`docs/dev/versioning.md`** — rewrites the release section for the **Cut Release** workflow: `workflow_dispatch` (bump = major/minor/patch) → automated PR-then-tag → clean `X.Y.Z` tag (**no `v` prefix**) → GitHub Release + signed Docker image → version-only sync-back to `dev` (`X.Y.Z+canary.1`). Removes stale "push a bump to main / rebase-force-push / open a main→dev PR" rituals. Keeps the canary-on-dev + `[skip-version]` explanations and adds the signed-image `cosign verify` steps.
- **`README.md`** — points contributions at `dev` / `CONTRIBUTING.md`; adds a "Signed Releases" section with the `cosign verify` command.
- **`CONTRIBUTING.md`** — branch off `dev`, PR to `dev`, two code-owner review, releases cut by maintainers via the Cut Release workflow; drops the stale long-running-PR #495 note.
- **`indexer/README.md`** (Docker Hub description) — corrects the tag list (`X.Y.Z`, no `v` prefix; `latest` = release tag, not `main`) and adds a "Verifying this image" cosign keyless-verify section, consistent with the root README.

## Notes / risks
- CODEOWNERS review requests for `@btcopenstamp` only fire once that account has **write (collaborator)** access — grant that separately; this PR does not (and should not) make them an admin.
- The `cosign verify` identity/commands mirror exactly what #900 emits into each GitHub Release; the two PRs should land together for consistency (docs describe behavior #900 adds).

Draft — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)