### PR TITLE
fix(v11.2): drop show_unconfirmed from dispenses/dispensers/balances API calls

### DIFF
--- a/indexer/src/index_core/dispense_processor.py
+++ b/indexer/src/index_core/dispense_processor.py
@@ -263,9 +263,7 @@ class DispenseProcessor:
 
                 # Get dispenses for this dispenser/asset combination
                 rate_limiter.acquire()
-                dispense_response = fetch_xcp(
-                    f"/addresses/{source}/dispenses", {"asset": cpid, "verbose": "true"}
-                )
+                dispense_response = fetch_xcp(f"/addresses/{source}/dispenses", {"asset": cpid, "verbose": "true"})
 
                 if dispense_response and "result" in dispense_response:
                     dispenses = dispense_response["result"]

--- a/indexer/src/index_core/dispense_processor.py
+++ b/indexer/src/index_core/dispense_processor.py
@@ -95,8 +95,10 @@ class DispenseProcessor:
         rate_limiter.acquire()
 
         try:
-            # Fetch all dispenses in the block with verbose data
-            response = fetch_xcp(f"/blocks/{block_index}/dispenses", {"verbose": "true", "show_unconfirmed": "false"})
+            # Fetch all dispenses in the block with verbose data.
+            # NB: no show_unconfirmed here — CP v11.2 strict-validates params and the
+            # dispenses endpoints reject it (they read the confirmed-only dispenses table).
+            response = fetch_xcp(f"/blocks/{block_index}/dispenses", {"verbose": "true"})
 
             if not response or "result" not in response:
                 return 0
@@ -246,7 +248,7 @@ class DispenseProcessor:
         try:
             # Step 1: Get all dispensers for this CPID
             rate_limiter.acquire()
-            response = fetch_xcp(f"/assets/{cpid}/dispensers", {"show_unconfirmed": "false"})
+            response = fetch_xcp(f"/assets/{cpid}/dispensers", {})
 
             if not response or "result" not in response:
                 return 0
@@ -262,7 +264,7 @@ class DispenseProcessor:
                 # Get dispenses for this dispenser/asset combination
                 rate_limiter.acquire()
                 dispense_response = fetch_xcp(
-                    f"/addresses/{source}/dispenses", {"asset": cpid, "verbose": "true", "show_unconfirmed": "false"}
+                    f"/addresses/{source}/dispenses", {"asset": cpid, "verbose": "true"}
                 )
 
                 if dispense_response and "result" in dispense_response:

--- a/indexer/src/index_core/sales_history_processor.py
+++ b/indexer/src/index_core/sales_history_processor.py
@@ -132,7 +132,9 @@ class SalesHistoryProcessor:
             # Fetch dispenses from Counterparty API
             from index_core.fetch_utils import fetch_xcp
 
-            response = fetch_xcp(f"/blocks/{block_index}/dispenses", {"verbose": "true", "show_unconfirmed": "false"})
+            # No show_unconfirmed: CP v11.2 rejects it on the dispenses endpoint
+            # (confirmed-only dispenses table); harmless on v11.1.x too.
+            response = fetch_xcp(f"/blocks/{block_index}/dispenses", {"verbose": "true"})
 
             if not response or "result" not in response:
                 logger.debug(f"No dispenses found in block {block_index}")

--- a/indexer/src/index_core/stamp_worker.py
+++ b/indexer/src/index_core/stamp_worker.py
@@ -131,8 +131,11 @@ class StampWorker:
             # Fallback to old individual API call logic
             try:
                 self.rate_limiter.acquire()
+                # FIXME(v11.2): the top-level /dispensers endpoint also dropped the
+                # `asset` param under CP v11.2 strict validation — this fallback should
+                # migrate to /assets/{cpid}/dispensers. Tracked in the v11.2 API audit.
                 endpoint = "/dispensers"
-                params = {"asset": cpid, "limit": MAX_DISPENSERS_PER_REQUEST, "show_unconfirmed": "false"}
+                params = {"asset": cpid, "limit": MAX_DISPENSERS_PER_REQUEST}
 
                 logger.debug(f"Fetching dispensers for {cpid} from endpoint (fallback): {endpoint}")
                 response = fetch_xcp(endpoint, params)
@@ -178,7 +181,7 @@ class StampWorker:
             self.rate_limiter.acquire()
 
             endpoint = f"/assets/{cpid}/dispenses"
-            params = {"limit": MAX_DISPENSES_PER_REQUEST, "show_unconfirmed": "false", "verbose": "true"}
+            params = {"limit": MAX_DISPENSES_PER_REQUEST, "verbose": "true"}
 
             logger.debug(f"Fetching dispenses for {cpid}")
             response = fetch_xcp(endpoint, params)
@@ -213,7 +216,7 @@ class StampWorker:
             self.rate_limiter.acquire()
 
             endpoint = f"/assets/{cpid}/balances"
-            params = {"limit": MAX_BALANCES_PER_REQUEST, "show_unconfirmed": "false"}
+            params = {"limit": MAX_BALANCES_PER_REQUEST}
 
             logger.debug(f"Fetching balances for {cpid}")
             response = fetch_xcp(endpoint, params)

--- a/indexer/tests/test_sales_history_processor.py
+++ b/indexer/tests/test_sales_history_processor.py
@@ -190,7 +190,7 @@ class TestSalesHistoryProcessor:
         assert count == 1
 
         # Verify API was called correctly
-        mock_fetch.assert_called_once_with("/blocks/800000/dispenses", {"verbose": "true", "show_unconfirmed": "false"})
+        mock_fetch.assert_called_once_with("/blocks/800000/dispenses", {"verbose": "true"})
 
     @pytest.mark.skip(reason="Expects fetch_xcp API that doesn't exist")
     def test_process_block_before_genesis(self, processor):
@@ -501,7 +501,7 @@ class TestSalesHistoryProcessor:
 
         # Should process the dispense and make API call
         assert count == 1
-        mock_fetch.assert_called_once_with("/blocks/850000/dispenses", {"verbose": "true", "show_unconfirmed": "false"})
+        mock_fetch.assert_called_once_with("/blocks/850000/dispenses", {"verbose": "true"})
 
     def test_catchup_mode_start_stop(self, processor, mock_cursor):
         """Test starting and stopping catchup mode"""

--- a/indexer/tests/test_sales_history_processor_integration.py
+++ b/indexer/tests/test_sales_history_processor_integration.py
@@ -139,7 +139,7 @@ class TestSalesHistoryProcessorIntegration:
     def test_counterparty_api_dispense_fetch(self):
         """Test fetching dispenses from Counterparty API directly"""
         # Test the actual API endpoint
-        response = fetch_xcp("/blocks/800000/dispenses", {"verbose": "true", "show_unconfirmed": "false"})
+        response = fetch_xcp("/blocks/800000/dispenses", {"verbose": "true"})
 
         # Validate response structure
         assert response is not None


### PR DESCRIPTION
## Problem

CP **v11.2.0** added strict per-endpoint parameter validation. The **dispenses / dispensers / balances** endpoints now reject `show_unconfirmed` with `HTTP 400: {"error": "Unrecognized parameter(s): show_unconfirmed"}`.

When `api.counterparty.io:4000` (the CI backup node) upgraded to v11.2.0 today (~11:53–13:39 UTC), this broke **Integration Tests repo-wide** — `main` and every open PR went red on `test_counterparty_api_dispense_fetch`. It would also break **prod** dispense/sales fetches the moment the prod CP node is upgraded to v11.2.

## Why it's safe

CP's dispenses/dispensers/balances queries read **confirmed-only** ledger tables and take no `show_unconfirmed` param — so it was always a no-op there. Dropping it returns identical confirmed-only results on **both v11.1.x and v11.2.0**, so this is safe to deploy ahead of the node upgrade.

Verified against the live v11.2.0 node: each of these endpoints returns valid results **without** the param and 400s **with** it. The `/blocks/{n}/transactions` endpoints (fetch_utils.py) still accept `show_unconfirmed`, so those are **left unchanged**.

## Changes
- `dispense_processor.py` — `/blocks/{n}/dispenses`, `/assets/{cpid}/dispensers`, `/addresses/{source}/dispenses`
- `sales_history_processor.py` — `/blocks/{n}/dispenses`
- `stamp_worker.py` — `/dispensers`, `/assets/{cpid}/dispenses`, `/assets/{cpid}/balances`
- tests — sales-history integration test + 2 unit-mock assertions

## Follow-up (not in this PR)
v11.2 also dropped the **`asset`** param on the top-level `/dispensers` endpoint — flagged with a `FIXME` in `stamp_worker.py`. There may be further v11.2 API drift; a dedicated **v11.2 API-compatibility audit** should run before the prod CP node is upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)