### PR TITLE
docs: rewrite for the main-primary (trunk) model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ software — please read the consensus rule below before opening a PR.
 
 ## Getting started
 
-- Read [`CLAUDE.md`](CLAUDE.md) (dev vs prod, the consensus model, gotchas) and
+- Read [`CLAUDE.md`](CLAUDE.md) (the consensus model, gotchas) and
   [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) / [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 - A Rust transaction parser (`indexer/src/rust_parser/`, PyO3 module `btc_stamps_parser`)
   feeds the Python ledger engine (`indexer/src/index_core/`). **All commands run from
@@ -60,15 +60,20 @@ Drift CI fails.
 
 ## Pull requests
 
-- **Branch off `dev`; PRs target `dev`** (not `main`). `v1.9.0` cuts via long-running
-  PR #495 (dev→main).
+- **Branch off `main`; PRs target `main`.** This repo follows a trunk model —
+  `main` is the single primary branch (there is no `dev` branch). Every PR is
+  reviewed by **both** code owners (see [`.github/CODEOWNERS`](.github/CODEOWNERS));
+  code-owner review is required before merge.
+- **Releases are cut by maintainers**, not by contributors, via the automated
+  **Cut Release** workflow (PR-then-tag → signed `X.Y.Z` Docker image + GitHub
+  Release → `main` reopened at `X.Y.Z+dev.0`). Do not open release PRs or edit
+  version files yourself. See [`docs/dev/versioning.md`](docs/dev/versioning.md).
 - Title convention: `type(#NNN): summary` (e.g. `fix(#812): ...`, `chore: ...`).
-- Set a **milestone** (e.g. `v1.9.0`) and **labels**
-  (`consensus` / `ci` / `perf` / `supply-chain` / `documentation`).
+- Set **labels** (`consensus` / `ci` / `perf` / `supply-chain` / `documentation`).
 - **Stage files explicitly — never `git add -A`** (scratch/debug/`.env.local*` files get
   swept in otherwise).
-- **Do not hand-edit** `VERSION` / `pyproject` version / `config.py:VERSION_STRING` —
-  version bumps are automated (`.bumpversion.cfg`).
+- **Do not hand-edit** `VERSION` / `pyproject` version / `config.py:VERSION_STRING` /
+  `.bumpversion.cfg` — version bumps are automated (`.bumpversion.cfg`).
 - Fill out the [pull request template](.github/PULL_REQUEST_TEMPLATE.md); open issues with
   the [issue templates](.github/ISSUE_TEMPLATE/).
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   # Bitcoin Stamps
   
   ### SRC-20 / SRC-721 / OLGA / SRC-721r / SRC-101
-  [![Code Quality & Unit Tests](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/python-check.yml?label=Code%20Quality&job=code-quality&branch=dev)](https://github.com/stampchain-io/btc_stamps/actions/workflows/python-check.yml) [![Rust Checks](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/python-check.yml?label=Rust%20Checks&job=rust&branch=dev)](https://github.com/stampchain-io/btc_stamps/actions/workflows/python-check.yml) [![Integration Tests](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/python-check.yml?label=Integration&job=integration&branch=dev)](https://github.com/stampchain-io/btc_stamps/actions/workflows/python-check.yml) [![Coverage Analysis](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/coverage.yml?label=Coverage&branch=dev)](https://github.com/stampchain-io/btc_stamps/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/stampchain-io/btc_stamps/graph/badge.svg?token=OB2OS37L5H)](https://codecov.io/gh/stampchain-io/btc_stamps)
- [![Docker Build](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/docker-auto-publish.yml?label=Docker%20Build&branch=dev)](https://github.com/stampchain-io/btc_stamps/actions/workflows/docker-auto-publish.yml)
+  [![Code Quality & Unit Tests](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/python-check.yml?label=Code%20Quality&job=code-quality&branch=main)](https://github.com/stampchain-io/btc_stamps/actions/workflows/python-check.yml) [![Rust Checks](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/python-check.yml?label=Rust%20Checks&job=rust&branch=main)](https://github.com/stampchain-io/btc_stamps/actions/workflows/python-check.yml) [![Integration Tests](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/python-check.yml?label=Integration&job=integration&branch=main)](https://github.com/stampchain-io/btc_stamps/actions/workflows/python-check.yml) [![Coverage Analysis](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/coverage.yml?label=Coverage&branch=main)](https://github.com/stampchain-io/btc_stamps/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/stampchain-io/btc_stamps/graph/badge.svg?token=OB2OS37L5H)](https://codecov.io/gh/stampchain-io/btc_stamps)
+ [![Docker Build](https://img.shields.io/github/actions/workflow/status/stampchain-io/btc_stamps/docker-auto-publish.yml?label=Docker%20Build&branch=main)](https://github.com/stampchain-io/btc_stamps/actions/workflows/docker-auto-publish.yml)
 
   [![Last Commit](https://img.shields.io/github/last-commit/stampchain-io/btc_stamps)](https://github.com/stampchain-io/btc_stamps) [![Python Versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org/) [![License](https://img.shields.io/github/license/stampchain-io/btc_stamps)](LICENSE) [![Stars](https://img.shields.io/github/stars/stampchain-io/btc_stamps?style=social)](https://github.com/stampchain-io/btc_stamps/stargazers) [![Forks](https://img.shields.io/github/forks/stampchain-io/btc_stamps?style=social)](https://github.com/stampchain-io/btc_stamps/network/members) [![Issues](https://img.shields.io/github/issues/stampchain-io/btc_stamps)](https://github.com/stampchain-io/btc_stamps/issues) [![Pull Requests](https://img.shields.io/github/issues-pr/stampchain-io/btc_stamps)](https://github.com/stampchain-io/btc_stamps/pulls)
 </div>
@@ -105,9 +105,33 @@ Full roadmap and gating criteria: [bitcoinstamps.xyz/en/protocols/sips](https://
 
 ## 🤝 Contributions
 
-The Bitcoin Stamps protocol is open source and community-driven. 
+The Bitcoin Stamps protocol is open source and community-driven.
 If you have ideas, improvements, or bug fixes, please submit
 a pull request or open an issue.
+
+This repository follows a **trunk model**: **branch off `main` and open PRs
+against `main`** (the single primary branch). Every PR is reviewed by two code
+owners. Releases are cut by maintainers via the automated **Cut Release**
+workflow. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow and
+[`docs/dev/versioning.md`](docs/dev/versioning.md) for versioning and the release
+process.
+
+## 🔏 Signed Releases
+
+Release images published to Docker Hub (`btcstamps/indexer`) are **signed keyless
+with [Sigstore/cosign](https://www.sigstore.dev/)** (GitHub Actions OIDC — no
+private keys) and carry an SPDX SBOM attestation. Each
+[GitHub Release](https://github.com/stampchain-io/btc_stamps/releases) records the
+exact `btcstamps/indexer@sha256:…` digest and the `cosign verify` command. To
+verify provenance before running an image (substitute the release version and
+digest):
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+```
 
 ## 💎 Donate
 
@@ -142,12 +166,18 @@ running a local Counterparty node to reduce dependency on public resources.
 If you don't have Docker installed, follow the official Docker installation guide:
 [Install Docker Engine](https://docs.docker.com/engine/install/) for your platform.
 
-#### Clone the repo and switch to the main production branch
+#### Clone the repo
+
+`main` is the trunk and default branch, so a fresh clone already checks it out:
 
 ```shell
 git clone https://github.com/stampchain-io/btc_stamps.git
-git switch main
+cd btc_stamps
 ```
+
+For a verified, reproducible deployment, check out a signed release tag (e.g.
+`git switch --detach 1.9.1`) and verify its Docker image per
+[Signed Releases](#-signed-releases).
 
 #### Step 1: Create & configure the env file
 
@@ -198,13 +228,13 @@ cd indexer
 ./run-container.sh --build
 
 # Run specific Docker Hub version with local MySQL
-./run-container.sh --image 1.9.1  # or --image dev
+./run-container.sh --image 1.9.1  # or --image edge (latest main build)
 
 # Run with logs to stdout (ideal for testing)
-./run-container.sh --image dev --prod
+./run-container.sh --image edge --prod
 
 # Run detached in background
-./run-container.sh --image dev --detach
+./run-container.sh --image edge --detach
 
 # Show all options
 ./run-container.sh --help
@@ -230,13 +260,13 @@ cp .env.sample .env.local
 # Edit .env.local with your MySQL and BTC node details
 ```
 
-2. **Run the latest development version:**
+2. **Run the latest pre-release (edge) build:**
 ```shell
-./run-container.sh --image dev --prod
+./run-container.sh --image edge --prod
 ```
 
 This will:
-- Pull the latest dev image from Docker Hub
+- Pull the latest edge image from Docker Hub (newest main build)
 - Connect to your local MySQL database (specified in .env.local)
 - Output logs to stdout for easy debugging
 - Use your local Bitcoin node configuration
@@ -268,7 +298,7 @@ If you encounter problems with container execution:
 
 2. **Test with production mode:**
    ```shell
-   ./run-container.sh --image dev --prod
+   ./run-container.sh --image edge --prod
    ```
    This outputs logs directly to the console, making it easier to identify errors.
 
@@ -287,7 +317,7 @@ If you encounter problems with container execution:
    If using host mode (default), ensure your local services are available on localhost.
    If your services are on different hosts, try bridge mode:
    ```shell
-   ./run-container.sh --image dev --bridge
+   ./run-container.sh --image edge --bridge
    ```
 
 ### 💻 Local Execution without Docker

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -1,305 +1,165 @@
-# Bitcoin Stamps Versioning Guide
+# Bitcoin Stamps Versioning & Release Guide
 
-This document outlines the versioning processes for the Bitcoin Stamps project, particularly focusing on managing versions between development (dev) and production (main) branches.
+This document describes how versions and releases work for the Bitcoin Stamps
+indexer. The repository follows a **trunk model**: **`main` is the single
+primary branch** and the source of truth. Releases are **tag-driven** and cut by
+maintainers with one manual workflow — you should almost never touch versions by
+hand.
 
-## Version Format
+## Version format
 
-- Main branch: `MAJOR.MINOR.PATCH` (e.g., `1.8.26`)
-- Dev branch: `MAJOR.MINOR.PATCH+canary.BUILD` (e.g., `1.8.26+canary.1`)
+`main` carries one of two states in its `VERSION` file (and its three mirrors —
+see [Files the automation updates](#files-the-automation-updates)):
 
-## Command Breakdown
+- **Between releases (normal state):** `MAJOR.MINOR.PATCH+dev.N` — e.g.
+  `1.9.1+dev.0`. The base `X.Y.Z` is the **last shipped release**; `+dev.N` marks
+  it as in-development. There is **no per-push version bump**, so `main` normally
+  sits at `+dev.0` for the whole cycle.
+- **A freshly cut release (momentary):** `MAJOR.MINOR.PATCH` — e.g. `1.10.0`.
+  A release commit carries a clean `X.Y.Z` (**no `v` prefix**; the git tag is
+  also `1.10.0`, not `v1.10.0`). Immediately after the release lands, `main` is
+  reopened at `X.Y.Z+dev.0` for the next cycle.
 
-### bump2version Command Format
+`Version Format Check` CI (`.github/workflows/version-check.yml`) enforces that
+`VERSION` is always either a clean `X.Y.Z` or the `X.Y.Z+dev.N` marker.
+
+## Golden rules
+
+1. **Branch off `main`; PRs target `main`.** There is no `dev` branch (it was
+   retired and preserved as the `dev-archive` tag).
+2. **Never** hand-edit the version carriers (`VERSION`, `indexer/pyproject.toml`,
+   `indexer/src/config.py`, `.bumpversion.cfg`) — bumps are automated via
+   `.bumpversion.cfg`.
+3. **Never** push a version-bump commit directly to `main`. The `main-req`
+   ruleset requires status checks on `refs/heads/main` with an empty bypass list,
+   so a direct push of a version commit is rejected. Every version change flows
+   through a PR + auto-merge (the Cut Release workflow does this for you).
+4. **Releases are cut only by maintainers** via the **Cut Release** workflow
+   (below). Release tags have **no `v` prefix**.
+
+## `[skip-version]`
+
+`[skip-version]` in a PR title documents that a PR must **not** trigger any
+version automation. In the trunk model there is no per-push bump, so the only
+version-changing PRs are the two automated ones the Cut Release workflow opens
+(the release freeze and the reopen-at-`+dev.0` follow-up) — both are tagged
+`[skip-version]` so no other automation acts on them. You do not normally add it
+by hand.
+
+## Cutting a release (the **Cut Release** workflow)
+
+Releases are produced entirely by the `release.yml` **"Cut Release"** workflow —
+a PR-then-tag flow that satisfies branch protection on `main` (a direct
+version-bump push to `main` is rejected by the required-checks ruleset). A
+maintainer triggers it manually:
+
+> **Actions → Cut Release → Run workflow → choose bump = `major` | `minor` | `patch`**
+
+What happens, hands-off, from there:
+
+1. **`prepare`** — reads `main`'s `X.Y.Z+dev.0`, strips the `+dev.N` marker to
+   recover the last released base, and applies the chosen bump to compute the
+   clean target (`patch → 1.9.2`, `minor → 1.10.0`, `major → 2.0.0`). It creates
+   `release/vX.Y.Z` off `main` with all version files frozen to `X.Y.Z`, opens a
+   `[skip-version]` PR to `main`, and enables squash auto-merge. The PR merges
+   once the required checks (including code-owner review) are green.
+2. **`finalize`** (runs when that `release/*` PR squash-merges into `main`):
+   - **tags `X.Y.Z`** (no `v` prefix) on the merge commit, pushed with the `PAT`
+     so tag-triggered workflows fire (a tag pushed with the default token would
+     not trigger downstream Actions);
+   - creates the **`Release X.Y.Z`** GitHub Release (auto-generated notes);
+   - opens a follow-up `[skip-version]` PR (branch `chore/reopen-X.Y.Z-dev`)
+     that **reopens `main` at `X.Y.Z+dev.0`** for the next cycle, and
+     auto-merges it. This PR's head is `chore/*` (not `release/*`), so it does
+     not re-trigger `finalize`.
+3. **`docker-auto-publish.yml`** — the `X.Y.Z` tag push triggers the release
+   image build, which publishes `btcstamps/indexer:X.Y.Z` + `:latest` to Docker
+   Hub, then **signs the image keyless and attaches an SPDX SBOM** (see
+   [Verifying a signed release image](#verifying-a-signed-release-image)).
+
+Example: a `minor` bump from `1.9.1+dev.0` produces tag `1.10.0`, Release
+`1.10.0`, Docker `btcstamps/indexer:1.10.0` + `:latest`, and reopens `main` at
+`1.10.0+dev.0`.
+
+There is **no** manual "push a bump to main", "sync branches", or "force-push"
+step — the trunk model has none of those.
+
+## Between-release builds (pre-release images)
+
+Every push to `main` (merged PRs) triggers `docker-auto-publish.yml`, which
+publishes **staging-only** images:
+
+- `btcstamps/indexer:edge` — a moving pointer to the newest `main` build.
+- `btcstamps/indexer:sha-<short>` — the specific commit build (7-char SHA). Only
+  the newest five `sha-*` tags are kept; older ones are pruned automatically.
+
+Staging pushes **never** publish `:latest` or a clean `:X.Y.Z` tag, and they are
+**not** signed. Merged Dependabot / feature PRs therefore reach `:edge`
+immediately but **do not ship** to `:latest` / `:X.Y.Z` until a maintainer cuts a
+tag.
+
+## Verifying a signed release image
+
+Release images are signed **keyless** (Sigstore/cosign via GitHub Actions OIDC —
+no private keys) and carry an SPDX SBOM attestation. Each GitHub Release records
+the exact `btcstamps/indexer@sha256:…` digest and the commands to verify it. The
+signing identity is the release workflow running on the release tag:
+
 ```bash
-bump2version [part] [options]
+# Verify the signature (substitute the release version and the digest from the
+# Release notes):
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
 
-# Common parts:
-# - release: Switch between prod/canary formats
-# - minor: Increment minor version (1.8.26 → 1.9.0)
-# - patch: Increment patch version (1.8.26 → 1.8.27)
-# - major: Increment major version (1.8.26 → 2.0.0)
-# - build: Increment canary build (1.8.26+canary.1 → 1.8.26+canary.2)
-
-# Common options:
-# --new-version: Specify exact version or format (prod/canary)
-# --allow-dirty: Allow uncommitted changes in working directory
+# Verify the SPDX SBOM attestation:
+cosign verify-attestation --type spdxjson \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
 ```
 
-## Branch Synchronization Workflows
+## Files the automation updates
 
-### 1. Starting New Development Work (Main → Dev)
+`bump2version` (driven by `.bumpversion.cfg`) keeps four mirrored version
+carriers in lockstep:
 
-To sync dev with main's latest changes:
+- `VERSION`
+- `indexer/pyproject.toml`
+- `indexer/src/config.py` (`VERSION_STRING`)
+- `.bumpversion.cfg` (`current_version`)
+
+The `X.Y.Z+dev.N` marker matches `config.py`'s `VERSION_STRING` parser
+(`release="dev"`, `build=N`), so the minimum-version comparison in `check.py`
+(which only looks at `MAJOR.MINOR.PATCH`) is unaffected.
+
+## `bump2version` reference (maintainers / manual recovery only)
+
+The Cut Release workflow uses an explicit `--new-version` (not a semantic part
+bump) because `main`'s release-part value is `dev`, which is intentionally
+outside `.bumpversion.cfg`'s bumpable set. You should not need these by hand.
 
 ```bash
-# 1. Create a PR from main to dev
-# You can do this via GitHub UI or command line:
-git checkout main
-git pull origin main
-git checkout dev
-git pull origin main
-git push origin dev
-# Then create PR from main to dev via GitHub UI
+bump2version --new-version X.Y.Z --no-tag --allow-dirty patch   # freeze a release
+bump2version --new-version X.Y.Z+dev.0 --no-tag --allow-dirty patch   # reopen dev marker
+
+# Options:
+#   --new-version   set an exact version (e.g. 1.10.0 or 1.10.0+dev.0)
+#   --no-tag        do NOT create a git tag (finalize tags separately)
+#   --allow-dirty   allow uncommitted changes in the working tree
 ```
 
-The GitHub Action will automatically:
-1. Detect that it's a PR from main to dev
-2. Convert the version to canary format
-3. Update all version files
-4. Create appropriate tags
+## Troubleshooting
 
-Example:
-- Starting version: `1.8.26`
-- After PR merge: `1.8.26+canary.1`
-
-Note: No need to manually run any version commands - the workflow handles everything!
-
-### 2. Making Dev Changes
-
-The GitHub Action will automatically:
-1. Check if version is in canary format
-2. If in canary format, increment the build number
-3. Update all version files and create tags
-
-Example progression:
-```
-1.8.26+canary.1 → 1.8.26+canary.2 → 1.8.26+canary.3
-```
-
-### 3. Creating PR to Main
-
-When creating a PR from dev to main:
-
-#### Default Behavior (Automatic Patch Bump)
-By default, when merging to main:
-1. Keep the version in canary format
-2. The GitHub Action will automatically:
-   - Convert canary version to prod format
-   - Bump the patch version
-   - Update version files
-   - Create appropriate tags
-
-Example:
-- PR version: `1.8.26+canary.5`
-- After merge: `1.8.27`
-
-#### Version Control via PR Title
-You can control version bumping using keywords in the PR title:
-- `[minor]`: Will bump minor version instead of patch
-- `[major]`: Will bump major version instead of patch
-- `[skip-version]`: Will skip version bump entirely
-
-Example PR titles:
-- "feat: add new feature [minor]" → `1.8.26+canary.5` → `1.9.0`
-- "fix: bug fix" → `1.8.26+canary.5` → `1.8.27` (default patch bump)
-- "feat: breaking change [major]" → `1.8.26+canary.5` → `2.0.0`
-- "chore: update deps [skip-version]" → `1.8.26+canary.5` → `1.8.26`
-
-### 4. Manual Version Updates
-
-For cases requiring manual version control:
-
-```bash
-# Using workflow_dispatch:
-# Go to Actions → Bump Version → Run workflow
-# Select version type: major, minor, patch, build, or release
-# Optionally mark as pre-release
-
-# Or using command line:
-bump2version [type] --allow-dirty
-git push origin HEAD --tags
-```
-
-Note: When using manual version control, add `[skip-version]` to your PR title to prevent automatic version bumping.
-
-### 5. Syncing Dev After Main Update (automated)
-
-After a release lands on main, dev must advance to the new canary line
-(e.g. `1.9.0` → `1.9.0+canary.1`). **This is fully automated** by the
-`Sync version back to dev` step in `bump-version.yml` — you normally do nothing.
-
-**Do NOT rebase/force-push dev onto main, and do NOT open a `main → dev` PR.**
-This repo **squash-merges** dev → main (merge commits are disabled repo-wide), so
-main is a single squashed commit while dev keeps full history. A `main → dev`
-merge therefore phantom-conflicts on *every* squashed commit (hundreds of files)
-and can never merge; a `git rebase origin/main` + force-push would rewrite dev's
-protected history and break every open PR and clone.
-
-Because dev already contains **all of main's code** (main was squashed *from*
-dev), only the **version number** needs to sync. The workflow does exactly that:
-
-1. Branches off `dev` (`chore/sync-<version>-canary`).
-2. Sets the version files to `<version>+canary.1` (`bump2version ... --no-tag`).
-3. Opens a small PR to `dev` (title contains `[skip-version]`) and auto-merges it.
-
-Example:
-- Release version on main: `1.9.0`
-- dev after sync: `1.9.0+canary.1` (next dev push → `+canary.2`)
-
-If auto-merge is unavailable, just merge that one-file sync PR by hand.
-
-## GitHub Actions Workflow Behavior
-
-The workflow (`bump-version.yml`) handles:
-
-1. PR Merge to Main:
-   - Converts canary version to prod format
-   - Applies version bump based on PR title
-   - Updates version files
-   - Creates appropriate tags
-
-2. PR Merge to Dev:
-   - Converts to canary format if merging from main
-   - Creates appropriate tags
-   - Updates version files
-
-3. Dev Branch Commits:
-   - Increments build number if in canary format
-   - Updates version files
-   - Creates appropriate tags
-
-4. Manual Version Updates:
-   - Supports manual version bumping via workflow_dispatch
-   - Allows specifying version type (major, minor, patch, build, release)
-
-## Files Updated
-
-The workflow automatically updates these files:
-- VERSION
-- indexer/pyproject.toml
-- indexer/src/config.py
-
-## Best Practices
-
-1. Let the GitHub Action handle format conversions
-2. Use PR title keywords to control version bumping
-3. Use `[skip-version]` when manual control is needed
-4. Always ensure changes are committed before version updates
-
-## Common Issues and Solutions
-
-1. **Version Format Mismatch**
-   - The workflow automatically handles format conversions
-   - No need to manually convert between prod/canary formats
-
-2. **Failed CI Workflows**
-   - Ensure all changes are committed
-   - Use `--allow-dirty` flag for manual updates
-
-3. **Sync Issues**
-   - Let the workflow handle version conversions during syncs
-   - Manual intervention only needed for special cases
-
-4. **Release aborts with `fatal: tag 'X.Y.Z' already exists`**
-   - Cause: the canary-strip on merge-to-main (`X.Y.Z+canary.N → X.Y.Z`) lands on
-     the *previous* release version, whose tag already exists. If that
-     `bump2version release` runs without `--no-tag` it re-creates that tag and
-     aborts the whole release (main left on canary, no new tag/Release, wrong
-     Docker publish).
-   - Invariant: the canary-strip **must** use `--no-tag`; only the title-driven
-     `[major|minor|patch]` bump creates the new tag. Do not remove it.
-   - Recovery if it ever aborts again: branch off main → set the four version
-     files to the intended `X.Y.Z` → PR to main with `[skip-version]` → merge →
-     `git tag X.Y.Z <sha> && git push origin X.Y.Z` → create the GitHub Release →
-     confirm Docker published `X.Y.Z`/`latest` → let the sync-back PR restore
-     canary on dev.
-
-Note on cleanup: canary **git tags** and **GitHub Releases** are no longer
-created for dev builds (the dev-push bump uses `--no-tag`; the Release step is
-gated to `main`). Any pre-existing `X.Y.Z+canary.N` tags/Releases are legacy
-cruft and safe to delete — real release tags (`X.Y.Z`) must be kept.
-
-## Version Control Keywords
-
-### PR Title Keywords
-When creating a Pull Request, use these keywords in the PR title to control version bumping:
-- `[minor]` - Bumps minor version
-- `[major]` - Bumps major version
-- `[skip-version]` - Skips version update for this PR
-
-Note: For PRs, only the PR title is checked for keywords. Commit messages within the PR are ignored.
-
-### Commit Message Keywords
-For direct commits to branches (not through PRs):
-- `[skip-version]` - Skips version update for this specific commit
-
-Example:
-```bash
-# Direct commit to dev - will skip version bump
-git commit -m "chore: update deps [skip-version]"
-
-# PR to main - will bump minor version regardless of commit messages
-git commit -m "feat: new feature [skip-version]"  # [skip-version] is ignored
-git push origin dev
-# Create PR with title: "feat: new feature [minor]"
-```
-
-## Process Flows
-
-### 1. Normal PR to Main
-```bash
-# Create PR with title based on change type:
-"feat: new feature"              # Will bump patch
-"feat: new feature [minor]"      # Will bump minor
-"feat: new feature [major]"      # Will bump major
-"chore: update [skip-version]"   # Won't bump version
-
-# Result:
-# - Workflow checks PR title only
-# - Ignores commit messages within PR
-# - Applies version bump based on PR title
-```
-
-### 2. Direct Commits to Dev
-```bash
-# Regular commit - will bump canary build
-git commit -m "feat: your changes"
-git push origin dev
-
-# Skip version bump
-git commit -m "chore: quick fix [skip-version]"
-git push origin dev
-
-# Result:
-# - Workflow checks commit message
-# - Skips version bump if [skip-version] is present
-```
-
-## Important Notes
-
-1. **PR Version Control**
-   - Only PR titles control version bumping
-   - Commit messages within PRs are ignored
-   - PR title keywords: `[major]`, `[minor]`, `[skip-version]`
-
-2. **Direct Commit Version Control**
-   - Only affects direct pushes to branches
-   - Only `[skip-version]` is checked
-   - Applies to that specific commit only
-
-3. **Process Safety**
-   - PR merges always use PR title for version control
-   - Direct commits can be skipped individually
-   - No mixing of PR and commit message controls
-
-4. **Best Practices**
-   - Use PR titles to control major/minor version bumps
-   - Use commit `[skip-version]` for maintenance commits
-   - Keep version control intent clear in PR titles
-
-### Version Format Validation
-
-The CI pipeline automatically validates version formats through a dedicated workflow:
-
-- Dev branch: Must use canary format (e.g., `1.0.0+canary.1`)
-- Main branch: Must use production format (e.g., `1.0.0`)
-
-The validation runs:
-1. On every push to dev/main
-2. On every pull request targeting dev/main
-
-If you see version format errors:
-1. For dev branch: Run `bump2version release --new-version canary`
-2. For main branch: Run `bump2version release --new-version prod`
-
-The validation workflow must pass before the version bumping workflow can run.
+- **Version format error in CI.** `VERSION` must be a clean `X.Y.Z` or the
+  `X.Y.Z+dev.N` marker. If `main` is ever wrong, open a small `[skip-version]` PR
+  that sets the four version carriers correctly.
+- **Release didn't tag / publish.** Confirm the `release/*` PR actually
+  squash-merged into `main` (that is what triggers `finalize`), then check the
+  Cut Release run for the `finalize` job and the Docker Auto-Publish run for the
+  tag build. Release tags must be pushed with the `PAT` for the downstream build
+  to fire.
+- **Reopen PR didn't auto-merge.** If auto-merge is unavailable, merge the
+  one-file `chore: reopen development at X.Y.Z+dev.0 [skip-version]` PR by hand to
+  restore the development marker on `main`.

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -6,10 +6,36 @@ Official Docker image for the Bitcoin Stamps Indexer - the reference implementat
 
 ## Available Tags
 
-- `latest` - Built automatically from the `main` branch
-- `dev` - Built automatically from the `dev` branch
-- `<sha>` - Built from specific commits (first 7 characters of commit hash)
-- `vX.Y.Z` - Stable release versions
+- `X.Y.Z` - Stable release versions (no `v` prefix), e.g. `1.9.1`. Cut from a
+  release tag and **signed** (see [Verifying this image](#verifying-this-image)).
+- `latest` - The most recent stable release (updated on every `X.Y.Z` release).
+- `edge` - The latest `main` build (pre-release / unstable). Not signed.
+- `sha-<short>` - A specific `main` commit build (7-char commit hash). Not signed.
+
+Only clean `X.Y.Z` release tags and `latest` are signed. `edge` and
+`sha-<short>` are development builds published on every push to `main`.
+
+## Verifying this image
+
+Release images are **signed keyless** with [Sigstore/cosign](https://www.sigstore.dev/)
+(GitHub Actions OIDC — no private keys) and carry an SPDX SBOM attestation. The
+matching [GitHub Release](https://github.com/stampchain-io/btc_stamps/releases)
+records the exact `btcstamps/indexer@sha256:…` digest. Verify provenance before
+running (substitute the release version and digest):
+
+```bash
+# Verify the signature:
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+
+# Verify the SPDX SBOM attestation:
+cosign verify-attestation --type spdxjson \
+  --certificate-identity-regexp '^https://github.com/stampchain-io/btc_stamps/.github/workflows/docker-auto-publish.yml@refs/tags/X.Y.Z$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  btcstamps/indexer@sha256:<digest>
+```
 
 ## Quick Start
 
@@ -85,7 +111,7 @@ To validate Docker builds before deployment:
 
 # Test with specific configuration
 ./run-container.sh --build --with-db  # Test with local MySQL
-./run-container.sh --image dev --prod  # Test with dev image and stdout logs
+./run-container.sh --image edge --prod  # Test with the edge image and stdout logs
 ```
 
 The `--test` option is ideal for CI pipelines and pre-commit validation.


### PR DESCRIPTION
## Summary

Rewrites the versioning/release and contributor-facing docs for the **trunk model** the repo migrated to (`main` is the single primary branch; `dev` was retired to the `dev-archive` tag). Content is written to match the **actual merged workflows on `main`** — `release.yml` ("Cut Release"), `docker-auto-publish.yml`, `version-check.yml`, `dependabot.yml`, and `CODEOWNERS`. Docs only; no workflows/rulesets/code touched.

## Per-file changes

**`docs/dev/versioning.md`** — full rewrite.
- Trunk model: `main` carries `X.Y.Z+dev.0` between releases (no per-push bump); a release momentarily freezes a clean `X.Y.Z` then reopens `main` at `X.Y.Z+dev.0`.
- Exact **Cut Release** runbook (`workflow_dispatch` → `bump = major|minor|patch`): `prepare` (compute target, `release/vX.Y.Z` branch, `[skip-version]` PR + squash auto-merge) → `finalize` (tag `X.Y.Z` **no v-prefix** via PAT, GitHub Release, `chore/reopen-*` `[skip-version]` follow-up to `X.Y.Z+dev.0`) → `docker-auto-publish` release build.
- Pre-release images: `:edge` + `:sha-<short>` on every `main` push (never `:latest`/`:X.Y.Z`, not signed).
- `cosign verify` + `verify-attestation` with the real certificate identity (`docker-auto-publish.yml@refs/tags/X.Y.Z`) and OIDC issuer.
- Lists the 4 version carriers (`VERSION`, `indexer/pyproject.toml`, `indexer/src/config.py` `VERSION_STRING`, `.bumpversion.cfg` `current_version`).
- Removed all rebase/force-push/sync-back/`main→dev`/canary content. Kept `[skip-version]`.

**`CONTRIBUTING.md`** — branch off `main` / PR to `main`; **both** code owners review (required); releases cut by maintainers via Cut Release. Removed the `dev`-branch/`PR #495` instructions; added `.bumpversion.cfg` to the do-not-hand-edit list.

**`README.md`** — badge/CI URLs `branch=dev` → `branch=main`; new **🔏 Signed Releases** section with `cosign verify`; trunk-model Contributions + clone wording; retired the removed `:dev` Docker tag in the run-container examples (→ `:edge`).

**`indexer/README.md`** (Docker Hub description) — corrected tag list (`:X.Y.Z` signed releases, `:latest` = newest release, `:edge` = latest `main` build, `:sha-<short>` = per-commit) and added the **Verifying this image** cosign section.

## Consistency with the merged workflows

All claims verified against the files on `main`:
- Tags have **no v-prefix** (`.bumpversion.cfg` `tag_name = {new_version}`; `release.yml` tags `${NEW_VERSION}`).
- `version-check.yml` accepts exactly `X.Y.Z` or `X.Y.Z+dev.N`.
- `docker-auto-publish.yml`: main push → `:edge` + `:sha-<short>`; tag push → `:X.Y.Z` + `:latest` + keyless cosign sign + SPDX SBOM attest + digest recorded in the Release; prunes to newest 5 `sha-*` tags.
- Cosign identity regexp and OIDC issuer copied from the workflow's own recorded verify instructions.
- `dependabot.yml` targets `main`; `CODEOWNERS` = `@reinamora137 @btcopenstamp` (both review every PR).

No inconsistencies found between the reality of the workflows and the rewritten docs. Draft — **do not merge**; for review.