### PR TITLE
ci(#907): make consensus gates report a status on every PR (prep for required-checks)

### DIFF
--- a/.github/workflows/freeze-drift.yml
+++ b/.github/workflows/freeze-drift.yml
@@ -15,15 +15,13 @@ name: Freeze Drift Check
 # locally and commit the new indexer/ci/freeze.prod.lock in the same PR.
 # See indexer/ci/README.md.
 
+# The path filter lives on the `freeze-drift` JOB (via the `changes` detector),
+# NOT on the `on:` trigger, so the workflow still runs on every PR and the
+# `Freeze Drift Gate` status check is always reported (#907). A workflow skipped
+# by an `on: paths` filter reports NO check, which traps a required context as
+# "expected but never runs" (GH013) and blocks the PR forever.
 on:
   pull_request:
-    paths:
-      - 'indexer/pyproject.toml'
-      - 'indexer/poetry.lock'
-      - 'indexer/Dockerfile'
-      - 'indexer/ci/freeze.prod.lock'
-      - 'indexer/ci/freeze-filter.sh'
-      - '.github/workflows/freeze-drift.yml'
   workflow_dispatch:
 
 permissions:
@@ -31,8 +29,37 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Detect whether freeze-relevant files changed. Keeps the heavy Docker build
+  # off unrelated PRs while the workflow still runs (so the gate reports).
+  changes:
+    name: Detect freeze-relevant changes
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')) || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      freeze: ${{ steps.filter.outputs.freeze }}
+    steps:
+      - name: Filter freeze-relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            freeze:
+              - 'indexer/pyproject.toml'
+              - 'indexer/poetry.lock'
+              - 'indexer/Dockerfile'
+              - 'indexer/ci/freeze.prod.lock'
+              - 'indexer/ci/freeze-filter.sh'
+              - '.github/workflows/freeze-drift.yml'
+
   freeze-drift:
     name: Freeze Drift Check
+    needs: changes
+    # Heavy Docker build only when freeze-relevant files change (or a manual run).
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.freeze == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -129,3 +156,27 @@ jobs:
       - name: Fail on drift
         if: steps.diff.outputs.drift == 'true'
         run: exit 1
+
+  # Stable, always-present status check (#907). Keep this job's name FIXED — it is
+  # the requireable ruleset context. Green when freeze-drift passed OR was skipped
+  # (freeze-irrelevant PR); red only when freeze-drift actually failed/cancelled.
+  freeze-drift-gate:
+    name: Freeze Drift Gate
+    needs: [changes, freeze-drift]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve gate from freeze-drift result
+        env:
+          RESULT: ${{ needs.freeze-drift.result }}
+        run: |
+          echo "freeze-drift job result: $RESULT"
+          case "$RESULT" in
+            success|skipped)
+              echo "Gate PASS: freeze-drift $RESULT (no unresolved drift)."
+              ;;
+            *)
+              echo "::error::Freeze Drift Gate failed (freeze-drift result: $RESULT)."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -138,3 +138,30 @@ jobs:
           # Run integration tests that work with mocks or external APIs
           # Exclude only tests that require a local Bitcoin node
           poetry run pytest -m "integration and not requires_bitcoin_node" -v --tb=short
+
+  # Dedicated, always-present consensus gate for the Python 3.13 base64/binascii
+  # divergence (#871, #907). The broad "Code Quality & Unit Tests (3.13)" matrix
+  # leg also exercises this test, but this job gives a FIXED, isolated, requireable
+  # status context that is fast (no indexer/Rust build — the detection test only
+  # needs base64/os/sys/pytest) and runs on every PR to main/dev.
+  #
+  # The test is a STRICT xfail on 3.13 (b64decode must reject the block-783775
+  # non-canonical payload): green while 3.13 keeps diverging as documented, RED if
+  # 3.13 ever decodes it again (xpass) — the signal to revisit #871.
+  python313-consensus-gate:
+    name: Python 3.13 Consensus Divergence Gate
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')) || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: Run Python 3.13 base64 consensus-divergence detection test
+        # -o addopts="" drops the repo pytest addopts (--cov-config etc.) and
+        # --noconftest skips indexer/tests/conftest.py (which imports index_core)
+        # so this stays a zero-dependency run of just the detection test.
+        run: python -m pytest indexer/tests/test_python313_base64_regression.py -o addopts="" --noconftest -v

--- a/.github/workflows/reparse-validate.yml
+++ b/.github/workflows/reparse-validate.yml
@@ -31,29 +31,58 @@ name: Reparse Consensus Validation
 # This is advisory on first land (does not block merge). Promote to required
 # after one bake cycle confirms zero false positives.
 
+# The path filter lives on the `reparse-validate` JOB (via the `changes`
+# detector), NOT on the `on:` trigger, so the workflow runs on every PR and the
+# `Reparse Consensus Validation Gate` status check is always reported (#907). A
+# workflow skipped by an `on: paths` filter reports NO check, trapping a required
+# context as "expected but never runs" (GH013) and blocking the PR forever.
 on:
   pull_request:
-    paths:
-      - 'indexer/src/index_core/**'
-      - 'indexer/src/rust_parser/**'
-      - 'indexer/pyproject.toml'
-      - 'indexer/poetry.lock'
-      - 'indexer/snapshots/ci_consensus_hashes.json'
-      - 'indexer/snapshots/reference_hashes.json'
-      - 'indexer/src/config.py'
-      - 'indexer/ci/**'
-      - '.github/workflows/reparse-validate.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # Detect whether consensus-surface files changed. Keeps the heavy reparse off
+  # unrelated PRs while the workflow still runs (so the gate reports).
+  changes:
+    name: Detect reparse-relevant changes
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')) || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      reparse: ${{ steps.filter.outputs.reparse }}
+    steps:
+      - name: Filter reparse-relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            reparse:
+              - 'indexer/src/index_core/**'
+              - 'indexer/src/rust_parser/**'
+              - 'indexer/pyproject.toml'
+              - 'indexer/poetry.lock'
+              - 'indexer/snapshots/ci_consensus_hashes.json'
+              - 'indexer/snapshots/reference_hashes.json'
+              - 'indexer/src/config.py'
+              - 'indexer/ci/**'
+              - '.github/workflows/reparse-validate.yml'
+
   reparse-validate:
     name: Reparse Consensus Validation (${{ matrix.python-version }})
+    needs: changes
+    # Heavy reparse only when consensus-surface files change (or a manual run).
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.reparse == 'true'
     runs-on: ubuntu-latest
-    # Advisory on first land — promote to required after one bake cycle.
-    continue-on-error: true
+    # NOTE (#907): continue-on-error removed — a genuine reparse failure must go
+    # red so this gate can be made required. The deliberate scope exclusions
+    # (TIER3_CROSS_BLOCK_LEDGER) remain SKIPS inside ci_reparse_subprocess.py
+    # (dropped from the block list), not failures, so they never turn the gate red.
     strategy:
       fail-fast: false
       matrix:
@@ -140,3 +169,28 @@ jobs:
           poetry run python ci/ci_reparse_subprocess.py \
             --baseline snapshots/ci_consensus_hashes.json \
             --timeout 120
+
+  # Stable, always-present status check (#907). Keep this job's name FIXED — it is
+  # the requireable ruleset context. Green when the reparse matrix passed OR was
+  # skipped (consensus-irrelevant PR); red only when a matrix leg actually
+  # failed/cancelled.
+  reparse-validate-gate:
+    name: Reparse Consensus Validation Gate
+    needs: [changes, reparse-validate]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve gate from reparse matrix result
+        env:
+          RESULT: ${{ needs.reparse-validate.result }}
+        run: |
+          echo "reparse-validate matrix result: $RESULT"
+          case "$RESULT" in
+            success|skipped)
+              echo "Gate PASS: reparse-validate $RESULT (consensus surface OK or untouched)."
+              ;;
+            *)
+              echo "::error::Reparse Consensus Validation Gate failed (result: $RESULT)."
+              exit 1
+              ;;
+          esac

--- a/indexer/ci/ci_validate_consensus.py
+++ b/indexer/ci/ci_validate_consensus.py
@@ -14,8 +14,19 @@ For each block:
      verification is the next layer once the workflow is proven on CI.
 
 Exit codes:
-  0 — every block fetched, hash-verified
-  1 — any block missing, fetched-but-wrong-hash, or fetch failed
+  0 — every block fetched & hash-verified, OR only transient fetch failures
+      (network/public-node flake) remained after retries. A fetch failure is
+      NOT a consensus signal, so — for a required gate (#907) — it must not go
+      red; it is surfaced as a ::warning:: instead.
+  1 — any block fetched-but-hash-MISMATCH. This IS a genuine consensus signal
+      (content-addressed bytes diverged from the baseline) and always goes red.
+
+Rationale (#907): this gate is being promoted from advisory (continue-on-error)
+to required. A blockstream.info read timeout is transient infra, not parser
+drift — treating it as red would block consensus PRs on public-node flakiness
+(the exact "blocks PRs for non-consensus reasons" trap #907 exists to avoid).
+Retries absorb the common single-timeout case; a genuine HASH MISMATCH still
+fails hard. Tier 1 (checkpoints cross-check, no network) and Tier 3 still run.
 """
 
 from __future__ import annotations
@@ -25,8 +36,34 @@ import hashlib
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
+
+# Bounded retry for the network fetch. Absorbs transient public-node timeouts
+# without masking a genuine wrong-bytes response (that surfaces as a HASH
+# MISMATCH after a successful fetch, which is never retried away).
+FETCH_ATTEMPTS = 3
+FETCH_BACKOFF_SECONDS = 3
+
+
+def _fetch_with_retries(fetch, block_hash: str):
+    """Call fetch(block_hash) with bounded retries + linear backoff.
+
+    Retries only the FETCH (network) layer. Re-raises the last error if every
+    attempt fails so the caller can classify it as a (non-fatal) fetch failure.
+    """
+    last_err: Exception | None = None
+    for attempt in range(1, FETCH_ATTEMPTS + 1):
+        try:
+            return fetch(block_hash)
+        except (urllib.error.URLError, TimeoutError, RuntimeError, OSError) as e:
+            last_err = e
+            if attempt < FETCH_ATTEMPTS:
+                print(f"    fetch attempt {attempt}/{FETCH_ATTEMPTS} failed ({e}); retrying...")
+                time.sleep(FETCH_BACKOFF_SECONDS * attempt)
+    assert last_err is not None
+    raise last_err
 
 
 def fetch_via_rpc(url: str, user: str, secret: str, block_hash: str) -> bytes:
@@ -88,24 +125,27 @@ def main() -> int:
     source = "bitcoind RPC" if rpc_url else "blockstream.info"
     print(f"Validating {len(blocks)} consensus boundary blocks via {source}\n")
 
-    failures = 0
+    # Classify outcomes: HASH MISMATCH is a genuine consensus signal (fatal,
+    # red); FETCH FAILED is transient infra (non-fatal warning). See #907.
+    hash_mismatches = 0
+    fetch_failures = 0
+    verified = 0
     for block_index in sorted(blocks, key=int):
         entry = blocks[block_index]
         block_hash = entry["block_hash"]
         reason = entry.get("reason", "")
+        fetch = (lambda h: fetch_via_rpc(rpc_url, rpc_user, rpc_secret, h)) if rpc_url else fetch_via_blockstream
         try:
-            if rpc_url:
-                raw = fetch_via_rpc(rpc_url, rpc_user, rpc_secret, block_hash)
-            else:
-                raw = fetch_via_blockstream(block_hash)
-        except (urllib.error.URLError, RuntimeError) as e:
-            print(f"  block {block_index} ({reason}): FETCH FAILED — {e}")
-            failures += 1
+            raw = _fetch_with_retries(fetch, block_hash)
+        except (urllib.error.URLError, TimeoutError, RuntimeError, OSError) as e:
+            # Not a consensus signal — the node was unreachable/slow. Warn, don't fail.
+            print(f"  block {block_index} ({reason}): FETCH FAILED after {FETCH_ATTEMPTS} attempts — {e}")
+            fetch_failures += 1
             continue
 
         if not verify_block_hash(raw, block_hash):
             print(f"  block {block_index} ({reason}): HASH MISMATCH — " f"fetched bytes do not hash to {block_hash}")
-            failures += 1
+            hash_mismatches += 1
             continue
 
         # TODO: run indexer parser pipeline against `raw` and verify
@@ -113,12 +153,22 @@ def main() -> int:
         # That's the actual parser-output snapshot; this commit lands the
         # fetch+hash scaffolding so the workflow is proven on real CI.
         size_kb = len(raw) // 1024
+        verified += 1
         print(f"  block {block_index} ({reason}): {size_kb} KB, hash verified")
 
     print()
-    if failures:
-        print(f"::error::{failures} of {len(blocks)} blocks failed validation")
+    # Genuine consensus divergence — always red.
+    if hash_mismatches:
+        print(f"::error::{hash_mismatches} of {len(blocks)} blocks HASH-MISMATCHED the baseline (consensus divergence)")
         return 1
+    # Transient infra only — surface loudly but do NOT block the gate (#907).
+    if fetch_failures:
+        print(
+            f"::warning::{fetch_failures} of {len(blocks)} blocks could not be fetched "
+            f"(transient public-node/network failure after {FETCH_ATTEMPTS} attempts). "
+            f"{verified} verified, 0 mismatched — not treating infra flake as consensus failure."
+        )
+        return 0
     print(f"All {len(blocks)} blocks validated cleanly.")
     return 0
 


### PR DESCRIPTION
## What & why (part 1 of #907)

Post-trunk-migration, the deep consensus gates (`freeze-drift`, `reparse-validate`, and the Python-3.13 base64 divergence detection) are **path-triggered at the `on:` level**. A workflow skipped by an `on: paths` filter reports **no status check**, so adding these to the required-checks set as-is would trap them as *"expected but never runs"* (GH013) and block every unrelated PR to `main` forever.

This PR makes each gate **exist and report on every PR** — green when its path-triggered work is skipped or passes, red when it actually fails — **without** touching any ruleset. Making them *required* is the separate, incremental manual step tracked in #907.

## Stable, always-present status checks introduced (the requireable contexts)

| Gate | New fixed check-run context (always reports) | Heavy job (conditional, do NOT require) |
|------|----------------------------------------------|-----------------------------------------|
| Freeze drift | **`Freeze Drift Gate`** | `Freeze Drift Check` |
| Reparse consensus | **`Reparse Consensus Validation Gate`** | `Reparse Consensus Validation (3.10/3.11/3.12)` |
| Python 3.13 divergence | **`Python 3.13 Consensus Divergence Gate`** | (was folded into `Code Quality & Unit Tests (3.13)`) |

Require the **Gate** names, not the heavy jobs.

## Per-workflow change

**`freeze-drift.yml`** — Path filter moved off `on:` onto a `changes` detector job (`dorny/paths-filter`, SHA-pinned `de90cc6` / v3.0.2). The heavy Docker-build `freeze-drift` job runs only when freeze-relevant files change (or `workflow_dispatch`). New sibling `Freeze Drift Gate` job (`needs: [changes, freeze-drift]`, `if: always()`) resolves the heavy job's result.

**`reparse-validate.yml`** — Same `changes`/detector pattern; matrix job gated by it. **`continue-on-error: true` removed** so a genuine reparse failure now goes red. The deliberate scope exclusions (`TIER3_CROSS_BLOCK_LEDGER`) remain **skips inside `ci_reparse_subprocess.py`** (dropped from the block list), not failures. New `Reparse Consensus Validation Gate` summary job.

**`python-check.yml`** — Added a dedicated, fast `Python 3.13 Consensus Divergence Gate` job: Python 3.13, `pip install pytest`, runs only `indexer/tests/test_python313_base64_regression.py` (`-o addopts="" --noconftest` — the detection test needs only base64/os/sys/pytest, no indexer/Rust build). Gives the #871 consensus concern an isolated, requireable context instead of relying on the broad unit-test matrix leg.

**`indexer/ci/ci_validate_consensus.py`** — Follow-on to removing `continue-on-error`. The block-bytes tier conflated **FETCH FAILED** (transient blockstream.info timeout = infra) with **HASH MISMATCH** (genuine consensus divergence): both returned exit 1. Observed live on the first CI run of this PR — the 3.12 leg red on a `urllib` read timeout while 3.10/3.11 passed the identical fetch. Fix: bounded retries (3 attempts, linear backoff), then classify — **HASH MISMATCH → fatal (red); FETCH FAILED after retries → non-fatal `::warning::` (exit 0)**. So genuine divergence still turns the gate red; public-node flakiness no longer does. Tier 1 (checkpoints, no network) and Tier 3 still run.

## How skipped-vs-failed resolves

Each Gate job runs `if: always()` and inspects `needs.<heavy>.result`:
- `success` or `skipped` → **exit 0 (green)** — path-triggered work passed, or the PR didn't touch the gate's paths.
- `failure` or `cancelled` → **exit 1 (red)** — a real gate failure.

A docs-only PR to `main` shows all three Gates green; a PR that breaks freeze drift / reparse consensus / the 3.13 divergence turns the corresponding Gate red. The 3.13 gate is a **strict xfail** on 3.13 (green while it keeps diverging as documented; red as an XPASS if 3.13 is ever fixed — the signal to revisit #871).

## Live verification on this PR
First run exercised the real path (this PR edits the two gated workflow files, so the detectors fire and the heavy jobs run): `Freeze Drift Gate` = green (heavy passed), `Python 3.13 Consensus Divergence Gate` = green, and the `Reparse Consensus Validation Gate` correctly went **red** off a failing leg — which turned out to be the blockstream timeout, now fixed by the fetch-resilience commit and re-verified green.

## Validation
- PyYAML `safe_load` + `actionlint` 1.7.12 **+ shellcheck** 0.10.0: no findings on the changed jobs. (One pre-existing `SC2086` on the untouched `Set PYTHONPATH` step is out of scope.)
- New action `dorny/paths-filter` pinned to commit SHA `de90cc6fb38fc0963ad72b210f1f284cd68cea36` (v3.0.2).
- `ci_validate_consensus.py`: `py_compile` + `black --check` clean; classification unit-checked offline (all-fetch-fail → 0, hash-mismatch → 1).

## Residual note
Tier 3 (`ci_reparse_subprocess.py`) also does per-block network fetches; a total node outage there could still time a block out. Not re-classified in this PR to keep the consensus-reparse failure semantics untouched — flagged for the #907 bake cycle.

## Explicitly out of scope
No ruleset edits, nothing made required — that's the separate manual step after this merges. This PR only makes the checks *exist and report* on every PR.

Refs #907, #871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
