### PR TITLE
docs(sip-0110): apply #878 review — 2-tx layout, Method-B scope, activation/fail-safe + precision fixes

### DIFF
--- a/docs/sips/SIP-0110/reference-implementation.md
+++ b/docs/sips/SIP-0110/reference-implementation.md
@@ -2,6 +2,17 @@
 
 > Non-normative supporting material for **SIP-0110**. Grounds the proposed indexer changes in the actual `btc_stamps` codebase. See the SIP issue for the normative specification.
 
+> **Revision note (2026-07 — applies the #878 code-grounded technical review).** This revision
+> adopts the **2-tx on-wire reference model** for `full` mode (content = a plain OLGA stamp;
+> `PRESERVE` = a JSON sidecar referencing it via `stamp_tx`; rule 3 hashes the content stamp's
+> **raw on-wire OLGA payload bytes**); reduces the **v1.10 scope to `full` + `anchor`, Method B
+> (`utxo-spend`) only** (Method A / BIP-322 deferred to a follow-up SIP); corrects the
+> activation/fail-safe description (a non-upgraded indexer **drops** `p:"SRC-ORD"`, it does not
+> index it as an ordinary stamp); resolves Open Question **#8**
+> (`PRESERVE_MAX_FULL_CONTENT_BYTES = 65_535`) and Open Question **#11** (BIP-110 34-byte cap:
+> scriptPubKey, inclusive — favorable); and applies the review's precision fixes to the BIP-110
+> facts.
+
 ## 4. Reference Implementation
 
 ### 4.1 Overview
@@ -52,16 +63,71 @@ dispatches on `op` to `handle_deploy()` / `handle_mint()` / `handle_transfer()`.
 implementation SHOULD add a parallel module **`preserve.py`** exposing `parse_preserve(...)` and
 a `PreserveProcessor` with a `validate_and_process_operation()` implementing the §3.4 rules,
 mirroring the SRC-20 structure (including a `PreserveValidator` analogous to `Src20Validator`).
-Because the modern SRC-20 substrate is JSON-only, `preserve.py` additionally handles the
-**embedded OLGA content** carried alongside the `SRC-ORD` JSON envelope in the same direct,
-non-Counterparty transaction (§3.7).
+Because the modern SRC-20 substrate is JSON-only, `preserve.py` handles **only the JSON
+envelope**; in `full` mode the content bytes arrive in a **separate, ordinary OLGA stamp
+transaction** referenced by the envelope's `stamp_tx` field — see the on-wire layout below.
+`preserve.py` never touches the stamp-content extraction path.
+
+**On-wire layout — the 2-tx reference model (applies #878 review, G1; normative in the SIP).**
+Full-mode `PRESERVE` is carried by **two transactions**, not one:
+
+1. **The content transaction — an ordinary OLGA stamp.** The source inscription's content bytes
+   ride the existing CP-OLGA stamp pipeline — the raw-binary, length-first, **base64-free**
+   carrier (`transaction_utils.py:514-517`: 2-byte big-endian length prefix, then raw chunk
+   data; OpenStamp already implements it byte-for-byte). This requires **zero changes** to the
+   `#749`-protected extractor: on every indexer, upgraded or not, this transaction is a plain
+   stamp and is numbered identically.
+2. **The `PRESERVE` transaction — a small, JSON-only op on the direct substrate** (P2WSH data,
+   keyburn, no `cpid`) whose envelope adds `"stamp_tx": "<64 hex>"` referencing the content
+   transaction. In `anchor` mode there is no content transaction and no `stamp_tx`.
+
+**Rule-3 hashing binds to the wire, not the pipeline.** The §3.4 rule-3 integrity check hashes
+the content stamp's **raw on-wire OLGA payload bytes** — the reassembled length-prefixed chunk
+data (`chunk[2:2+len]`) minus the leading 6-byte `stamp:` marker (`config.PREFIX`) — **not**
+post-pipeline content. Rationale: MIME normalization / svgz-decompression can silently replace
+decoded bytes after extraction (`models.py:420-422`), and raw-bytes hashing sidesteps the
+base64 / Python-3.13 decoder hazard entirely.
+
+**Design rationale — why not a single-tx binary `SRC-ORD` (rejected).** The single-transaction
+alternative (binary content inline on the direct substrate, e.g. a TLV second segment) was
+evaluated and rejected for four code-grounded reasons:
+
+1. **The direct substrate is JSON-only and binary-unsafe.** `transaction_utils.py:537` does
+   `.rstrip(b"\x00")` *before* reading the 2-byte length prefix (line 541). Binary content whose
+   final byte is `0x00` (common across real formats) loses those bytes, the
+   `len >= 2 + chunk_length` check fails, and the transaction is silently dropped.
+2. **Making it binary-capable means editing the highest-risk consensus surface in the repo.**
+   `transaction_utils.py:536-564` is the shared extractor for **all** SRC-20 *and* SRC-101
+   parsing — the `#749 (WONTFIX)` zone flagged as consensus-forking. Reordering `rstrip`/length
+   would require a full genesis→tip reindex-diff to prove zero historical reclassifications.
+3. **You'd still hit base64-or-segment.** The direct payload is JSON, so inline binary is either
+   base64-in-JSON (~33% overhead on already-4×-cost output bytes, plus JSON parse-determinism
+   risk) or a raw segment appended after the envelope — which *is* the extractor surgery of
+   point 2.
+4. **It breaks the preservation guarantee.** A `p:"SRC-ORD"` transaction hits
+   `raise ValueError("invalid p")` on every non-upgraded indexer (`stamp.py:247-252`) → the
+   whole tx is dropped → the content is **lost** on non-upgraded indexers. In the 2-tx model the
+   content is a plain OLGA stamp, indexed and numbered identically by *every* indexer; only the
+   small provenance sidecar is missed. For a SIP named "Preservation," that property is the
+   point.
+
+Two further properties of the 2-tx model: the content stamp is a **Counterparty asset**, so the
+preserved content becomes a first-class tradeable Stamp (CP DEX order book, dispensers, the
+existing market/indexing stack) — a deliberate upside of the CP-issuance dependency, not just a
+caveat; and the **64 KB cap is identical either way** (both carriers share the same 2-byte
+length prefix), so a single-tx layout gains nothing on size. Cost of the extra transaction:
+~2–5%, shrinking as content grows. Precedent for the 2-tx shape: ord's own commit/reveal, and
+SRC-721 mints referencing other stamps via `valid_stamps_in_block`.
 
 **Block routing — `blocks.py :: BlockProcessor`.** PRESERVE ops route through the existing
 `BlockProcessor.process_transaction_results()` (which already calls `parse_stamp(...)` and,
 conditionally, `parse_src20(...)`). A parallel branch would call the new
 `parse_preserve(...)` when the `SRC-ORD` op is detected and collect results on the
 `BlockProcessor` instance (analogous to `self.processed_src20_in_block`), then persist them in
-`finalize_block(...)`.
+`finalize_block(...)`. Resolving a full-mode `stamp_tx` reference that points at a content stamp
+in the **same block** uses the `valid_stamps_in_block` collection — the same precedent SRC-721
+mints already rely on; the content stamp MUST be confirmed at a lower (block, tx_index) than the
+`PRESERVE` op (see §3.4 rule 3).
 
 **Check-hashes — `block_validation.py :: create_check_hashes`, NOT `blocks.py`.** The brief
 says "include migration records in ledger check-hashes." The real function is
@@ -82,7 +148,12 @@ separable and makes the SRC-20-isolation invariant self-evident. Whatever is cho
 serialization MUST be deterministic and derived only from consensus fields (§4.2). **Divergence
 note:** there is no single function literally named "ledger check-hashes"; `create_check_hashes`
 is the real equivalent, and `ledger_hash` today is specifically the SRC-20 ledger, not a general
-stamp ledger — which is exactly why PRESERVE records must not enter it.
+stamp ledger — which is exactly why PRESERVE records must not enter it. **Scope of the isolation
+(per the #878 review):** a dedicated `migration_hash` isolates the *provenance records*, but
+**not numbering** — a valid `PRESERVE` sidecar is still a stamp and still enters `txlist_hash`
+post-activation (see "Stamp numbering and the activation gate" below). What is verified in code:
+`ledger_hash` (`str(processed_src20_in_block)`, SRC-20-only) and `messages_hash` (all txids)
+**cannot** be affected by PRESERVE.
 
 **Persistence — new table, modeled on `StampTableV4` / `SRC20Valid`.** The brief's `migrations`
 table does not exist. Real precedents: `insert_into_stamp_table()` writes to
@@ -92,14 +163,16 @@ table does not exist. Real precedents: `insert_into_stamp_table()` writes to
 
 ```
 stamp_migrations(
-  stamp_id            <FK to StampTableV4.stamp>,   -- primary key
+  stamp_id            <FK to StampTableV4.stamp>,   -- primary key (the PRESERVE sidecar's stamp)
+  stamp_tx            TEXT,        -- full mode: txid of the referenced content stamp (§3.3); NULL in anchor mode
   inscription_id      TEXT,                          -- indexed
   genesis_txid        TEXT,
   content_sha256      TEXT,
   mode                TEXT,        -- 'full' | 'anchor'
-  proof_type          TEXT,        -- 'bip322' | 'utxo-spend'
+  proof_type          TEXT,        -- 'utxo-spend' (v1.10); 'bip322' reserved for the follow-up SIP
   proof_address       TEXT,
-  proof_block         INTEGER,     -- msg_block (Method A) / spend height (Method B)
+  proof_utxo          TEXT,        -- Method B: the claimed "<txid>:<vout>" (§3.5, review G3)
+  proof_block         INTEGER,     -- spend height (Method B) / msg_block (Method A, deferred)
   content_verified    BOOLEAN,     -- consensus-layer hash check (true only for full-mode pass)
   canonical_flag      BOOLEAN,     -- first-valid per §3.4 rule 6
   block_index         INTEGER,
@@ -111,15 +184,31 @@ The table is indexer-internal, but its contents derive from consensus rules, so 
 (§3.4) is the normative part; two conformant indexers MUST produce identical `content_verified`
 and `canonical_flag` values for the same chain.
 
-**Stamp-number assignment stays unchanged.** A Migration Stamp is still a stamp: it receives its
-number via the existing `get_next_stamp_number(db, "stamp")` path in `stamp.py ::
-StampProcessor.process_stamp()`. PRESERVE does not alter stamp numbering.
+**Reorg safety (consensus-critical, easiest to miss).** `stamp_migrations` MUST be added to the
+table list purged by `purge_block_db` (`database.py:1199-1211`). Otherwise a reorg leaves stale
+rows behind and `canonical_flag` diverges across indexers after re-derivation.
+
+**Stamp numbering and the activation gate (corrected per the #878 review, G5).** The numbering
+*mechanism* is unchanged: a valid stamp receives its number via the existing
+`get_next_stamp_number(db, "stamp")` path in `stamp.py :: StampProcessor.process_stamp()`. But
+SIP-0110 is an **activation-gated consensus change**, not "purely additive metadata": a valid
+`PRESERVE` sidecar is itself assigned a stamp number (`stamp.py:63-64`) and enters `txlist_hash`
+(via the sorted `valid_stamps_in_block`, `block_validation.py:70-75`). Post-activation, upgraded
+and non-upgraded indexers therefore **diverge on numbering and `txlist_hash`** — the normal
+consequence of *any* new stamp-creating op, and exactly why AUTHORING §4/§5 require a
+coordinated activation height that all participating indexers ship before. A non-upgraded
+indexer **drops** a `p:"SRC-ORD"` transaction outright (`raise ValueError("invalid p")`,
+`stamp.py:247-252`) — fail-**safe** per AUTHORING §5, but *not* "indexed as an ordinary stamp."
+Under the 2-tx model, the **content** transaction is a plain OLGA stamp and is preserved and
+numbered identically on every indexer, upgraded or not; only the small provenance sidecar is
+missed by non-upgraded indexers.
 
 ### 4.4 API surface
 
 - `GET /migrations/{inscription_id}` — all migration records referencing an inscription ID
   (there may be several; §3.4 rule 6), each with its `canonical_flag`.
-- `GET /stamps/{id}/provenance` — the provenance record for a given Migration Stamp.
+- `GET /stamps/{id}/provenance` — the provenance record for a given Migration Stamp (including,
+  in full mode, the referenced content stamp's `stamp_tx`).
 - (Option 2) A `verified` status field on the above, sourced from the **external verifier**
   (§3.6), NOT from the indexer. The consensus layer never emits `verified`; it emits
   `content_verified` (the self-contained full-mode hash result) and the raw attestation.
@@ -141,15 +230,30 @@ are now **decided**, and should be read as design decisions rather than proposal
 - **Protocol identifier = `p = "SRC-ORD"`**, registered alongside SRC-20/721/101 but routed to a
   separate `PRESERVE` processor and fully isolated from SRC-20 balance consensus (Open Question
   #9 resolved; §3.3, §3.7, §4.3).
-- **Encoding = Option (a): a direct, non-Counterparty transaction** on the modern SRC-20-style
-  substrate, with `full`-mode content via the existing OLGA P2WSH path (§3.7). The
-  Counterparty/SRC-721 route was rejected for its Counterparty consensus dependency.
+- **Encoding = Option (a): a direct, non-Counterparty transaction** for the `PRESERVE` envelope
+  (§3.7). The Counterparty/SRC-721 route was rejected *for the envelope* for its Counterparty
+  consensus dependency; note that under the 2-tx model the full-mode **content** deliberately
+  rides the CP-OLGA stamp path (see the on-wire layout in §4.3 and its design rationale).
+- **On-wire layout = the 2-tx reference model** (#878 review, G1): content = a plain OLGA stamp;
+  `PRESERVE` = a JSON sidecar referencing it via `stamp_tx`; rule 3 hashes the content stamp's
+  raw on-wire OLGA payload bytes. The single-tx binary `SRC-ORD` alternative is rejected (four
+  reasons, §4.3).
+- **v1.10 scope = `full` + `anchor`, Method B (`utxo-spend`) only.** Method A (BIP-322) is
+  **deferred to a follow-up SIP**: no BIP-322 implementation exists in the dependency tree
+  (neither `bitcoinlib` nor `python-bitcoinlib` implements it), and full BIP-322 executes
+  Bitcoin script — a library disagreement would become a Stamps consensus bug (§5 item 5's exact
+  risk).
+- **Maximum full-mode content size = `PRESERVE_MAX_FULL_CONTENT_BYTES = 65_535`** (Open Question
+  #8 resolved — see below).
+- **BIP-110 34-byte boundary resolved favorably** (Open Question #11 resolved — see below).
 
 **Genuinely-remaining open items:** #1 (verification architecture — recommend Option 2), #3
-(commit/reveal — recommend defer), #4 (multi-owner canonicity), #5 (signature window N≈144), #6
-(SIP-0005 binary-format alignment), #7 (`deps` normativity), #8 (max full-mode size), #10 (add
-dedicated `migration_hash` — recommended), #11 (BIP-110 34-byte cap inclusive/exclusive
-boundary), #12 (anchor-mode canonical-flag semantics).
+(commit/reveal — recommend defer), #4 (multi-owner canonicity), #6 (SIP-0005 binary-format
+alignment), #7 (`deps` normativity), #10 (add dedicated `migration_hash` — recommended), #12
+(anchor-mode canonical-flag semantics). #5 (signature acceptance window) applies to Method A
+only and **defers with it** to the follow-up SIP; the pinned form of the window inequality is
+`0 ≤ confirmation_height − msg_block ≤ N` (proposed N = 144), with a future-dated `msg_block`
+(negative delta) invalid. #8 and #11 are now **resolved** (see the finalized-decisions list).
 
 **(a) Brief items that could NOT be grounded in real code, and why.**
 
@@ -176,21 +280,37 @@ boundary), #12 (anchor-mode canonical-flag semantics).
   Question #9): `p = "SRC-ORD"`**, registered alongside the existing sub-protocols but routed to
   the new `PRESERVE` processor and isolated from SRC-20 balance consensus. The gate MUST be
   extended to accept `SRC-ORD`.
-- **Max full-mode content size.** No single explicit max-size constant was found in `config.py`
-  (grep for size/limit constants returned no authoritative max-stamp-size). Left as Open
-  Question #8 with the divergence noted.
-- **BIP-110 specifics.** Verified against public sources (bip110.org; Bitcoin Knots 29.2
-  reference implementation; 256-byte witness-element cap, 34-byte output cap, pre-activation
-  UTXO exemption, ~1-year temporary soft fork, ~August 2026 flag day / 55% miner fast-track,
-  <1% miner support as of mid-2026). The Motivation subsection was rewritten with these facts
-  plus the OLGA-P2WSH-is-exactly-34-bytes analysis. The one remaining unverified detail — the
-  inclusive/exclusive semantics of the 34-byte output cap relative to a 34-byte P2WSH output —
-  is Open Question #11.
+- **Max full-mode content size — RESOLVED: `PRESERVE_MAX_FULL_CONTENT_BYTES = 65_535`** (Open
+  Question #8; #878 review). The earlier divergence note ("no explicit max-size constant in
+  `config.py`") stands, but the binding limit is structural: the OLGA payload's **2-byte
+  big-endian length prefix** (`transaction_utils.py:536-546`) hard-caps the payload at
+  **65,535 bytes**, binding *below* transaction standardness (~72–74 KB). Effective media size
+  is **65,529 bytes** after the 6-byte `stamp:` prefix. Because stamp data is carried in
+  **output/base bytes with no witness discount**, witness-scale content (~4 MB) is **not
+  reachable** in this encoding. The constant SHOULD be codified in `config.py` at
+  implementation time.
+- **BIP-110 specifics (corrected per the #878 external review, primary-source-verified).**
+  Reference implementation is **Bitcoin Knots v29.3.knots20260508** (not 29.2). Flag-day
+  activation is **~September 1, 2026 (height 965,664)**; **August 2026 is the
+  mandatory-signaling window**, not the flag day. Miner fast-track: 55% of a 2,016-block period
+  (version bit 4); miner support **under 1%** as of mid-2026. The 256-byte witness cap applies
+  to **data pushes**, not the tapleaf container — large witness content could be re-chunked
+  (less efficiently) rather than being outright blocked. The pre-activation exemption precisely
+  **grandfathers *spends of* pre-activation UTXOs** (rather than "exempting UTXOs" loosely).
+  **The 34-byte boundary (Open Question #11) is RESOLVED, favorably:** the canonical BIP-110
+  text — *"New output scriptPubKeys exceeding 34 bytes are invalid…"* — measures the
+  **scriptPubKey** and is **inclusive (≤ 34)**; a P2WSH scriptPubKey is exactly 34 bytes, so
+  **new OLGA stamps remain creatable under BIP-110**, while the larger bare-multisig encoding is
+  blocked under any reading. The resolution is pinned to the current `bip-0110.mediawiki` text;
+  the exact upstream revision/commit hash MUST be recorded when the SIP moves to Accepted (TBD).
+  On OLGA efficiency, use sourced figures — **~50% size / ~60–70% cost** improvement over bare
+  multisig — not the unsourced "30–95%".
 
 **(b) Additional open questions identified during drafting.** #10 (add a dedicated
-`migration_hash`, recommended), #11 (BIP-110 34-byte-cap boundary), #12 (anchor-mode
-canonical-flag semantics) — see Open Questions above. (#9, protocol-identifier registration, is
-now **resolved** to `p = "SRC-ORD"`.)
+`migration_hash`, recommended) and #12 (anchor-mode canonical-flag semantics) — see Open
+Questions above. (#9, protocol-identifier registration, is **resolved** to `p = "SRC-ORD"`;
+#11, the BIP-110 34-byte-cap boundary, is now **resolved favorably** — see the BIP-110 bullet
+in (a).)
 
 **(c) Numbering.** The number is **decided: SIP-0110**, a deliberate, maintainer-reserved
 thematic mirror of BIP-110 (§ Numbering note). This intentionally departs from strict sequential

--- a/docs/sips/SIP-0110/test-vectors.md
+++ b/docs/sips/SIP-0110/test-vectors.md
@@ -1,17 +1,50 @@
 # SIP-0110 — Test Vectors (supporting material)
 
-> Non-normative supporting material for **SIP-0110: Ordinals Provenance Preservation (PRESERVE)**. Illustrative JSON test vectors (TV-01–TV-10). See the SIP issue for the normative specification. An accepted SIP MUST ship concrete testnet vectors per SIP-0000.
+> Non-normative supporting material for **SIP-0110: Ordinals Provenance Preservation (PRESERVE)**. Illustrative JSON test vectors (TV-01–TV-15). See the SIP issue for the normative specification. An accepted SIP MUST ship concrete testnet vectors per SIP-0000.
+
+> **Revision note (2026-07 — applies the #878 code-grounded technical review).** Vectors updated
+> for: the **2-tx reference model** (full-mode content is a separate, ordinary OLGA stamp
+> referenced by `stamp_tx`; rule 3 hashes its **raw on-wire OLGA payload bytes**); the reduced
+> **v1.10 scope — Method B (`utxo-spend`) only** (Method A / BIP-322 vectors are retained but
+> marked **DEFERRED** to the follow-up SIP and are NOT part of the v1.10 activation vector set);
+> failed PRESERVE = **dropped**, identical to pre-activation handling (§3.4 rule 7 as corrected —
+> there is no ordinary-stamp fallback on the no-`cpid` substrate); the codified
+> `PRESERVE_MAX_FULL_CONTENT_BYTES = 65_535` cap; a corrected TV-04 (its previous
+> `inscription_id` was 67 chars and failed the SIP's own rule-2 regex, so it could not isolate
+> the rule-3 case); and new vectors TV-11–TV-15.
 
 ## Test Vectors
 
-All vectors are illustrative (hashes/signatures are placeholders); an accepted SIP MUST ship
-concrete testnet vectors per SIP-0000. Each vector states the expected consensus-layer outcome.
+All vectors are illustrative (hashes/signatures/txids are placeholders); an accepted SIP MUST
+ship concrete testnet vectors per SIP-0000. Each vector states the expected consensus-layer
+outcome.
 
-**TV-01 — Valid full-mode, BIP-322 proof (ACCEPTED, canonical).**
+**Vector conventions (2-tx model).**
+
+- Full-mode vectors involve **two transactions**: a `content_tx` (an **ordinary OLGA stamp**
+  carrying the raw content bytes) and the `PRESERVE` sidecar (the JSON envelope shown), whose
+  `stamp_tx` field references `content_tx`. Anchor-mode vectors are a single transaction with no
+  `stamp_tx`.
+- `content_stamp_payload_sha256_recomputed` is the indexer's SHA-256 over the content stamp's
+  **raw on-wire OLGA payload bytes** — the reassembled length-prefixed chunk data
+  (`chunk[2:2+len]`) minus the 6-byte `stamp:` marker — the §3.4 rule-3 input. No MIME
+  normalization, svgz decompression, or base64 decoding is applied before hashing.
+- **In every full-mode vector the content stamp is indexed and numbered as an ordinary stamp by
+  every indexer (upgraded or not), regardless of the PRESERVE outcome.** The `expected` block
+  describes the PRESERVE sidecar.
+- A **dropped** PRESERVE produces no stamp, no stamp number, and no `stamp_migrations` row —
+  byte-identical to how a pre-activation (or non-upgraded) indexer handles the same transaction.
+- Method B proofs carry `proof.utxo` (`"<txid>:<vout>"`, the claimed inscription-holding UTXO);
+  verification is pure input-set matching. `msg_block` and the acceptance window apply to
+  Method A only.
+
+**TV-01 — Valid full-mode, BIP-322 proof (Method A — DEFERRED; not in the v1.10 activation set).**
 ```json
 {
   "input": {
+    "content_tx": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
     "src": {
       "inscription_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaai0",
       "genesis_txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -19,34 +52,36 @@ concrete testnet vectors per SIP-0000. Each vector states the expected consensus
       "content_type": "image/png", "content_length": 1024
     },
     "proof": { "type": "bip322", "address": "bc1qexampleaddr...", "signature": "AkcwRAIg...==", "msg_block": 900000 },
-    "embedded_content_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content_stamp_payload_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "stamp_confirmation_block": 900050
   },
-  "expected": { "indexed_as": "migration_stamp", "content_verified": true, "canonical_flag": true, "reason": "well-formed; hash matches embedded content; valid BIP-322 sig over canonical message; msg_block within 144 of confirmation" }
+  "expected": { "v110_scope": "DEFERRED — Method A ships in a follow-up SIP; under v1.10 rules this op is dropped (unknown proof.type)", "if_method_a_active": { "indexed_as": "migration_stamp", "content_verified": true, "canonical_flag": true }, "reason": "well-formed; declared hash matches the content stamp's raw on-wire payload bytes; valid BIP-322 sig over canonical message; 0 <= 900050-900000 <= 144" }
 }
 ```
 
-**TV-02 — Valid full-mode, UTXO-spend proof (ACCEPTED).**
+**TV-02 — Valid full-mode, UTXO-spend proof (ACCEPTED, canonical — the flagship v1.10 vector).**
 ```json
 {
   "input": {
+    "content_tx": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
     "src": {
       "inscription_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbi0",
       "genesis_txid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "content_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       "content_type": "text/plain", "content_length": 5
     },
-    "proof": { "type": "utxo-spend", "address": "bc1qowneraddr...", "msg_block": 900100 },
-    "spends_inscription_utxo": true,
+    "proof": { "type": "utxo-spend", "address": "bc1qowneraddr...", "utxo": "e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5:0" },
+    "tx_spends_proof_utxo": true,
     "inscribed_sat_returned_to_owner": true,
-    "embedded_content_sha256_recomputed": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    "content_stamp_payload_sha256_recomputed": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
   },
-  "expected": { "indexed_as": "migration_stamp", "content_verified": true, "canonical_flag": true, "reason": "well-formed; hash matches; tx spends the claimed inscription UTXO; inscribed sat preserved to owner output" }
+  "expected": { "indexed_as": "migration_stamp", "content_verified": true, "canonical_flag": true, "reason": "well-formed; declared hash matches the content stamp's raw on-wire payload bytes; the PRESERVE tx spends the claimed proof.utxo (pure input-set match, §3.4 rule 5); inscribed sat preserved to owner output; no window applies to Method B" }
 }
 ```
 
-**TV-03 — Valid anchor-mode (ACCEPTED, verification pending).**
+**TV-03 — Valid anchor-mode, UTXO-spend proof (ACCEPTED, verification pending).**
 ```json
 {
   "input": {
@@ -57,54 +92,63 @@ concrete testnet vectors per SIP-0000. Each vector states the expected consensus
       "content_sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
       "content_type": "video/mp4", "content_length": 8388608
     },
-    "proof": { "type": "bip322", "address": "bc1qanchoraddr...", "signature": "AkcwRAIh...==", "msg_block": 901000 },
+    "proof": { "type": "utxo-spend", "address": "bc1qanchoraddr...", "utxo": "c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3:1" },
+    "tx_spends_proof_utxo": true,
     "stamp_confirmation_block": 901010
   },
-  "expected": { "indexed_as": "migration_stamp", "content_verified": false, "canonical_flag": true, "reason": "anchor mode: no embedded content; hash recorded as unverified claim; proof signature valid; verification-layer must confirm against ord" }
+  "expected": { "indexed_as": "migration_stamp", "content_verified": false, "canonical_flag": true, "reason": "anchor mode: no content stamp and no stamp_tx; hash recorded as unverified claim; proof.utxo spent by this tx; verification-layer must confirm against ord" }
 }
 ```
 
-**TV-04 — Hash mismatch, full mode (REJECTED as migration; VALID as plain stamp).**
+**TV-04 — Hash mismatch, full mode (PRESERVE DROPPED; content stamp unaffected).**
 ```json
 {
   "input": {
+    "content_tx": "d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
     "src": {
-      "inscription_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddi0",
+      "inscription_id": "ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddi0",
       "genesis_txid": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
       "content_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "content_type": "image/png", "content_length": 1024
     },
-    "proof": { "type": "bip322", "address": "bc1qexampleaddr...", "signature": "AkcwRAIg...==", "msg_block": 902000 },
-    "embedded_content_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "proof": { "type": "utxo-spend", "address": "bc1qexampleaddr...", "utxo": "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0:0" },
+    "tx_spends_proof_utxo": true,
+    "content_stamp_payload_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "stamp_confirmation_block": 902005
   },
-  "expected": { "indexed_as": "ordinary_stamp", "migration_status": "rejected", "reason": "declared content_sha256 != SHA-256 of embedded content; §3.4 rule 3 fails; rule 7 fallback: still a valid stamp if it meets normal stamp rules, but NO migration status" }
+  "expected": { "preserve_op": "dropped", "migration_status": "rejected", "content_stamp": "indexed as ordinary stamp (separate tx, unaffected on all indexers)", "reason": "inscription_id now VALID (66 chars, passes §3.4 rule 2) so this vector isolates rule 3: declared content_sha256 != SHA-256 of the content stamp's raw on-wire OLGA payload bytes; §3.4 rule 7 (corrected): failed PRESERVE is dropped — no ordinary-stamp fallback exists on the no-cpid substrate" }
 }
 ```
 
-**TV-05 — Malformed inscription_id (REJECTED as migration).**
+**TV-05 — Malformed inscription_id (PRESERVE DROPPED).**
 ```json
 {
   "input": {
+    "content_tx": "e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5",
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5",
     "src": {
       "inscription_id": "NOT-A-VALID-ID",
       "genesis_txid": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "content_type": "image/png", "content_length": 1024
     },
-    "proof": { "type": "bip322", "address": "bc1qexampleaddr...", "signature": "AkcwRAIg...==", "msg_block": 903000 }
+    "proof": { "type": "utxo-spend", "address": "bc1qexampleaddr...", "utxo": "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0:0" },
+    "tx_spends_proof_utxo": true
   },
-  "expected": { "indexed_as": "ordinary_stamp_or_none", "migration_status": "rejected", "reason": "inscription_id does not match ^[0-9a-f]{64}i[0-9]+$ (§3.4 rule 2); no migration status; if the tx is otherwise a valid stamp it is indexed as ordinary" }
+  "expected": { "preserve_op": "dropped", "migration_status": "rejected", "content_stamp": "indexed as ordinary stamp (separate tx, unaffected)", "reason": "inscription_id does not match ^[0-9a-f]{64}i[0-9]+$ (§3.4 rule 2); §3.4 rule 7 (corrected): dropped, identical to pre-activation handling" }
 }
 ```
 
-**TV-06 — Stale signature outside window (REJECTED as migration; post-sale replay defense).**
+**TV-06 — Stale signature outside window (Method A — DEFERRED; PRESERVE DROPPED either way).**
 ```json
 {
   "input": {
+    "content_tx": "f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6",
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6",
     "src": {
       "inscription_id": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffi0",
       "genesis_txid": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -112,43 +156,56 @@ concrete testnet vectors per SIP-0000. Each vector states the expected consensus
       "content_type": "image/png", "content_length": 1024
     },
     "proof": { "type": "bip322", "address": "bc1qprevowner...", "signature": "AkcwRAIg...==", "msg_block": 900000 },
-    "embedded_content_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content_stamp_payload_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "stamp_confirmation_block": 900500
   },
-  "expected": { "indexed_as": "ordinary_stamp", "migration_status": "rejected", "reason": "msg_block=900000, confirmation=900500, delta=500 > N=144; §3.8 edge 4/5; defends previous-owner replay after sale" }
+  "expected": { "preserve_op": "dropped", "migration_status": "rejected", "content_stamp": "indexed as ordinary stamp (separate tx, unaffected)", "reason": "v1.10: proof.type bip322 is out of scope (Method A deferred) — dropped. Under the follow-up SIP's rules: delta = 900500-900000 = 500 > N=144, violating 0 <= delta <= N — dropped (§3.8 edges 4/5; previous-owner replay defense). Not an ordinary-stamp fallback in either case (§3.4 rule 7, corrected)" }
 }
 ```
 
-**TV-07 — Duplicate migration, same inscription same address (BOTH recorded; first canonical).**
+**TV-07 — Duplicate migration, same inscription same owner (BOTH recorded; first canonical).**
 ```json
 {
   "input": [
-    { "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    { "content_tx": "7171717171717171717171717171717171717171717171717171717171717171",
+      "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+      "stamp_tx": "7171717171717171717171717171717171717171717171717171717171717171",
       "src": { "inscription_id": "1111111111111111111111111111111111111111111111111111111111111111i0", "genesis_txid": "1111111111111111111111111111111111111111111111111111111111111111", "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "content_type": "image/png", "content_length": 1024 },
-      "proof": { "type": "bip322", "address": "bc1qsameowner...", "signature": "AkcwRAIg...==", "msg_block": 904000 },
+      "proof": { "type": "utxo-spend", "address": "bc1qsameowner...", "utxo": "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a:0" },
+      "tx_spends_proof_utxo": true,
       "stamp_confirmation_block": 904005 },
-    { "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    { "note": "second PRESERVE spends the inscription's NEW utxo (the output created by the first spend) — a UTXO can be spent only once",
+      "content_tx": "7272727272727272727272727272727272727272727272727272727272727272",
+      "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+      "stamp_tx": "7272727272727272727272727272727272727272727272727272727272727272",
       "src": { "inscription_id": "1111111111111111111111111111111111111111111111111111111111111111i0", "genesis_txid": "1111111111111111111111111111111111111111111111111111111111111111", "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "content_type": "image/png", "content_length": 1024 },
-      "proof": { "type": "bip322", "address": "bc1qsameowner...", "signature": "AkcwRAIg...==", "msg_block": 904100 },
+      "proof": { "type": "utxo-spend", "address": "bc1qsameowner...", "utxo": "2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b:1" },
+      "tx_spends_proof_utxo": true,
       "stamp_confirmation_block": 904110 }
   ],
   "expected": { "indexed_as": ["migration_stamp", "migration_stamp"], "canonical_flag": [true, false], "reason": "§3.4 rule 6: both valid, both recorded; first valid (lower block/tx-index) is canonical; non-uniqueness prevents griefing" }
 }
 ```
 
-**TV-08 — Second migration by a DIFFERENT address post-sale (RECORDED; canonicity per chosen rule).**
+**TV-08 — Second migration by a DIFFERENT owner post-sale (RECORDED; canonicity per chosen rule).**
 ```json
 {
   "input": [
-    { "note": "original owner migrated earlier at block 905000 (canonical=true)",
+    { "note": "original owner migrated earlier at block 905000 (canonical=true), spending the inscription utxo they then held",
+      "content_tx": "8181818181818181818181818181818181818181818181818181818181818181",
       "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+      "stamp_tx": "8181818181818181818181818181818181818181818181818181818181818181",
       "src": { "inscription_id": "2222222222222222222222222222222222222222222222222222222222222222i0", "genesis_txid": "2222222222222222222222222222222222222222222222222222222222222222", "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "content_type": "image/png", "content_length": 1024 },
-      "proof": { "type": "bip322", "address": "bc1qoriginalowner...", "signature": "AkcwRAIg...==", "msg_block": 905000 },
+      "proof": { "type": "utxo-spend", "address": "bc1qoriginalowner...", "utxo": "3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c:0" },
+      "tx_spends_proof_utxo": true,
       "stamp_confirmation_block": 905005 },
-    { "note": "new owner (after legitimate sale) migrates at block 950000",
+    { "note": "new owner (after legitimate sale) migrates at block 950000, spending the inscription utxo they received",
+      "content_tx": "8282828282828282828282828282828282828282828282828282828282828282",
       "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+      "stamp_tx": "8282828282828282828282828282828282828282828282828282828282828282",
       "src": { "inscription_id": "2222222222222222222222222222222222222222222222222222222222222222i0", "genesis_txid": "2222222222222222222222222222222222222222222222222222222222222222", "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "content_type": "image/png", "content_length": 1024 },
-      "proof": { "type": "bip322", "address": "bc1qnewowner...", "signature": "AkcwRAIh...==", "msg_block": 950000 },
+      "proof": { "type": "utxo-spend", "address": "bc1qnewowner...", "utxo": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d:2" },
+      "tx_spends_proof_utxo": true,
       "stamp_confirmation_block": 950004 }
   ],
   "expected": { "indexed_as": ["migration_stamp", "migration_stamp"], "canonical_flag": "OPEN QUESTION #4 — recommended: record both with timestamps; if first-valid rule, canonical=[true,false]; if most-recent-owner rule, consumer decides at display", "reason": "§3.8 edge 8: legitimate multi-owner-over-time; both valid and retained" }
@@ -159,7 +216,9 @@ concrete testnet vectors per SIP-0000. Each vector states the expected consensus
 ```json
 {
   "input": {
+    "content_tx": "9393939393939393939393939393939393939393939393939393939393939393",
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "9393939393939393939393939393939393939393939393939393939393939393",
     "src": {
       "inscription_id": "3333333333333333333333333333333333333333333333333333333333333333i0",
       "genesis_txid": "3333333333333333333333333333333333333333333333333333333333333333",
@@ -167,32 +226,136 @@ concrete testnet vectors per SIP-0000. Each vector states the expected consensus
       "content_type": "image/webp", "content_length": 2048,
       "note": "underlying inscription has a negative inscription NUMBER (cursed); its ID form is unchanged"
     },
-    "proof": { "type": "bip322", "address": "bc1qcursedowner...", "signature": "AkcwRAIg...==", "msg_block": 906000 },
-    "embedded_content_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "proof": { "type": "utxo-spend", "address": "bc1qcursedowner...", "utxo": "5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e:0" },
+    "tx_spends_proof_utxo": true,
+    "content_stamp_payload_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "stamp_confirmation_block": 906003
   },
   "expected": { "indexed_as": "migration_stamp", "content_verified": true, "canonical_flag": true, "reason": "§3.8 edge 3: cursed inscriptions have normal ID form; regex passes; no special handling at consensus" }
 }
 ```
 
-**TV-10 — Oversized content, full mode (REJECTED as migration; anchor-only above limit).**
+**TV-10 — Oversized content, full mode (PRESERVE DROPPED; anchor-only above the cap).**
 ```json
 {
   "input": {
     "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "4444444444444444444444444444444444444444444444444444444444444444",
     "src": {
       "inscription_id": "4444444444444444444444444444444444444444444444444444444444444444i0",
       "genesis_txid": "4444444444444444444444444444444444444444444444444444444444444444",
       "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "content_type": "image/png", "content_length": 5242880
     },
-    "proof": { "type": "bip322", "address": "bc1qbigowner...", "signature": "AkcwRAIg...==", "msg_block": 907000 },
+    "proof": { "type": "utxo-spend", "address": "bc1qbigowner...", "utxo": "6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f:0" },
+    "tx_spends_proof_utxo": true,
     "declared_full_mode_content_bytes": 5242880,
-    "max_full_mode_size": "OPEN QUESTION #8 — reuse existing stamp limit or migration-specific"
+    "max_full_mode_size": "RESOLVED (#878 review / OQ #8): PRESERVE_MAX_FULL_CONTENT_BYTES = 65535 (2-byte OLGA length prefix; effective media 65529 after the 6-byte stamp: prefix)"
   },
-  "expected": { "indexed_as": "rejected_or_ordinary", "migration_status": "rejected", "reason": "content exceeds max full-mode size (§3.8 edge 6); above the limit only anchor mode is permitted; full-mode over-limit fails as migration (rule 7 fallback)" }
+  "expected": { "preserve_op": "dropped", "migration_status": "rejected", "reason": "content_length 5242880 > PRESERVE_MAX_FULL_CONTENT_BYTES = 65535 (§3.8 edge 6, resolved); no conformant OLGA content stamp can carry it — the 2-byte length prefix is a hard cap; above the cap only anchor mode is permitted; §3.4 rule 7 (corrected): dropped, no ordinary-stamp fallback" }
 }
 ```
 
----
+**TV-11 — Method B, transaction does NOT spend the claimed UTXO (PRESERVE DROPPED).**
+```json
+{
+  "input": {
+    "content_tx": "5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b",
+    "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+    "stamp_tx": "5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b",
+    "src": {
+      "inscription_id": "5555555555555555555555555555555555555555555555555555555555555555i0",
+      "genesis_txid": "5555555555555555555555555555555555555555555555555555555555555555",
+      "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "content_type": "image/png", "content_length": 1024
+    },
+    "proof": { "type": "utxo-spend", "address": "bc1qclaimant...", "utxo": "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a:1" },
+    "tx_spends_proof_utxo": false,
+    "content_stamp_payload_sha256_recomputed": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "expected": { "preserve_op": "dropped", "migration_status": "rejected", "content_stamp": "indexed as ordinary stamp (separate tx, unaffected)", "reason": "§3.4 rule 5 (Method B): the claimed proof.utxo does not appear in the PRESERVE transaction's input set — pure input-set match fails deterministically; §3.4 rule 7 (corrected): dropped" }
+}
+```
 
+**TV-12 — Acceptance-window boundary, Method A (DEFERRED with Method A; pins the inequality).**
+```json
+{
+  "note": "Pins the window inequality 0 <= confirmation_height - msg_block <= N (N = 144) and the future-dated outcome. Deferred with Method A; under v1.10 rules all three sub-cases are dropped (proof.type bip322 out of scope).",
+  "input": [
+    { "case": "delta == N (boundary, inclusive)", "proof": { "type": "bip322", "msg_block": 910000 }, "stamp_confirmation_block": 910144 },
+    { "case": "delta == N + 1 (just past the window)", "proof": { "type": "bip322", "msg_block": 910000 }, "stamp_confirmation_block": 910145 },
+    { "case": "future-dated msg_block (delta < 0)", "proof": { "type": "bip322", "msg_block": 910500 }, "stamp_confirmation_block": 910400 }
+  ],
+  "expected_under_followup_sip": [
+    { "case": "delta == N", "preserve_op": "valid", "reason": "0 <= 144 <= 144 — inclusive upper bound" },
+    { "case": "delta == N + 1", "preserve_op": "dropped", "reason": "145 > 144" },
+    { "case": "delta < 0", "preserve_op": "dropped", "reason": "future-dated proof is invalid: delta = -100 violates the 0 <= delta lower bound" }
+  ]
+}
+```
+
+**TV-13 — Same-block ordering (two valid PRESERVEs for one inscription in one block).**
+```json
+{
+  "input": [
+    { "note": "tx_index 7 within block 912000",
+      "content_tx": "6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c",
+      "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+      "stamp_tx": "6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c6c",
+      "src": { "inscription_id": "6666666666666666666666666666666666666666666666666666666666666666i0", "genesis_txid": "6666666666666666666666666666666666666666666666666666666666666666", "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "content_type": "image/png", "content_length": 1024 },
+      "proof": { "type": "utxo-spend", "address": "bc1qfirstintx...", "utxo": "8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b8b:0" },
+      "tx_spends_proof_utxo": true,
+      "block_index": 912000, "tx_index": 7 },
+    { "note": "tx_index 41 within the SAME block 912000",
+      "content_tx": "6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d",
+      "p": "SRC-ORD", "op": "PRESERVE", "mode": "full",
+      "stamp_tx": "6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d",
+      "src": { "inscription_id": "6666666666666666666666666666666666666666666666666666666666666666i0", "genesis_txid": "6666666666666666666666666666666666666666666666666666666666666666", "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "content_type": "image/png", "content_length": 1024 },
+      "proof": { "type": "utxo-spend", "address": "bc1qsecondintx...", "utxo": "9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c9c:0" },
+      "tx_spends_proof_utxo": true,
+      "block_index": 912000, "tx_index": 41 }
+  ],
+  "expected": { "indexed_as": ["migration_stamp", "migration_stamp"], "canonical_flag": [true, false], "reason": "§3.4 rule 6: canonical is ordered by (block height, then in-block tx_index) — 912000/7 beats 912000/41; deterministic from the confirmed chain, never from mempool/observation order" }
+}
+```
+
+**TV-14 — Oversized JSON envelope (PRESERVE DROPPED; envelope grammar bound).**
+```json
+{
+  "input": {
+    "p": "SRC-ORD", "op": "PRESERVE", "mode": "anchor",
+    "src": {
+      "inscription_id": "7777777777777777777777777777777777777777777777777777777777777777i0",
+      "genesis_txid": "7777777777777777777777777777777777777777777777777777777777777777",
+      "content_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "content_type": "image/png", "content_length": 1024,
+      "padding": "<key/value filler inflating the serialized envelope beyond the PRESERVE envelope byte cap>"
+    },
+    "proof": { "type": "utxo-spend", "address": "bc1qbloatowner...", "utxo": "adadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadad:0" },
+    "tx_spends_proof_utxo": true,
+    "serialized_envelope_bytes": "TBD — exceeds the envelope cap",
+    "envelope_cap_note": "PRESERVE_MAX_ENVELOPE_BYTES is TBD (review blocker G8: the envelope JSON grammar — max bytes, key case, duplicate keys, number formats — must be codified before Accepted)"
+  },
+  "expected": { "preserve_op": "dropped", "migration_status": "rejected", "reason": "serialized envelope exceeds the (TBD) PRESERVE envelope byte cap; malformed/over-limit envelopes have a defined outcome — dropped (§3.4 rules 1 and 7, corrected); no partial processing" }
+}
+```
+
+**TV-15 — Per-block consensus-hash expectations (PLACEHOLDER — the cross-indexer contract).**
+
+Concrete testnet blocks with expected per-block hashes are REQUIRED before Accepted (AUTHORING
+§4: shared vectors are the contract between implementations). This placeholder fixes the
+*shape*; every value is TBD until the testnet campaign produces real blocks.
+
+| testnet block | contains | expected `txlist_hash` | expected `migration_hash` | expected `ledger_hash` |
+|---|---|---|---|---|
+| TBD (pre-activation) | one `p:"SRC-ORD"` PRESERVE | TBD — MUST equal the no-op baseline (op dropped pre-activation) | TBD (empty/absent) | TBD — unchanged (isolation) |
+| TBD (post-activation) | TV-02-shaped valid full-mode pair | TBD — includes content stamp + PRESERVE sidecar | TBD — one provenance record | TBD — unchanged (isolation) |
+| TBD (post-activation) | TV-04-shaped hash mismatch | TBD — includes content stamp only (sidecar dropped) | TBD (no record) | TBD — unchanged (isolation) |
+| TBD (post-activation) | TV-13-shaped same-block duplicate | TBD | TBD — canonical by (block, tx_index) | TBD — unchanged (isolation) |
+
+Notes: `ledger_hash` (`str(processed_src20_in_block)`, SRC-20-only) and `messages_hash` MUST be
+byte-identical with and without SIP-0110 enabled on every vector block — the verified isolation
+property. A full genesis→tip reparse proving byte-identical pre-activation hashes (via the
+existing `validate_block_against_reference` infrastructure) is also required before activation.
+
+---


### PR DESCRIPTION
Applies the code-grounded technical review posted on #878 (the "Code-grounded technical review" and "Design note: why full-mode content rides the CP-OLGA stamp path" comments) to the SIP-0110 supporting material under `docs/sips/SIP-0110/`. Docs only — no workflow/code/ruleset changes. Values that remain genuinely undecided (activation height, concrete testnet hashes, envelope byte cap, BIP-110 mediawiki commit pin) are kept explicitly **TBD**.

The companion **#878 issue-body revisions** (the normative spec is the issue, per AUTHORING §8) are delivered separately as paste-ready text for the maintainer — this PR deliberately does not touch the issue.

## `reference-implementation.md`
- **G1 — 2-tx on-wire reference model** (new §4.3 subsection): content = a plain OLGA stamp (raw-binary, length-first, base64-free, `transaction_utils.py:514-517`, zero changes to the #749-protected extractor); PRESERVE = small JSON-only sidecar on the direct substrate carrying `"stamp_tx"`; **rule 3 hashes the content stamp's raw on-wire OLGA payload bytes** (`chunk[2:2+len]` minus the 6-byte `stamp:` marker), never post-pipeline content (`models.py:420-422` MIME/svgz hazard). Includes the four-reason design rationale rejecting single-tx binary `SRC-ORD`, plus tradeability/64KB-parity/precedent notes.
- **G5 — activation gate corrected**: "Stamp-number assignment stays unchanged" replaced with the honest activation-gated description — valid sidecars are numbered (`stamp.py:63-64`) and enter `txlist_hash` (`block_validation.py:70-75`); non-upgraded indexers **drop** `p:"SRC-ORD"` (`stamp.py:247-252`), they do not index it as an ordinary stamp; content stamp preserved + numbered identically everywhere; `ledger_hash`/`messages_hash` isolation stated as verified; `migration_hash` isolates records but **not** numbering.
- **G3**: `stamp_tx` + `proof_utxo` columns added to `stamp_migrations`; reorg-safety note (`purge_block_db`, `database.py:1199-1211`).
- **Scope**: v1.10 = `full` + `anchor`, **Method B only**; Method A (BIP-322) deferred to a follow-up SIP (no library in the tree; script-execution divergence risk). OQ #5 (window) defers with Method A; pinned inequality `0 ≤ confirmation_height − msg_block ≤ N`.
- **OQ #8 resolved**: `PRESERVE_MAX_FULL_CONTENT_BYTES = 65_535` (2-byte length prefix; effective media 65,529; output/base bytes — no witness discount, ~4 MB unreachable).
- **OQ #11 resolved favorably**: BIP-110's cap measures the **scriptPubKey**, inclusive (≤34) → OLGA remains creatable; pin to `bip-0110.mediawiki` (exact revision TBD at Accepted).
- **Precision fixes**: Knots **v29.3.knots20260508**; flag day **~Sept 1 2026 (height 965,664)**, August = mandatory-signaling window; 256-byte witness cap hits **data pushes**; grandfathers **spends of** pre-activation UTXOs; OLGA figures ~50% size / ~60–70% cost (unsourced 95% dropped).

## `test-vectors.md`
- **2-tx conventions block**: full-mode vectors are now a `content_tx` + sidecar pair; `content_stamp_payload_sha256_recomputed` defined as the rule-3 raw-wire-bytes input; dropped = byte-identical to pre-activation.
- **G4**: TV-04/05/06/10 expected outcomes corrected to **dropped** (content stamp unaffected, being a separate tx); no "ordinary stamp fallback" anywhere.
- **TV-04 fixed**: `inscription_id` corrected from 67 chars to a valid 66-char id so the vector actually isolates the rule-3 hash-mismatch case.
- **Method-B scope**: TV-02/03/07/08/09/10 converted to `utxo-spend` with `proof.utxo`; TV-01/06/12 (Method A) retained but marked **DEFERRED** — not in the v1.10 activation set (dropped under v1.10 rules).
- **New vectors**: TV-11 (Method B, claimed UTXO not spent → dropped), TV-12 (window boundary: delta=N accept / N+1 drop / future-dated drop; deferred with Method A), TV-13 (same-block ordering by `(block, tx_index)`), TV-14 (oversized envelope → dropped; envelope cap explicitly TBD per review G8), TV-15 (per-block `txlist_hash`/`migration_hash`/`ledger_hash` expectations placeholder — the cross-indexer contract, values TBD on testnet).
- All 14 JSON blocks machine-validated (parse + 64-hex/regex field checks).

## Needs maintainer decision
- **Method-A deferral confirmation** (reflected throughout; easy to revert if rejected).
- **Same-block `stamp_tx` ordering rule**: drafted as *content stamp must confirm at a lower `(block, tx_index)` than the sidecar* (SRC-721 `valid_stamps_in_block` precedent) — proposed, not settled in the review.
- **Activation height, envelope byte cap (G8), `migration_hash` serialization (G9), BIP-110 mediawiki commit pin** — all left TBD.

Ref: #878. Review comments applied verbatim where they gave normative language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
