### PR TITLE
feat(media): mirror Stamps through shared storage

### DIFF
--- a/indexer/.env.sample
+++ b/indexer/.env.sample
@@ -207,6 +207,19 @@ DB_WRITE_TIMEOUT=300
 # Upload settings
 USE_ASYNC_UPLOADS=1
 
+# Required shared Universe media ingestion whenever STORE_FILES=true. The central service owns B2
+# credentials and the global object namespace; this indexer uses only its
+# bearer token. Configure both values together; legacy per-indexer S3/disk
+# storage is not used for new media.
+# UNIVERSE_MEDIA_INGEST_URL=https://api.example/universe-media/v1/objects
+# UNIVERSE_MEDIA_INGEST_TOKEN=replace-with-at-least-32-random-characters
+UNIVERSE_MEDIA_UPLOAD_ATTEMPTS=5
+UNIVERSE_MEDIA_CONNECT_TIMEOUT=5
+UNIVERSE_MEDIA_READ_TIMEOUT=90
+# Must be persistent storage outside the release/container filesystem.
+UNIVERSE_MEDIA_SPOOL_DIR=/var/lib/btc-stamps/universe-media-spool
+UNIVERSE_MEDIA_QUEUE_MAX_ATTEMPTS=20
+
 # =============================================================================
 # PERFORMANCE & CACHING CONFIGURATION
 # =============================================================================

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -99,7 +99,21 @@ services:
 | `BITCOIND_PORT` | Bitcoin Core RPC port | `8332` |
 | `DOCKER_CONTAINER` | Set to 1 when running in container | `1` |
 | `STORE_FILES` | Whether to store files | `1` |
+| `UNIVERSE_MEDIA_INGEST_URL` | Shared Universe media object-ingest endpoint; required when `STORE_FILES=1` | - |
+| `UNIVERSE_MEDIA_INGEST_TOKEN` | Shared-ingest bearer token (minimum 32 characters) | - |
+| `UNIVERSE_MEDIA_SPOOL_DIR` | Absolute persistent path for the verified retry spool | - |
 | `DEBUG` | Enable debug mode | `0` |
+
+New and historical Stamp media must use the shared Universe service. The
+indexer never needs Backblaze credentials or a per-project bucket. After the
+schema update and service configuration, migrate historical exact bytes with:
+
+```bash
+poetry run python tools/backfill_universe_media.py --drain
+```
+
+The command is resumable. Missing or undecodable consensus source bytes and
+terminal uploads keep its source health incomplete and return a non-zero exit.
 
 ## Testing Docker Builds
 

--- a/indexer/src/config.py
+++ b/indexer/src/config.py
@@ -273,6 +273,27 @@ S3_OBJECTS: Dict[str, Dict[str, str]] = {}
 AWS_INVALIDATE_CACHE: Optional[str] = os.environ.get("AWS_INVALIDATE_CACHE", None)
 USE_ASYNC_UPLOADS = os.environ.get("USE_ASYNC_UPLOADS", "1") == "1"
 
+# All new Stamp media should flow through the single Universe media service.
+# The service owns B2 credentials, global SHA-256 deduplication, legal holds,
+# mapping registration, and read-back verification. The indexer receives only
+# a distinct ingestion token.
+UNIVERSE_MEDIA_INGEST_URL = os.environ.get("UNIVERSE_MEDIA_INGEST_URL", "").strip().rstrip("/")
+UNIVERSE_MEDIA_INGEST_TOKEN = os.environ.get("UNIVERSE_MEDIA_INGEST_TOKEN", "").strip()
+UNIVERSE_MEDIA_ENABLED = bool(STORE_FILES and UNIVERSE_MEDIA_INGEST_URL and UNIVERSE_MEDIA_INGEST_TOKEN)
+UNIVERSE_MEDIA_UPLOAD_ATTEMPTS = max(1, min(10, int(os.environ.get("UNIVERSE_MEDIA_UPLOAD_ATTEMPTS", "5"))))
+UNIVERSE_MEDIA_CONNECT_TIMEOUT = max(1.0, min(30.0, float(os.environ.get("UNIVERSE_MEDIA_CONNECT_TIMEOUT", "5"))))
+UNIVERSE_MEDIA_READ_TIMEOUT = max(5.0, min(300.0, float(os.environ.get("UNIVERSE_MEDIA_READ_TIMEOUT", "90"))))
+UNIVERSE_MEDIA_SPOOL_DIR = os.path.abspath(os.environ.get("UNIVERSE_MEDIA_SPOOL_DIR", "universe-media-spool"))
+UNIVERSE_MEDIA_QUEUE_MAX_ATTEMPTS = max(
+    1, min(100, int(os.environ.get("UNIVERSE_MEDIA_QUEUE_MAX_ATTEMPTS", "20")))
+)
+if bool(UNIVERSE_MEDIA_INGEST_URL) != bool(UNIVERSE_MEDIA_INGEST_TOKEN):
+    raise ConfigurationError("UNIVERSE_MEDIA_INGEST_URL and UNIVERSE_MEDIA_INGEST_TOKEN must be configured together")
+if UNIVERSE_MEDIA_INGEST_TOKEN and len(UNIVERSE_MEDIA_INGEST_TOKEN) < 32:
+    raise ConfigurationError("UNIVERSE_MEDIA_INGEST_TOKEN must contain at least 32 characters")
+if UNIVERSE_MEDIA_ENABLED and not os.path.isabs(os.environ.get("UNIVERSE_MEDIA_SPOOL_DIR", "")):
+    raise ConfigurationError("UNIVERSE_MEDIA_SPOOL_DIR must be an explicit absolute persistent path")
+
 # Define for Quicknode or similar remote nodes which use a token
 QUICKNODE_ENDPOINT: Optional[str] = os.environ.get("QUICKNODE_URL", None)  # Fallback to old URL for compatibility
 QUICKNODE_API_KEY: Optional[str] = os.environ.get("QUICKNODE_API_KEY", None)  # Used for Bearer token auth

--- a/indexer/src/index_core/async_upload.py
+++ b/indexer/src/index_core/async_upload.py
@@ -7,6 +7,7 @@ in the background.
 """
 
 import logging
+import hashlib
 import os
 import queue
 import threading
@@ -18,6 +19,8 @@ from typing import Optional
 import config
 from index_core.aws import invalidate_with_retries, update_s3_db_objects, upload_file_to_s3
 from index_core.database_manager import DatabaseManager
+from index_core.universe_media import upload_universe_media
+from index_core.universe_media_queue import UniverseMediaQueue
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +36,17 @@ upload_db_manager = DatabaseManager()
 # Flag to control the upload worker thread
 _upload_worker_running = False
 _upload_worker_thread = None
+_universe_queue = None
+
+
+def _durable_universe_queue() -> UniverseMediaQueue:
+    global _universe_queue
+    if _universe_queue is None:
+        _universe_queue = UniverseMediaQueue(
+            config.UNIVERSE_MEDIA_SPOOL_DIR,
+            config.UNIVERSE_MEDIA_QUEUE_MAX_ATTEMPTS,
+        )
+    return _universe_queue
 
 
 class UploadTask:
@@ -69,6 +83,14 @@ def _process_upload_task(task: UploadTask) -> None:
     Args:
         task: The upload task to process
     """
+    if config.UNIVERSE_MEDIA_ENABLED:
+        try:
+            task.file_obj.seek(0)
+            upload_universe_media(task.filename, task.mime_type, task.file_obj)
+            logger.debug(f"Uploaded {task.filename} through the shared Universe media service")
+        except Exception as e:
+            logger.error(f"Universe media upload failed for {task.filename}: {e}", exc_info=True)
+        return
     try:
         # Get a dedicated database connection for this upload
         db = upload_db_manager.connect()
@@ -113,6 +135,25 @@ def _process_upload_task(task: UploadTask) -> None:
         logger.error(f"Unexpected error in upload worker: {e}", exc_info=True)
 
 
+def _process_universe_job(job_id: int) -> None:
+    durable = _durable_universe_queue()
+    job = durable.claim(job_id)
+    if job is None:
+        return
+    try:
+        with open(job.body_path, "rb") as source:
+            body = source.read()
+        if hashlib.sha256(body).hexdigest() != job.content_sha256:
+            raise RuntimeError("Universe media spool integrity mismatch")
+        upload_universe_media(job.filename, job.mime_type, BytesIO(body))
+        durable.complete(job.job_id)
+    except Exception as error:
+        retry = durable.fail(job.job_id, str(error))
+        logger.error(f"Universe media upload failed for {job.filename}: {error}", exc_info=True)
+        if not retry:
+            logger.error(f"Universe media job {job.job_id} reached its terminal retry limit")
+
+
 def _upload_worker() -> None:
     """
     Worker thread function that processes the upload queue.
@@ -129,7 +170,10 @@ def _upload_worker() -> None:
 
             try:
                 # Process the upload task
-                _process_upload_task(task)
+                if isinstance(task, int):
+                    _process_universe_job(task)
+                else:
+                    _process_upload_task(task)
             except Exception as e:
                 logger.error(f"Error processing upload task: {e}", exc_info=True)
             finally:
@@ -137,7 +181,9 @@ def _upload_worker() -> None:
                 upload_queue.task_done()
 
         except queue.Empty:
-            # No tasks in the queue, continue waiting
+            if config.UNIVERSE_MEDIA_ENABLED:
+                for job_id in _durable_universe_queue().pending_ids(limit=1000):
+                    upload_queue.put(job_id)
             continue
         except Exception as e:
             logger.error(f"Unexpected error in upload worker: {e}", exc_info=True)
@@ -158,6 +204,9 @@ def start_upload_worker() -> None:
         return
 
     _upload_worker_running = True
+    if config.UNIVERSE_MEDIA_ENABLED:
+        for job_id in _durable_universe_queue().pending_ids():
+            upload_queue.put(job_id)
     _upload_worker_thread = threading.Thread(target=_upload_worker, daemon=True)
     _upload_worker_thread.start()
 
@@ -225,6 +274,16 @@ def queue_file_upload(filename: str, mime_type: str, file_obj: BytesIO, file_obj
     if not _upload_worker_running:
         logger.warning("Upload worker thread is not running, starting it now")
         start_upload_worker()
+
+    if config.UNIVERSE_MEDIA_ENABLED:
+        job_id = _durable_universe_queue().enqueue(
+            filename,
+            mime_type or "application/octet-stream",
+            file_obj.getvalue(),
+        )
+        upload_queue.put(job_id)
+        logger.debug(f"Queued durable Universe media job for {filename}")
+        return
 
     # Create a copy of the file object to avoid issues with concurrent access
     file_copy = BytesIO(file_obj.getvalue())

--- a/indexer/src/index_core/database.py
+++ b/indexer/src/index_core/database.py
@@ -2747,6 +2747,9 @@ def apply_schema_updates(db, cursor):
             "indexes": [
                 ("idx_encoding_method", ["encoding_method"]),
             ],
+            "modifications": [
+                ("stamp_url", "VARCHAR(512) NULL", "varchar(512)"),
+            ],
         },
     }
 
@@ -2797,6 +2800,31 @@ def apply_schema_updates(db, cursor):
                     db.rollback()
             else:
                 logger.debug(f"Column {column_name} already exists in {table_name}")
+
+        # Apply explicitly declared widening/type changes. These are kept
+        # narrow and idempotent because the legacy updater otherwise handles
+        # additions only.
+        for column_name, target_definition, expected_column_type in updates.get("modifications", []):
+            cursor.execute(
+                """
+                SELECT LOWER(COLUMN_TYPE)
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                AND table_name = %s
+                AND column_name = %s
+                """,
+                (table_name, column_name),
+            )
+            row = cursor.fetchone()
+            if row and row[0] != expected_column_type:
+                try:
+                    cursor.execute(f"ALTER TABLE `{table_name}` MODIFY COLUMN `{column_name}` {target_definition}")
+                    db.commit()
+                    logger.info(f"Modified column {column_name} on {table_name} to {expected_column_type}")
+                    updates_applied += 1
+                except Exception as e:
+                    logger.error(f"Failed to modify column {column_name} on {table_name}: {e}")
+                    db.rollback()
 
         # Check and add missing indexes
         for index_name, index_columns in updates.get("indexes", []):

--- a/indexer/src/index_core/files.py
+++ b/indexer/src/index_core/files.py
@@ -6,7 +6,7 @@ import os
 import config
 import index_core.log as log
 from index_core.async_upload import async_check_existing_and_upload_to_s3
-from index_core.aws import check_existing_and_upload_to_s3
+from index_core.universe_media import upload_universe_media
 
 logger = logging.getLogger(__name__)
 log.set_logger(logger)  # set root logger
@@ -42,22 +42,19 @@ def get_fileobj_and_md5(decoded_base64):
 
 
 def store_files(db, filename, decoded_base64, mime_type):
-    """Store files in either AWS S3 or disk storage, unless disabled."""
+    """Store exact Stamp bytes in the single shared Universe media service."""
     if not config.STORE_FILES:
         logger.debug("File storage is disabled, skipping storage operations")
         file_obj, file_obj_md5 = get_fileobj_and_md5(decoded_base64)
         return file_obj_md5, filename
 
     file_obj, file_obj_md5 = get_fileobj_and_md5(decoded_base64)
-    if config.AWS_S3_ENABLED:
-        if config.USE_ASYNC_UPLOADS:
-            # Use the asynchronous version for non-blocking uploads
-            async_check_existing_and_upload_to_s3(filename, mime_type, file_obj, file_obj_md5)
-        else:
-            # Use the original synchronous version
-            check_existing_and_upload_to_s3(db, filename, mime_type, file_obj, file_obj_md5)
+    if not config.UNIVERSE_MEDIA_ENABLED:
+        raise RuntimeError("STORE_FILES requires the shared Universe media service")
+    if config.USE_ASYNC_UPLOADS:
+        async_check_existing_and_upload_to_s3(filename, mime_type, file_obj, file_obj_md5)
     else:
-        store_files_to_disk(filename, decoded_base64)
+        upload_universe_media(filename, mime_type, file_obj)
     return file_obj_md5, filename
 
 

--- a/indexer/src/index_core/models.py
+++ b/indexer/src/index_core/models.py
@@ -11,6 +11,7 @@ from typing import ClassVar, Dict, List, Optional, Tuple, TypedDict, Union
 import msgpack
 import regex as re
 
+import config
 import index_core.log as log
 from config import (
     BTC_SRC101_GENESIS_BLOCK,
@@ -128,6 +129,7 @@ class StampData:
     db: Optional[object] = None
     _lock: Optional[threading.Lock] = None
     _cp_issuer: Optional[str] = None
+    _canonical_media_bytes: Optional[bytes] = None
 
     @staticmethod
     def check_custom_suffix(bytestring_data):
@@ -588,10 +590,21 @@ class StampData:
             self.stamp_mimetype,
             self.is_valid_base64,
         ) = get_data_func(stamp, self.block_index)
+        # Classification may normalize JSON, strip whitespace, or decompress a
+        # gzip-wrapped SVG. Preserve the exact post-base64 bytes before any of
+        # those display-oriented transformations run.
+        if isinstance(self.decoded_base64, bytes):
+            self._canonical_media_bytes = bytes(self.decoded_base64)
+        elif isinstance(self.decoded_base64, str):
+            self._canonical_media_bytes = self.decoded_base64.encode("utf-8")
 
     def process_p2wsh_data(self, decode_base64_func):
         self.stamp_base64 = base64.b64encode(self.p2wsh_data).decode()
         self.decoded_base64, self.is_valid_base64 = decode_base64_func(self.stamp_base64, self.block_index)
+        if isinstance(self.decoded_base64, bytes):
+            self._canonical_media_bytes = bytes(self.decoded_base64)
+        elif isinstance(self.decoded_base64, str):
+            self._canonical_media_bytes = self.decoded_base64.encode("utf-8")
         self.check_decoded_data_fetch_ident_mime()
         self.is_op_return = None  # reset because p2wsh are typically op_return
 
@@ -620,9 +633,14 @@ class StampData:
 
     def update_cpid_and_stamp_url(self, filename):
         self.cpid = self.cpid if self.cpid else self.stamp_hash
-        self.stamp_url = (
-            "https://" + DOMAINNAME + "/stamps/" + filename if self.file_suffix is not None and filename is not None else None
-        )
+        if self.file_suffix is None or filename is None:
+            self.stamp_url = None
+        elif config.UNIVERSE_MEDIA_ENABLED:
+            from index_core.universe_media import public_universe_media_url
+
+            self.stamp_url = public_universe_media_url(filename)
+        else:
+            self.stamp_url = "https://" + DOMAINNAME + "/stamps/" + filename
 
     def determine_stamp_data_type(self, decode_base64_func):
         if self.p2wsh_data is not None and self.block_index >= CP_P2WSH_FEAT_BLOCK_START:
@@ -794,8 +812,17 @@ class StampData:
 
         self.normalize_mime_and_suffix()
 
-        # Dual processing for cursed stamps: Try enhanced detection for better display
-        # This happens AFTER stamp classification, so it's consensus-safe
+        # Preserve the exact post-base64 blockchain bytes as the canonical
+        # object. Enhanced/decompressed content is a display derivative owned
+        # by the central media service; it must never replace the original.
+        storage_content = self._canonical_media_bytes if self._canonical_media_bytes is not None else self.decoded_base64
+        storage_suffix = self.file_suffix
+        storage_mimetype = self.stamp_mimetype
+        if isinstance(storage_content, bytes) and storage_content.startswith(b"\x1f\x8b"):
+            storage_mimetype = "application/gzip"
+
+        # Detect enhanced display metadata without mutating canonical bytes.
+        # This happens AFTER stamp classification, so it is consensus-safe.
         if self.is_cursed and hasattr(self, "_consensus_file_suffix"):
             # Only try enhanced detection if we had a potentially compressed file
             if self._consensus_mimetype in [
@@ -816,27 +843,14 @@ class StampData:
 
                 # If we got better content (e.g., decompressed SVG), use it for display
                 if enhanced_mime == "image/svg+xml" and enhanced_content != self.decoded_base64:
-                    self.decoded_base64 = enhanced_content
                     self.actual_mimetype = enhanced_mime
-                    # For storage, use the enhanced version for better display
-                    storage_suffix = "svg"
-                    storage_mimetype = enhanced_mime
-                else:
-                    storage_suffix = self.file_suffix
-                    storage_mimetype = self.stamp_mimetype
-            else:
-                storage_suffix = self.file_suffix
-                storage_mimetype = self.stamp_mimetype
-        else:
-            storage_suffix = self.file_suffix
-            storage_mimetype = self.stamp_mimetype
 
         # 'encode_and_store_file' can handle different types (bytestring, string, or dict)
         self.file_hash, filename, self.file_size_bytes = encode_and_store_file(
             db,
             self.tx_hash,
             storage_suffix,
-            self.decoded_base64,
+            storage_content,
             storage_mimetype,
         )
 

--- a/indexer/src/index_core/server.py
+++ b/indexer/src/index_core/server.py
@@ -18,7 +18,6 @@ import index_core.blocks as blocks
 import index_core.log as log
 from exceptions import ConfigurationError
 from index_core.async_upload import start_upload_worker, stop_upload_worker, wait_for_uploads
-from index_core.aws import get_s3_objects
 from index_core.backend import Backend
 from index_core.check import cp_version, software_version
 from index_core.critical_failure_handler import emergency_db_rollback, register_cleanup_callback, set_db_connection
@@ -343,13 +342,11 @@ def start_all(db: Connection) -> None:
         # Backend
         connect_to_backend()  # This sets the global backend_instance
         if config.STORE_FILES:
-            if config.AWS_S3_ENABLED:
-                config.S3_OBJECTS = get_s3_objects(db, config.AWS_S3_BUCKETNAME, config.AWS_S3_CLIENT)
-
-                # Start the async upload worker if async uploads are enabled
-                if config.USE_ASYNC_UPLOADS:
-                    logger.info("Starting async upload worker...")
-                    start_upload_worker()
+            if not config.UNIVERSE_MEDIA_ENABLED:
+                raise ConfigurationError("STORE_FILES requires the shared Universe media service")
+            if config.USE_ASYNC_UPLOADS:
+                logger.info("Starting durable Universe media upload worker...")
+                start_upload_worker()
 
         # TEMPORARILY DISABLED: Async holder updater causing lock timeouts
         # TODO: Re-enable after optimizing queries to work with smaller batches

--- a/indexer/src/index_core/universe_media.py
+++ b/indexer/src/index_core/universe_media.py
@@ -1,0 +1,86 @@
+"""Client for the single Universe content-addressed media service."""
+
+import hashlib
+import logging
+import time
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import requests
+
+import config
+
+logger = logging.getLogger(__name__)
+
+
+def _sha256(file_obj: BytesIO) -> str:
+    file_obj.seek(0)
+    digest = hashlib.sha256(file_obj.read()).hexdigest()
+    file_obj.seek(0)
+    return digest
+
+
+def _transaction_id(filename: str) -> str | None:
+    stem = Path(filename).stem.lower()
+    return stem if len(stem) == 64 and all(character in "0123456789abcdef" for character in stem) else None
+
+
+def public_universe_media_url(filename: str) -> str:
+    """Return the stable public identity URL that redirects to immutable bytes."""
+    if not filename:
+        raise ValueError("Universe media filename is required")
+    endpoint = urlsplit(config.UNIVERSE_MEDIA_INGEST_URL)
+    if endpoint.scheme not in {"http", "https"} or not endpoint.netloc:
+        raise RuntimeError("Universe media ingestion URL is invalid")
+    origin = urlunsplit((endpoint.scheme, endpoint.netloc, "", "", ""))
+    return f"{origin}/universe-media/v1/assets/stamps/{quote(filename, safe='')}/content?role=display"
+
+
+def upload_universe_media(filename: str, mime_type: str, file_obj: BytesIO) -> dict[str, Any]:
+    """Upload exact Stamp bytes through the shared verified B2 ingestion API."""
+    if not config.UNIVERSE_MEDIA_ENABLED:
+        raise RuntimeError("Universe media ingestion is not enabled")
+    body = file_obj.getvalue()
+    if not body:
+        raise ValueError("Universe media body is empty")
+    content_hash = _sha256(file_obj)
+    transaction_id = _transaction_id(filename)
+    headers = {
+        "Authorization": f"Bearer {config.UNIVERSE_MEDIA_INGEST_TOKEN}",
+        "Content-Type": mime_type or "application/octet-stream",
+        "X-Universe-Media-Network": "bitcoin",
+        "X-Universe-Media-Protocol": "stamps",
+        "X-Universe-Media-Asset-Id": filename,
+        "X-Universe-Media-Role": "original",
+        "X-Universe-Media-Canonical": "true",
+        "X-Universe-Media-Sha256": content_hash,
+        "X-Universe-Media-Source-Revision": transaction_id or content_hash,
+    }
+    if transaction_id:
+        headers["X-Universe-Media-Transaction-Id"] = transaction_id
+
+    last_error: Exception | None = None
+    for attempt in range(1, config.UNIVERSE_MEDIA_UPLOAD_ATTEMPTS + 1):
+        try:
+            response = requests.post(
+                config.UNIVERSE_MEDIA_INGEST_URL,
+                data=body,
+                headers=headers,
+                timeout=(config.UNIVERSE_MEDIA_CONNECT_TIMEOUT, config.UNIVERSE_MEDIA_READ_TIMEOUT),
+            )
+            response.raise_for_status()
+            result = response.json()
+            if (
+                not isinstance(result, dict)
+                or result.get("contentHash") != content_hash
+                or result.get("byteSize") != len(body)
+            ):
+                raise RuntimeError("Universe media service returned invalid verification evidence")
+            return result
+        except (requests.RequestException, ValueError, RuntimeError) as error:
+            last_error = error
+            if attempt < config.UNIVERSE_MEDIA_UPLOAD_ATTEMPTS:
+                time.sleep(min(8.0, 0.25 * (2 ** (attempt - 1))))
+    raise RuntimeError("Universe media upload failed after bounded retries") from last_error

--- a/indexer/src/index_core/universe_media_queue.py
+++ b/indexer/src/index_core/universe_media_queue.py
@@ -1,0 +1,320 @@
+"""Durable local spool for Universe media ingestion jobs."""
+
+import hashlib
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class UniverseMediaJob:
+    job_id: int
+    filename: str
+    mime_type: str
+    content_sha256: str
+    body_path: str
+    attempts: int
+
+
+class UniverseMediaQueue:
+    def __init__(self, root: str, maximum_attempts: int = 20):
+        self.root = Path(root).expanduser().resolve()
+        self.objects = self.root / "objects" / "sha256"
+        self.database_path = self.root / "jobs.sqlite3"
+        self.maximum_attempts = max(1, min(100, maximum_attempts))
+        self.objects.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path, timeout=30)
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=FULL")
+        connection.execute("PRAGMA busy_timeout=30000")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS media_jobs (
+                  job_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  filename TEXT NOT NULL,
+                  mime_type TEXT NOT NULL,
+                  content_sha256 TEXT NOT NULL,
+                  body_path TEXT NOT NULL,
+                  attempts INTEGER NOT NULL DEFAULT 0,
+                  status TEXT NOT NULL DEFAULT 'queued',
+                  next_retry_at REAL NOT NULL DEFAULT 0,
+                  last_error TEXT,
+                  created_at REAL NOT NULL,
+                  updated_at REAL NOT NULL,
+                  UNIQUE(filename, content_sha256)
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS media_jobs_claim ON media_jobs(status, next_retry_at, job_id)"
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS media_backfill_sources (
+                  source_name TEXT PRIMARY KEY,
+                  cursor_value INTEGER NOT NULL DEFAULT 0,
+                  high_watermark INTEGER NOT NULL DEFAULT 0,
+                  scanned INTEGER NOT NULL DEFAULT 0,
+                  enqueued INTEGER NOT NULL DEFAULT 0,
+                  missing INTEGER NOT NULL DEFAULT 0,
+                  decode_failures INTEGER NOT NULL DEFAULT 0,
+                  status TEXT NOT NULL DEFAULT 'pending',
+                  last_error TEXT,
+                  updated_at REAL NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                "UPDATE media_jobs SET status='retry', next_retry_at=0 WHERE status='processing'"
+            )
+
+    def enqueue(self, filename: str, mime_type: str, body: bytes) -> int:
+        if not filename or not body:
+            raise ValueError("Universe media queue requires filename and bytes")
+        content_hash = hashlib.sha256(body).hexdigest()
+        body_path = self.objects / content_hash[:2] / content_hash[2:4] / content_hash
+        body_path.parent.mkdir(parents=True, exist_ok=True)
+        if body_path.exists():
+            if hashlib.sha256(body_path.read_bytes()).hexdigest() != content_hash:
+                raise RuntimeError("Universe media spool content collision")
+        else:
+            temporary = body_path.with_name(f"{body_path.name}.{os.getpid()}.tmp")
+            try:
+                with open(temporary, "xb") as output:
+                    output.write(body)
+                    output.flush()
+                    os.fsync(output.fileno())
+                os.replace(temporary, body_path)
+            finally:
+                try:
+                    temporary.unlink()
+                except FileNotFoundError:
+                    pass
+        now = time.time()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO media_jobs
+                  (filename,mime_type,content_sha256,body_path,status,
+                   next_retry_at,created_at,updated_at)
+                VALUES (?,?,?,?,'queued',0,?,?)
+                ON CONFLICT(filename,content_sha256) DO UPDATE SET
+                  mime_type=excluded.mime_type,
+                  body_path=excluded.body_path,
+                  status=CASE WHEN media_jobs.status='completed'
+                    THEN media_jobs.status ELSE 'queued' END,
+                  next_retry_at=CASE WHEN media_jobs.status='completed'
+                    THEN media_jobs.next_retry_at ELSE 0 END,
+                  updated_at=excluded.updated_at
+                """,
+                (filename, mime_type or "application/octet-stream", content_hash, str(body_path), now, now),
+            )
+            row = connection.execute(
+                "SELECT job_id FROM media_jobs WHERE filename=? AND content_sha256=?",
+                (filename, content_hash),
+            ).fetchone()
+        if not row:
+            raise RuntimeError("Universe media queue failed to persist a job")
+        return int(row[0])
+
+    def pending_ids(self, limit: int = 100_000) -> list[int]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT job_id FROM media_jobs
+                WHERE status IN ('queued','retry') AND next_retry_at<=?
+                ORDER BY job_id LIMIT ?
+                """,
+                (time.time(), max(1, min(1_000_000, limit))),
+            ).fetchall()
+        return [int(row[0]) for row in rows]
+
+    def claim(self, job_id: int) -> UniverseMediaJob | None:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT job_id,filename,mime_type,content_sha256,body_path,attempts
+                FROM media_jobs
+                WHERE job_id=? AND status IN ('queued','retry') AND next_retry_at<=?
+                """,
+                (job_id, time.time()),
+            ).fetchone()
+            if not row:
+                connection.rollback()
+                return None
+            connection.execute(
+                "UPDATE media_jobs SET status='processing',updated_at=? WHERE job_id=?",
+                (time.time(), job_id),
+            )
+            connection.commit()
+            return UniverseMediaJob(
+                job_id=int(row[0]),
+                filename=str(row[1]),
+                mime_type=str(row[2]),
+                content_sha256=str(row[3]),
+                body_path=str(row[4]),
+                attempts=int(row[5]),
+            )
+        finally:
+            connection.close()
+
+    def complete(self, job_id: int) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "UPDATE media_jobs SET status='completed',last_error=NULL,updated_at=? WHERE job_id=?",
+                (time.time(), job_id),
+            )
+
+    def fail(self, job_id: int, message: str) -> bool:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT attempts FROM media_jobs WHERE job_id=?", (job_id,)
+            ).fetchone()
+            if not row:
+                return False
+            attempts = int(row[0]) + 1
+            terminal = attempts >= self.maximum_attempts
+            retry_at = time.time() + min(3600, 5 * (2 ** min(10, attempts)))
+            connection.execute(
+                """
+                UPDATE media_jobs SET attempts=?,status=?,next_retry_at=?,
+                  last_error=?,updated_at=? WHERE job_id=?
+                """,
+                (
+                    attempts,
+                    "failed" if terminal else "retry",
+                    retry_at,
+                    str(message)[:512],
+                    time.time(),
+                    job_id,
+                ),
+            )
+        return not terminal
+
+    def health(self) -> dict:
+        with self._connect() as connection:
+            counts = {
+                str(row[0]): int(row[1])
+                for row in connection.execute(
+                    "SELECT status,COUNT(*) FROM media_jobs GROUP BY status"
+                ).fetchall()
+            }
+            oldest = connection.execute(
+                """
+                SELECT CAST(MAX(?-created_at) AS INTEGER) FROM media_jobs
+                WHERE status IN ('queued','retry','processing')
+                """,
+                (time.time(),),
+            ).fetchone()
+            sources = [
+                {
+                    "source_name": str(row[0]),
+                    "cursor_value": int(row[1]),
+                    "high_watermark": int(row[2]),
+                    "scanned": int(row[3]),
+                    "enqueued": int(row[4]),
+                    "missing": int(row[5]),
+                    "decode_failures": int(row[6]),
+                    "status": str(row[7]),
+                    "last_error": row[8],
+                }
+                for row in connection.execute(
+                    """
+                    SELECT source_name,cursor_value,high_watermark,scanned,
+                           enqueued,missing,decode_failures,status,last_error
+                    FROM media_backfill_sources ORDER BY source_name
+                    """
+                ).fetchall()
+            ]
+        terminal = counts.get("failed", 0)
+        incomplete_sources = sum(1 for source in sources if source["status"] != "complete")
+        return {
+            "ready": terminal == 0 and incomplete_sources == 0,
+            "counts": counts,
+            "terminal": terminal,
+            "oldest_pending_seconds": max(0, int(oldest[0] or 0)),
+            "incomplete_sources": incomplete_sources,
+            "sources": sources,
+        }
+
+    def backfill_source(self, source_name: str) -> dict | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT source_name,cursor_value,high_watermark,scanned,enqueued,
+                       missing,decode_failures,status,last_error
+                FROM media_backfill_sources WHERE source_name=?
+                """,
+                (source_name,),
+            ).fetchone()
+        if not row:
+            return None
+        return {
+            "source_name": str(row[0]),
+            "cursor_value": int(row[1]),
+            "high_watermark": int(row[2]),
+            "scanned": int(row[3]),
+            "enqueued": int(row[4]),
+            "missing": int(row[5]),
+            "decode_failures": int(row[6]),
+            "status": str(row[7]),
+            "last_error": row[8],
+        }
+
+    def update_backfill_source(
+        self,
+        source_name: str,
+        *,
+        cursor_value: int,
+        high_watermark: int,
+        scanned: int,
+        enqueued: int,
+        missing: int,
+        decode_failures: int,
+        status: str,
+        last_error: str | None = None,
+    ) -> None:
+        if status not in {"pending", "running", "complete", "error"}:
+            raise ValueError("Invalid Universe media backfill status")
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO media_backfill_sources
+                  (source_name,cursor_value,high_watermark,scanned,enqueued,
+                   missing,decode_failures,status,last_error,updated_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(source_name) DO UPDATE SET
+                  cursor_value=excluded.cursor_value,
+                  high_watermark=excluded.high_watermark,
+                  scanned=excluded.scanned,
+                  enqueued=excluded.enqueued,
+                  missing=excluded.missing,
+                  decode_failures=excluded.decode_failures,
+                  status=excluded.status,
+                  last_error=excluded.last_error,
+                  updated_at=excluded.updated_at
+                """,
+                (
+                    source_name,
+                    cursor_value,
+                    high_watermark,
+                    scanned,
+                    enqueued,
+                    missing,
+                    decode_failures,
+                    status,
+                    str(last_error)[:512] if last_error else None,
+                    time.time(),
+                ),
+            )

--- a/indexer/table_schema.sql
+++ b/indexer/table_schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS `StampTableV4` (
   `message_index` int DEFAULT NULL,
   `stamp_base64` mediumtext,
   `stamp_mimetype` varchar(24) DEFAULT NULL,
-  `stamp_url` varchar(106) DEFAULT NULL,
+  `stamp_url` varchar(512) DEFAULT NULL,
   `supply` bigint unsigned DEFAULT NULL,
   `block_time` datetime NULL DEFAULT NULL,
   `tx_hash` varchar(64) NOT NULL,

--- a/indexer/tests/conftest.py
+++ b/indexer/tests/conftest.py
@@ -11,6 +11,10 @@ import pytest
 os.environ["TESTING"] = "1"
 os.environ["USE_TEST_DB"] = "1"
 os.environ["MOCK_DB"] = "1"
+# Unit tests must not inherit the production default that persists media. Tests
+# covering the shared media path enable STORE_FILES explicitly and mock the
+# central ingest service; unrelated parser tests must remain side-effect free.
+os.environ["STORE_FILES"] = "false"
 # Disable sales history catchup during tests to prevent background API calls
 os.environ["ENABLE_SALES_HISTORY_CATCHUP"] = "false"
 

--- a/indexer/tests/test_async_upload_comprehensive.py
+++ b/indexer/tests/test_async_upload_comprehensive.py
@@ -55,6 +55,7 @@ class TestAsyncUpload:
             mock.AWS_INVALIDATE_CACHE = True
             mock.S3_OBJECTS = {}
             mock.AWS_S3_CLIENT = Mock()
+            mock.UNIVERSE_MEDIA_ENABLED = True
             yield mock
 
     @pytest.fixture
@@ -83,104 +84,66 @@ class TestAsyncUpload:
 
         assert task.mime_type == "binary/octet-stream"
 
-    @patch("index_core.async_upload.upload_file_to_s3")
-    @patch("index_core.async_upload.update_s3_db_objects")
-    def test_process_upload_task_new_file(self, mock_update_db, mock_upload, mock_config, mock_db_manager):
-        """Test processing upload task for new file."""
-        # Setup
-        db_conn = mock_db_manager.connect.return_value
-        mock_config.S3_OBJECTS = {}  # No existing file
-
+    @patch("index_core.async_upload.upload_universe_media")
+    def test_process_upload_task_new_file(self, mock_upload, mock_config, mock_db_manager):
+        """Test processing a new file through central ingestion."""
         file_obj = BytesIO(b"new content")
         task = UploadTask("newfile.png", "image/png", file_obj, "newhash")
 
-        # Execute
         async_upload._process_upload_task(task)
 
-        # Assert
-        mock_upload.assert_called_once_with(
-            file_obj, "test-bucket", "stamps/newfile.png", mock_config.AWS_S3_CLIENT, content_type="image/png"
-        )
-        mock_update_db.assert_called_once_with(db_conn, "newfile.png", "newhash")
-        db_conn.close.assert_called()
+        mock_upload.assert_called_once_with("newfile.png", "image/png", file_obj)
+        mock_db_manager.connect.assert_not_called()
 
-    @patch("index_core.async_upload.upload_file_to_s3")
-    @patch("index_core.async_upload.update_s3_db_objects")
-    def test_process_upload_task_existing_same_hash(self, mock_update_db, mock_upload, mock_config, mock_db_manager, caplog):
-        """Test skipping upload when file exists with same hash."""
-        # Setup
-        db_conn = mock_db_manager.connect.return_value
+    @patch("index_core.async_upload.upload_universe_media")
+    def test_process_upload_task_delegates_global_dedup(self, mock_upload, mock_config, mock_db_manager):
+        """Central ingestion owns deduplication instead of a local S3 listing."""
         mock_config.S3_OBJECTS = {"stamps/existing.png": {"md5": "samehash"}}
-
         file_obj = BytesIO(b"content")
         task = UploadTask("existing.png", "image/png", file_obj, "samehash")
 
-        # Execute
-        with caplog.at_level(logging.DEBUG):
-            async_upload._process_upload_task(task)
+        async_upload._process_upload_task(task)
 
-        # Assert
-        mock_upload.assert_not_called()
-        mock_update_db.assert_not_called()
-        assert "already exists in S3. Skipping upload" in caplog.text
-        db_conn.close.assert_called()
+        mock_upload.assert_called_once_with("existing.png", "image/png", file_obj)
+        mock_db_manager.connect.assert_not_called()
 
-    @patch("index_core.async_upload.upload_file_to_s3")
-    @patch("index_core.async_upload.update_s3_db_objects")
-    @patch("index_core.async_upload.invalidate_with_retries")
-    def test_process_upload_task_existing_different_hash(
-        self, mock_invalidate, mock_update_db, mock_upload, mock_config, mock_db_manager
-    ):
-        """Test uploading file with different hash and CloudFront invalidation."""
-        # Setup
-        db_conn = mock_db_manager.connect.return_value
+    @patch("index_core.async_upload.upload_universe_media")
+    def test_process_upload_task_existing_different_hash(self, mock_upload, mock_config, mock_db_manager):
+        """Filename drift is verified centrally without legacy cache invalidation."""
         mock_config.S3_OBJECTS = {"stamps/updated.png": {"md5": "oldhash"}}
-
         file_obj = BytesIO(b"updated content")
         task = UploadTask("updated.png", "image/png", file_obj, "newhash")
 
-        # Execute
         async_upload._process_upload_task(task)
 
-        # Assert
-        mock_upload.assert_called_once()
-        mock_update_db.assert_called_once_with(db_conn, "updated.png", "newhash")
-        mock_invalidate.assert_called_once_with("stamps/updated.png", "ABCD1234")
-        db_conn.close.assert_called()
+        mock_upload.assert_called_once_with("updated.png", "image/png", file_obj)
+        mock_db_manager.connect.assert_not_called()
 
-    @patch("index_core.async_upload.upload_file_to_s3")
+    @patch("index_core.async_upload.upload_universe_media")
     def test_process_upload_task_handles_upload_error(self, mock_upload, mock_config, mock_db_manager, caplog):
-        """Test handling upload errors."""
-        # Setup
-        db_conn = mock_db_manager.connect.return_value
-        mock_config.S3_OBJECTS = {}
-        mock_upload.side_effect = Exception("S3 error")
+        """Test handling central ingestion errors."""
+        mock_upload.side_effect = Exception("central error")
 
         file_obj = BytesIO(b"content")
         task = UploadTask("error.png", "image/png", file_obj, "hash123")
 
-        # Execute
-        with caplog.at_level(logging.WARNING):
-            async_upload._process_upload_task(task)
-
-        # Assert
-        assert "ERROR: Unable to upload error.png to S3" in caplog.text
-        db_conn.close.assert_called()
-
-    def test_process_upload_task_handles_db_error(self, mock_config, mock_db_manager, caplog):
-        """Test handling database connection errors."""
-        # Setup
-        mock_db_manager.connect.side_effect = Exception("DB connection failed")
-
-        file_obj = BytesIO(b"content")
-        task = UploadTask("test.png", "image/png", file_obj, "hash123")
-
-        # Execute
         with caplog.at_level(logging.ERROR):
             async_upload._process_upload_task(task)
 
-        # Assert
-        assert "Unexpected error in upload worker" in caplog.text
+        assert "Universe media upload failed for error.png" in caplog.text
+        mock_db_manager.connect.assert_not_called()
+
+    @patch("index_core.async_upload.upload_universe_media")
+    def test_process_upload_task_does_not_touch_legacy_db(self, mock_upload, mock_config, mock_db_manager):
+        """Central ingestion cannot select the legacy S3 metadata database."""
+        mock_db_manager.connect.side_effect = Exception("DB connection failed")
+        file_obj = BytesIO(b"content")
+        task = UploadTask("test.png", "image/png", file_obj, "hash123")
+
+        async_upload._process_upload_task(task)
+
+        mock_upload.assert_called_once_with("test.png", "image/png", file_obj)
+        mock_db_manager.connect.assert_not_called()
 
     def test_upload_worker_processes_queue(self, mock_config):
         """Test upload worker thread processing queue."""
@@ -431,21 +394,10 @@ class TestAsyncUpload:
 
         task = UploadTask("test.png", "image/png", file_obj, "hash")
 
-        with patch("index_core.async_upload.upload_file_to_s3") as mock_upload:
+        with patch("index_core.async_upload.upload_universe_media"):
             with patch("index_core.async_upload.config") as mock_config:
-                with patch("index_core.async_upload.update_s3_db_objects"):
-                    with patch("index_core.async_upload.upload_db_manager") as mock_db_manager:
-                        # Setup mocks
-                        mock_config.S3_OBJECTS = {}
-                        mock_config.AWS_S3_BUCKETNAME = "test-bucket"
-                        mock_config.AWS_S3_CLIENT = Mock()
-                        mock_config.AWS_CLOUDFRONT_DISTRIBUTION_ID = None  # Disable CloudFront to simplify
-
-                        # Mock database connection
-                        mock_db = Mock()
-                        mock_db_manager.connect.return_value = mock_db
-
-                        async_upload._process_upload_task(task)
+                mock_config.UNIVERSE_MEDIA_ENABLED = True
+                async_upload._process_upload_task(task)
 
         # Assert - file should be at position 0 after seek(0) call in _process_upload_task
         assert file_obj.tell() == 0

--- a/indexer/tests/test_aws_s3_enabled.py
+++ b/indexer/tests/test_aws_s3_enabled.py
@@ -1,110 +1,48 @@
-"""Regression tests for issue #813 — keyless AWS auth via AWS_S3_ENABLED gate.
-
-These tests verify that S3 storage is gated on *configured + intended* targets
-(STORE_FILES + bucket + dir) rather than on the presence of AWS access keys, so
-that instance/task-role (keyless) deployments using the boto3 default credential
-chain still take the S3 upload path.
-
-Test-pollution rules: `config` is resolved at call time via the `index_core.files`
-module reference and patched with `monkeypatch.setattr`, so no stale module-level
-imports are relied upon and no real I/O or network occurs.
-"""
+"""Regression coverage for the single Universe media backend cutover."""
 
 import io
+
+import pytest
 
 from index_core import files
 
 
-class TestStoreFilesS3EnabledGate:
-    """store_files() should follow config.AWS_S3_ENABLED, not key presence."""
-
-    def test_keyless_takes_async_s3_path(self, monkeypatch):
-        """Keys absent but bucket/dir/STORE_FILES set -> async S3 upload path."""
-        monkeypatch.setattr(files.config, "STORE_FILES", True)
-        monkeypatch.setattr(files.config, "AWS_S3_ENABLED", True)
-        monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", True)
-        # Keys intentionally absent — simulates instance/task-role deployment.
-        monkeypatch.setattr(files.config, "AWS_ACCESS_KEY_ID", None)
-        monkeypatch.setattr(files.config, "AWS_SECRET_ACCESS_KEY", None)
-
-        async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
-        sync_upload = _mock(monkeypatch, "check_existing_and_upload_to_s3")
-        disk = _mock(monkeypatch, "store_files_to_disk")
-
-        md5_hash, returned_filename = files.store_files(None, "test.txt", b"data", "text/plain")
-
-        async_upload.assert_called_once()
-        sync_upload.assert_not_called()
-        disk.assert_not_called()
-
-        # store_files returns the same (md5, filename) regardless of storage path.
-        call_args = async_upload.call_args[0]
-        assert call_args[0] == "test.txt"
-        assert call_args[1] == "text/plain"
-        assert isinstance(call_args[2], io.BytesIO)
-        assert call_args[3] == md5_hash
-        assert returned_filename == "test.txt"
-
-    def test_keyless_takes_sync_s3_path(self, monkeypatch):
-        """Keys absent, async disabled -> synchronous S3 upload path."""
-        monkeypatch.setattr(files.config, "STORE_FILES", True)
-        monkeypatch.setattr(files.config, "AWS_S3_ENABLED", True)
-        monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", False)
-        monkeypatch.setattr(files.config, "AWS_ACCESS_KEY_ID", None)
-        monkeypatch.setattr(files.config, "AWS_SECRET_ACCESS_KEY", None)
-
-        async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
-        sync_upload = _mock(monkeypatch, "check_existing_and_upload_to_s3")
-        disk = _mock(monkeypatch, "store_files_to_disk")
-
-        files.store_files(None, "test.txt", b"data", "text/plain")
-
-        sync_upload.assert_called_once()
-        async_upload.assert_not_called()
-        disk.assert_not_called()
-
-    def test_disabled_falls_back_to_disk(self, monkeypatch):
-        """Bucket/dir not configured -> AWS_S3_ENABLED False -> disk fallback."""
-        monkeypatch.setattr(files.config, "STORE_FILES", True)
-        monkeypatch.setattr(files.config, "AWS_S3_ENABLED", False)
-        monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", True)
-
-        async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
-        sync_upload = _mock(monkeypatch, "check_existing_and_upload_to_s3")
-        disk = _mock(monkeypatch, "store_files_to_disk")
-
-        files.store_files(None, "test.txt", b"data", "text/plain")
-
-        disk.assert_called_once_with("test.txt", b"data")
-        async_upload.assert_not_called()
-        sync_upload.assert_not_called()
-
-
-class TestAwsS3EnabledFlag:
-    """The derived AWS_S3_ENABLED flag = STORE_FILES and bucket and dir."""
-
-    @staticmethod
-    def _enabled(store_files, bucket, image_dir):
-        return bool(store_files and bucket and image_dir)
-
-    def test_true_regardless_of_keys(self):
-        # bucket + dir + STORE_FILES set -> enabled, independent of credentials.
-        assert self._enabled(True, "bucket", "images") is True
-
-    def test_false_when_bucket_missing(self):
-        assert self._enabled(True, None, "images") is False
-
-    def test_false_when_dir_missing(self):
-        assert self._enabled(True, "bucket", None) is False
-
-    def test_false_when_store_files_off(self):
-        assert self._enabled(False, "bucket", "images") is False
-
-
 def _mock(monkeypatch, name):
-    """Patch a name on the files module with a MagicMock and return it."""
     from unittest.mock import MagicMock
 
-    m = MagicMock()
-    monkeypatch.setattr(files, name, m)
-    return m
+    value = MagicMock()
+    monkeypatch.setattr(files, name, value)
+    return value
+
+
+def test_legacy_s3_configuration_cannot_select_a_parallel_backend(monkeypatch):
+    monkeypatch.setattr(files.config, "STORE_FILES", True)
+    monkeypatch.setattr(files.config, "UNIVERSE_MEDIA_ENABLED", False)
+    monkeypatch.setattr(files.config, "AWS_S3_ENABLED", True)
+    monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", True)
+    async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
+    disk = _mock(monkeypatch, "store_files_to_disk")
+
+    with pytest.raises(RuntimeError, match="shared Universe media"):
+        files.store_files(None, "test.txt", b"data", "text/plain")
+
+    async_upload.assert_not_called()
+    disk.assert_not_called()
+
+
+def test_central_async_path_preserves_existing_call_contract(monkeypatch):
+    monkeypatch.setattr(files.config, "STORE_FILES", True)
+    monkeypatch.setattr(files.config, "UNIVERSE_MEDIA_ENABLED", True)
+    monkeypatch.setattr(files.config, "USE_ASYNC_UPLOADS", True)
+    async_upload = _mock(monkeypatch, "async_check_existing_and_upload_to_s3")
+    disk = _mock(monkeypatch, "store_files_to_disk")
+
+    md5_hash, filename = files.store_files(None, "test.txt", b"data", "text/plain")
+
+    call = async_upload.call_args[0]
+    assert call[0] == "test.txt"
+    assert call[1] == "text/plain"
+    assert isinstance(call[2], io.BytesIO)
+    assert call[3] == md5_hash
+    assert filename == "test.txt"
+    disk.assert_not_called()

--- a/indexer/tests/test_backfill_universe_media.py
+++ b/indexer/tests/test_backfill_universe_media.py
@@ -1,0 +1,33 @@
+import base64
+import importlib.util
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).parents[1] / "tools" / "backfill_universe_media.py"
+_SPEC = importlib.util.spec_from_file_location("backfill_universe_media", _SCRIPT)
+backfill = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(backfill)
+
+
+def test_decode_exact_media_preserves_bytes():
+    body = b"\x1f\x8b\x08\x00exact-chain-bytes"
+    assert backfill.decode_exact_media(base64.b64encode(body).decode()) == body
+    assert backfill.canonical_mime(body, "image/svg+xml") == "application/gzip"
+
+
+def test_media_filename_supports_central_and_legacy_urls():
+    tx_hash = "a" * 64
+    assert backfill.media_filename(
+        tx_hash,
+        f"https://core.example/universe-media/v1/assets/stamps/{tx_hash}.svg/content?role=display",
+        "image/svg+xml",
+    ) == f"{tx_hash}.svg"
+    assert backfill.media_filename(tx_hash, f"https://legacy.example/stamps/{tx_hash}.png", "image/png") == (
+        f"{tx_hash}.png"
+    )
+
+
+def test_media_filename_has_deterministic_fallback():
+    tx_hash = "b" * 64
+    assert backfill.media_filename(tx_hash, None, "image/webp") == f"{tx_hash}.webp"

--- a/indexer/tests/test_files.py
+++ b/indexer/tests/test_files.py
@@ -57,22 +57,16 @@ class TestFiles(unittest.TestCase):
         self.assertEqual(returned_filename, filename)
 
     @mock.patch("index_core.files.config.STORE_FILES", True)
-    @mock.patch("index_core.files.config.AWS_SECRET_ACCESS_KEY", None)
+    @mock.patch("index_core.files.config.UNIVERSE_MEDIA_ENABLED", False)
     @mock.patch("index_core.files.store_files_to_disk")
-    def test_store_files_disk_storage(self, mock_store_disk):
-        """Test store_files falls back to disk storage when AWS not configured."""
+    def test_store_files_fails_closed_without_universe_media(self, mock_store_disk):
+        """Enabled storage must never split into a local or legacy backend."""
         test_data = b"Test data"
         filename = "test.txt"
 
-        md5_hash, returned_filename = store_files(None, filename, test_data, "text/plain")
-
-        # Should call disk storage
-        mock_store_disk.assert_called_once_with(filename, test_data)
-
-        # Should return MD5 and filename
-        expected_md5 = hashlib.md5(test_data, usedforsecurity=False).hexdigest()
-        self.assertEqual(md5_hash, expected_md5)
-        self.assertEqual(returned_filename, filename)
+        with self.assertRaisesRegex(RuntimeError, "shared Universe media"):
+            store_files(None, filename, test_data, "text/plain")
+        mock_store_disk.assert_not_called()
 
     def test_store_files_to_disk_valid(self):
         """Test store_files_to_disk with valid input."""
@@ -111,15 +105,11 @@ class TestFiles(unittest.TestCase):
             self.assertEqual(str(context.exception), "Disk full")
 
     @mock.patch("index_core.files.config.STORE_FILES", True)
-    @mock.patch("index_core.files.config.AWS_S3_ENABLED", True)
-    @mock.patch("index_core.files.config.AWS_SECRET_ACCESS_KEY", "secret")
-    @mock.patch("index_core.files.config.AWS_ACCESS_KEY_ID", "key")
-    @mock.patch("index_core.files.config.AWS_S3_BUCKETNAME", "bucket")
-    @mock.patch("index_core.files.config.AWS_S3_IMAGE_DIR", "images")
+    @mock.patch("index_core.files.config.UNIVERSE_MEDIA_ENABLED", True)
     @mock.patch("index_core.files.config.USE_ASYNC_UPLOADS", True)
     @mock.patch("index_core.files.async_check_existing_and_upload_to_s3")
-    def test_store_files_async_aws(self, mock_async_upload):
-        """Test store_files with async AWS upload."""
+    def test_store_files_async_universe_media(self, mock_async_upload):
+        """Test durable asynchronous central-media ingestion."""
         test_data = b"Test data"
         filename = "test.txt"
 
@@ -136,15 +126,11 @@ class TestFiles(unittest.TestCase):
         self.assertEqual(call_args[3], md5_hash)
 
     @mock.patch("index_core.files.config.STORE_FILES", True)
-    @mock.patch("index_core.files.config.AWS_S3_ENABLED", True)
-    @mock.patch("index_core.files.config.AWS_SECRET_ACCESS_KEY", "secret")
-    @mock.patch("index_core.files.config.AWS_ACCESS_KEY_ID", "key")
-    @mock.patch("index_core.files.config.AWS_S3_BUCKETNAME", "bucket")
-    @mock.patch("index_core.files.config.AWS_S3_IMAGE_DIR", "images")
+    @mock.patch("index_core.files.config.UNIVERSE_MEDIA_ENABLED", True)
     @mock.patch("index_core.files.config.USE_ASYNC_UPLOADS", False)
-    @mock.patch("index_core.files.check_existing_and_upload_to_s3")
-    def test_store_files_sync_aws(self, mock_sync_upload):
-        """Test store_files with synchronous AWS upload."""
+    @mock.patch("index_core.files.upload_universe_media")
+    def test_store_files_sync_universe_media(self, mock_sync_upload):
+        """Test synchronous central-media ingestion."""
         test_data = b"Test data"
         filename = "test.txt"
 
@@ -155,11 +141,9 @@ class TestFiles(unittest.TestCase):
 
         # Check call arguments
         call_args = mock_sync_upload.call_args[0]
-        self.assertIsNone(call_args[0])  # db
-        self.assertEqual(call_args[1], filename)
-        self.assertEqual(call_args[2], "text/plain")
-        self.assertIsInstance(call_args[3], io.BytesIO)
-        self.assertEqual(call_args[4], md5_hash)
+        self.assertEqual(call_args[0], filename)
+        self.assertEqual(call_args[1], "text/plain")
+        self.assertIsInstance(call_args[2], io.BytesIO)
 
     def test_store_files_to_disk_with_existing_directory(self):
         """Test store_files_to_disk when files directory already exists."""

--- a/indexer/tests/test_server.py
+++ b/indexer/tests/test_server.py
@@ -58,6 +58,8 @@ def mock_config():
         mock_cfg.APP_NAME = "bitcoin-stamps"
         mock_cfg.USE_ASYNC_UPLOADS = False
         mock_cfg.STORE_FILES = False
+        mock_cfg.UNIVERSE_MEDIA_ENABLED = False
+        mock_cfg.ENABLE_SRC20_BACKGROUND_VALIDATION = False
         mock_cfg.AWS_SECRET_ACCESS_KEY = None
         mock_cfg.AWS_ACCESS_KEY_ID = None
         mock_cfg.AWS_S3_BUCKETNAME = None
@@ -448,14 +450,12 @@ class TestStartAll:
                 mock_blocks.follow.assert_called_once_with(mock_db)
                 assert shutdown_flag.is_set()
 
-    def test_start_all_with_s3(self, mock_config, mock_backend, mock_logger):
-        """Test start_all with S3 configuration."""
+    def test_start_all_with_universe_media(self, mock_config, mock_backend, mock_logger):
+        """Test start_all with central durable media ingestion."""
         from index_core.server import shutdown_flag, start_all
 
         mock_config.STORE_FILES = True
-        mock_config.AWS_SECRET_ACCESS_KEY = "secret"
-        mock_config.AWS_ACCESS_KEY_ID = "access"
-        mock_config.AWS_S3_BUCKETNAME = "test-bucket"
+        mock_config.UNIVERSE_MEDIA_ENABLED = True
         mock_config.USE_ASYNC_UPLOADS = True
 
         mock_db = mock.MagicMock()
@@ -463,18 +463,16 @@ class TestStartAll:
 
         with mock.patch("index_core.server.concurrent.futures.ThreadPoolExecutor"):
             with mock.patch("index_core.server.blocks"):
-                with mock.patch("index_core.server.get_s3_objects") as mock_s3:
-                    with mock.patch("index_core.server.start_upload_worker") as mock_start_worker:
-                        with mock.patch("index_core.server.wait_for_uploads") as mock_wait:
-                            with mock.patch("index_core.server.stop_upload_worker") as mock_stop:
-                                mock_wait.return_value = True
+                with mock.patch("index_core.server.start_upload_worker") as mock_start_worker:
+                    with mock.patch("index_core.server.wait_for_uploads") as mock_wait:
+                        with mock.patch("index_core.server.stop_upload_worker") as mock_stop:
+                            mock_wait.return_value = True
 
-                                start_all(mock_db)
+                            start_all(mock_db)
 
-                                mock_s3.assert_called_once()
-                                mock_start_worker.assert_called_once()
-                                mock_wait.assert_called_once()
-                                mock_stop.assert_called_once()
+                            mock_start_worker.assert_called_once()
+                            mock_wait.assert_called_once()
+                            mock_stop.assert_called_once()
 
     def test_start_all_with_exception(self, mock_config, mock_backend, mock_logger):
         """Test start_all with exception handling."""

--- a/indexer/tests/test_universe_media.py
+++ b/indexer/tests/test_universe_media.py
@@ -1,0 +1,79 @@
+import hashlib
+from io import BytesIO
+from unittest.mock import Mock
+
+import pytest
+
+import index_core.universe_media as universe_media
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setattr(universe_media.config, "UNIVERSE_MEDIA_ENABLED", True)
+    monkeypatch.setattr(
+        universe_media.config,
+        "UNIVERSE_MEDIA_INGEST_URL",
+        "https://media.example/universe-media/v1/objects",
+    )
+    monkeypatch.setattr(universe_media.config, "UNIVERSE_MEDIA_INGEST_TOKEN", "t" * 48)
+    monkeypatch.setattr(universe_media.config, "UNIVERSE_MEDIA_UPLOAD_ATTEMPTS", 3)
+    monkeypatch.setattr(universe_media.config, "UNIVERSE_MEDIA_CONNECT_TIMEOUT", 5.0)
+    monkeypatch.setattr(universe_media.config, "UNIVERSE_MEDIA_READ_TIMEOUT", 90.0)
+
+
+def test_upload_binds_exact_stamp_bytes_and_transaction_identity(monkeypatch, enabled):
+    body = b"canonical stamp bytes"
+    content_hash = hashlib.sha256(body).hexdigest()
+    transaction_id = "a" * 64
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"contentHash": content_hash, "byteSize": len(body)}
+    post = Mock(return_value=response)
+    monkeypatch.setattr(universe_media.requests, "post", post)
+
+    result = universe_media.upload_universe_media(
+        f"{transaction_id}.png", "image/png", BytesIO(body)
+    )
+
+    assert result["contentHash"] == content_hash
+    _, kwargs = post.call_args
+    assert kwargs["data"] == body
+    assert kwargs["headers"] == {
+        "Authorization": "Bearer " + "t" * 48,
+        "Content-Type": "image/png",
+        "X-Universe-Media-Network": "bitcoin",
+        "X-Universe-Media-Protocol": "stamps",
+        "X-Universe-Media-Asset-Id": f"{transaction_id}.png",
+        "X-Universe-Media-Role": "original",
+        "X-Universe-Media-Canonical": "true",
+        "X-Universe-Media-Sha256": content_hash,
+        "X-Universe-Media-Source-Revision": transaction_id,
+        "X-Universe-Media-Transaction-Id": transaction_id,
+    }
+
+
+def test_upload_retries_but_never_accepts_unverified_evidence(monkeypatch, enabled):
+    body = b"canonical stamp bytes"
+    bad_response = Mock()
+    bad_response.raise_for_status.return_value = None
+    bad_response.json.return_value = {"contentHash": "0" * 64, "byteSize": len(body)}
+    monkeypatch.setattr(universe_media.requests, "post", Mock(return_value=bad_response))
+    monkeypatch.setattr(universe_media.time, "sleep", Mock())
+
+    with pytest.raises(RuntimeError, match="bounded retries"):
+        universe_media.upload_universe_media("stamp.svg", "image/svg+xml", BytesIO(body))
+
+    assert universe_media.requests.post.call_count == 3
+
+
+def test_public_url_uses_central_stable_identity(monkeypatch, enabled):
+    monkeypatch.setattr(
+        universe_media.config,
+        "UNIVERSE_MEDIA_INGEST_URL",
+        "https://api.bitcoinuniverse.io/universe-media/v1/objects",
+    )
+
+    assert universe_media.public_universe_media_url("stamp name.svg") == (
+        "https://api.bitcoinuniverse.io/universe-media/v1/assets/stamps/"
+        "stamp%20name.svg/content?role=display"
+    )

--- a/indexer/tests/test_universe_media_queue.py
+++ b/indexer/tests/test_universe_media_queue.py
@@ -1,0 +1,79 @@
+import hashlib
+from pathlib import Path
+
+from index_core.universe_media_queue import UniverseMediaQueue
+
+
+def test_queue_persists_exact_bytes_and_recovers_processing_jobs(tmp_path):
+    body = b"durable canonical bytes"
+    content_hash = hashlib.sha256(body).hexdigest()
+    queue = UniverseMediaQueue(str(tmp_path))
+    job_id = queue.enqueue("asset.png", "image/png", body)
+    job = queue.claim(job_id)
+
+    assert job is not None
+    assert job.content_sha256 == content_hash
+    assert Path(job.body_path).read_bytes() == body
+
+    recovered = UniverseMediaQueue(str(tmp_path))
+    assert recovered.pending_ids() == [job_id]
+    retried = recovered.claim(job_id)
+    assert retried is not None
+    recovered.complete(job_id)
+    assert recovered.pending_ids() == []
+
+
+def test_queue_globally_deduplicates_spooled_bytes(tmp_path):
+    body = b"same bytes"
+    queue = UniverseMediaQueue(str(tmp_path))
+    first = queue.enqueue("one.svg", "image/svg+xml", body)
+    second = queue.enqueue("two.svg", "image/svg+xml", body)
+
+    first_job = queue.claim(first)
+    second_job = queue.claim(second)
+    assert first_job is not None and second_job is not None
+    assert first_job.body_path == second_job.body_path
+    assert len(list((tmp_path / "objects" / "sha256").rglob(hashlib.sha256(body).hexdigest()))) == 1
+
+
+def test_queue_uses_bounded_retry_and_terminal_failure(tmp_path, monkeypatch):
+    queue = UniverseMediaQueue(str(tmp_path), maximum_attempts=2)
+    job_id = queue.enqueue("asset.bin", "application/octet-stream", b"body")
+    assert queue.claim(job_id) is not None
+    assert queue.fail(job_id, "temporary") is True
+    monkeypatch.setattr("index_core.universe_media_queue.time.time", lambda: 10_000_000_000)
+    assert queue.claim(job_id) is not None
+    assert queue.fail(job_id, "terminal") is False
+    assert queue.pending_ids() == []
+    assert queue.health()["ready"] is False
+    assert queue.health()["terminal"] == 1
+
+
+def test_queue_tracks_backfill_source_readiness(tmp_path):
+    queue = UniverseMediaQueue(str(tmp_path))
+    queue.update_backfill_source(
+        "stamps:StampTableV4",
+        cursor_value=10,
+        high_watermark=20,
+        scanned=10,
+        enqueued=9,
+        missing=1,
+        decode_failures=0,
+        status="running",
+    )
+
+    assert queue.health()["ready"] is False
+    assert queue.health()["incomplete_sources"] == 1
+    assert queue.backfill_source("stamps:StampTableV4")["missing"] == 1
+
+    queue.update_backfill_source(
+        "stamps:StampTableV4",
+        cursor_value=20,
+        high_watermark=20,
+        scanned=20,
+        enqueued=20,
+        missing=0,
+        decode_failures=0,
+        status="complete",
+    )
+    assert queue.health()["ready"] is True

--- a/indexer/tests/test_zlib_compression.py
+++ b/indexer/tests/test_zlib_compression.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import gzip
 import zlib
 from unittest.mock import patch
 
@@ -61,6 +62,16 @@ class TestZlibCompression:
         assert stamp_data.decoded_base64 == expected_dict
         assert stamp_data.file_suffix == "json"
         assert stamp_data.ident == "SRC-20"
+
+    def test_p2wsh_keeps_exact_gzip_bytes_before_display_detection(self):
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>'
+        compressed = gzip.compress(svg, mtime=0)
+        stamp_data = self.create_stamp_data(block_index=999999, p2wsh_data=compressed)
+
+        stamp_data.process_p2wsh_data(lambda encoded, _height: (compressed, True))
+
+        assert stamp_data._canonical_media_bytes == compressed
+        assert stamp_data._canonical_media_bytes != svg
 
     def test_zlib_decompress_valid_generic_json(self):
         """Test zlib decompression with generic JSON data"""

--- a/indexer/tools/backfill_universe_media.py
+++ b/indexer/tools/backfill_universe_media.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Durably backfill historical Bitcoin Stamps into Universe media storage.
+
+The scan is keyset-paginated and resumable. Exact bytes are decoded from the
+consensus ``stamp_base64`` column, written to the content-addressed local spool,
+and then uploaded through the same verified central ingestion API used by live
+indexing. Rows whose exact bytes are unavailable are counted as unresolved and
+prevent a successful completion status.
+
+Examples:
+    poetry run python tools/backfill_universe_media.py --dry-run
+    poetry run python tools/backfill_universe_media.py --drain
+    poetry run python tools/backfill_universe_media.py --drain --retry-incomplete
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+import pymysql
+
+_INDEXER_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_INDEXER_DIR / "src"))
+
+import config  # noqa: E402
+from index_core.base64_utils import lenient_b64decode  # noqa: E402
+from index_core.universe_media import upload_universe_media  # noqa: E402
+from index_core.universe_media_queue import UniverseMediaQueue  # noqa: E402
+
+SOURCE_NAME = "stamps:StampTableV4"
+
+MIME_SUFFIXES = {
+    "application/gzip": "gz",
+    "application/javascript": "js",
+    "application/json": "json",
+    "audio/mpeg": "mp3",
+    "image/avif": "avif",
+    "image/gif": "gif",
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/svg+xml": "svg",
+    "image/webp": "webp",
+    "text/html": "html",
+    "text/plain": "txt",
+}
+
+
+def connect():
+    return pymysql.connect(
+        host=os.environ.get("RDS_HOSTNAME", os.environ.get("MYSQL_HOST", "localhost")),
+        port=int(os.environ.get("RDS_PORT", os.environ.get("MYSQL_PORT", 3306))),
+        user=os.environ.get("RDS_USER", os.environ.get("MYSQL_USER", "root")),
+        password=os.environ.get("RDS_PASSWORD", os.environ.get("MYSQL_PASSWORD", "")),
+        database=os.environ.get("RDS_DATABASE", os.environ.get("MYSQL_DATABASE", "btc_stamps")),
+        charset="utf8mb4",
+        autocommit=True,
+        read_timeout=600,
+        cursorclass=pymysql.cursors.SSCursor,
+    )
+
+
+def decode_exact_media(value: str | bytes | None) -> bytes | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("ascii")
+        except UnicodeDecodeError:
+            return None
+    if not value:
+        return None
+    try:
+        return lenient_b64decode(value)
+    except Exception:
+        return None
+
+
+def media_filename(tx_hash: str, stamp_url: str | None, mime_type: str | None) -> str:
+    if stamp_url:
+        path = unquote(urlsplit(stamp_url).path)
+        marker = "/assets/stamps/"
+        if marker in path:
+            candidate = path.split(marker, 1)[1].split("/content", 1)[0]
+        else:
+            candidate = Path(path).name
+        if candidate and "/" not in candidate and candidate not in {".", ".."}:
+            return candidate
+    suffix = MIME_SUFFIXES.get((mime_type or "").lower(), "bin")
+    return f"{tx_hash}.{suffix}"
+
+
+def canonical_mime(body: bytes, stored_mime: str | None) -> str:
+    if body.startswith(b"\x1f\x8b"):
+        return "application/gzip"
+    return stored_mime or "application/octet-stream"
+
+
+def drain_jobs(queue: UniverseMediaQueue, workers: int, limit: int = 1000) -> int:
+    job_ids = queue.pending_ids(limit=limit)
+    if not job_ids:
+        return 0
+
+    def process(job_id: int) -> None:
+        job = queue.claim(job_id)
+        if job is None:
+            return
+        try:
+            body = Path(job.body_path).read_bytes()
+            upload_universe_media(job.filename, job.mime_type, BytesIO(body))
+            queue.complete(job.job_id)
+        except Exception as error:
+            queue.fail(job.job_id, str(error))
+
+    with ThreadPoolExecutor(max_workers=max(1, min(32, workers))) as executor:
+        list(executor.map(process, job_ids))
+    return len(job_ids)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--batch-size", type=int, default=250)
+    parser.add_argument("--max-rows", type=int, default=0, help="Stop after N rows; 0 scans to the high watermark")
+    parser.add_argument("--workers", type=int, default=5)
+    parser.add_argument("--drain", action="store_true", help="Upload queued jobs as the scan progresses")
+    parser.add_argument("--dry-run", action="store_true", help="Read and decode without changing the durable spool")
+    parser.add_argument(
+        "--retry-incomplete",
+        action="store_true",
+        help="Rescan from the beginning to retry rows whose exact bytes were previously unavailable",
+    )
+    parser.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="Return zero even if exact source bytes remain unavailable (health remains not ready)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    if not args.dry_run and not config.UNIVERSE_MEDIA_ENABLED:
+        raise RuntimeError("UNIVERSE_MEDIA_ENABLED must be true for a durable backfill")
+
+    queue = UniverseMediaQueue(config.UNIVERSE_MEDIA_SPOOL_DIR, config.UNIVERSE_MEDIA_QUEUE_MAX_ATTEMPTS)
+    db = connect()
+    try:
+        with db.cursor() as cursor:
+            cursor.execute("SELECT MIN(stamp),MAX(stamp),COUNT(*) FROM StampTableV4")
+            minimum, maximum, total = cursor.fetchone()
+        if total == 0:
+            print("StampTableV4 is empty")
+            return 1
+
+        existing = queue.backfill_source(SOURCE_NAME)
+        if existing and not args.retry_incomplete:
+            cursor_value = existing["cursor_value"]
+            scanned = existing["scanned"]
+            enqueued = existing["enqueued"]
+            missing = existing["missing"]
+            decode_failures = existing["decode_failures"]
+        else:
+            cursor_value = int(minimum) - 1
+            scanned = enqueued = missing = decode_failures = 0
+        high_watermark = int(maximum)
+        processed_this_run = 0
+
+        while cursor_value < high_watermark:
+            limit = max(1, min(10_000, args.batch_size))
+            if args.max_rows:
+                remaining = args.max_rows - processed_this_run
+                if remaining <= 0:
+                    break
+                limit = min(limit, remaining)
+            with db.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT stamp,tx_hash,stamp_base64,stamp_mimetype,stamp_url,file_size_bytes
+                    FROM StampTableV4
+                    WHERE stamp > %s AND stamp <= %s
+                    ORDER BY stamp LIMIT %s
+                    """,
+                    (cursor_value, high_watermark, limit),
+                )
+                rows = list(cursor.fetchall())
+            if not rows:
+                break
+
+            for stamp, tx_hash, encoded, mime_type, stamp_url, file_size_bytes in rows:
+                cursor_value = int(stamp)
+                scanned += 1
+                processed_this_run += 1
+                if encoded is None or encoded == "" or encoded == b"":
+                    # Not every StampTable row represents a stored media
+                    # object. Only an absent payload that previously produced
+                    # a URL/size is an unresolved migration gap.
+                    if stamp_url or int(file_size_bytes or 0) > 0:
+                        missing += 1
+                    continue
+                body = decode_exact_media(encoded)
+                if not body:
+                    decode_failures += 1
+                    continue
+                filename = media_filename(str(tx_hash), stamp_url, mime_type)
+                if not args.dry_run:
+                    queue.enqueue(filename, canonical_mime(body, mime_type), body)
+                enqueued += 1
+
+            if not args.dry_run:
+                queue.update_backfill_source(
+                    SOURCE_NAME,
+                    cursor_value=cursor_value,
+                    high_watermark=high_watermark,
+                    scanned=scanned,
+                    enqueued=enqueued,
+                    missing=missing,
+                    decode_failures=decode_failures,
+                    status="running",
+                )
+                if args.drain:
+                    drain_jobs(queue, args.workers)
+            print(
+                f"cursor={cursor_value}/{high_watermark} scanned={scanned} "
+                f"enqueued={enqueued} missing={missing} decode_failures={decode_failures}",
+                flush=True,
+            )
+
+        if args.drain and not args.dry_run:
+            while drain_jobs(queue, args.workers):
+                pass
+
+        health = queue.health()
+        fully_scanned = cursor_value >= high_watermark
+        unresolved = missing + decode_failures
+        pending = sum(health["counts"].get(name, 0) for name in ("queued", "retry", "processing"))
+        complete = fully_scanned and unresolved == 0 and pending == 0 and health["terminal"] == 0
+        if not args.dry_run:
+            queue.update_backfill_source(
+                SOURCE_NAME,
+                cursor_value=cursor_value,
+                high_watermark=high_watermark,
+                scanned=scanned,
+                enqueued=enqueued,
+                missing=missing,
+                decode_failures=decode_failures,
+                status="complete" if complete else "pending",
+                last_error=None if complete else "Backfill has unresolved source rows or upload jobs",
+            )
+        print(
+            f"complete={complete} total_rows={total} scanned={scanned} enqueued={enqueued} "
+            f"unresolved={unresolved} pending={pending} terminal={health['terminal']}"
+        )
+        return 0 if complete or args.dry_run or args.allow_incomplete else 1
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- routes all newly indexed Stamp media through the shared Universe ingestion service
- preserves exact decoded blockchain bytes, including gzip-wrapped SVG originals
- adds a durable SHA-256-deduplicated SQLite spool with bounded retries and source health
- widens stable media URLs and adds a resumable historical backfill
- keeps Backblaze credentials out of the indexer

## Why

Universe projects need one authoritative private media store with global content-hash deduplication, verified uploads, immutable originals, central derivatives, and no per-project bucket or public-provider fallback.

## Impact

`STORE_FILES=true` now fails closed unless the central URL, token, and absolute persistent spool are configured. The schema updater idempotently widens `StampTableV4.stamp_url` before internal stable URLs are written. Historical rows can be migrated with `tools/backfill_universe_media.py`.

## Validation

- Python bytecode compilation for all changed source and tests
- durable spool/hash/dedup/resume smoke test
- 96 focused Python tests passed in an isolated Python 3.12 environment
- `git diff --check`
- secret-value scan

The full Rust-backed suite still requires native CI; this host has Rust but no system C linker, and upstream marks first-time fork workflow runs as maintainer-approval-required.
